### PR TITLE
Sort the Certificates by the secret name

### DIFF
--- a/pkg/controller/appdefinition/ingress.go
+++ b/pkg/controller/appdefinition/ingress.go
@@ -3,6 +3,7 @@ package appdefinition
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -84,6 +85,10 @@ func getCerts(namespace string, req router.Request) ([]*TLSCert, error) {
 		result = append(result, cert)
 	}
 
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].SecretName < result[j].SecretName
+	})
+
 	return result, nil
 }
 
@@ -91,8 +96,10 @@ func getCertsForPublishedHosts(rules []networkingv1.IngressRule, certs []*TLSCer
 	certSecretToHostMapping := map[string][]string{}
 	for _, rule := range rules {
 		for _, cert := range certs {
+			// Find the first cert and stop looking
 			if cert.certForThisDomain(rule.Host) {
 				certSecretToHostMapping[cert.SecretName] = append(certSecretToHostMapping[cert.SecretName], rule.Host)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Certificates for ingress rules are stored in
Kubernetes secrets. This change sorts the certs
based on the secret name they are stored in. When
selecting a certificate for a hostname the first
secret found is used.