### PR TITLE
Allow name length 3-64 for getting images

### DIFF
--- a/integration/client/images_test.go
+++ b/integration/client/images_test.go
@@ -316,7 +316,17 @@ func TestImageDetails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	details, err := c.ImageDetails(ctx, "foo:latest", nil)
+	details, err := c.ImageDetails(ctx, imageID[:3], nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, strings.Contains(details.AppImage.Acornfile, "nginx"))
+
+	_, err = c.ImageDetails(ctx, "a12", nil)
+	assert.True(t, apierrors.IsNotFound(err))
+
+	details, err = c.ImageDetails(ctx, "foo:latest", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/registry/images/detail.go
+++ b/pkg/server/registry/images/detail.go
@@ -6,6 +6,7 @@ import (
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/pull"
+	"github.com/acorn-io/acorn/pkg/tags"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +42,8 @@ func (s *ImageDetails) Get(ctx context.Context, name string, options *metav1.Get
 
 	image, err := s.images.ImageGet(ctx, name)
 	if err != nil && !apierror.IsNotFound(err) {
+		return nil, err
+	} else if err != nil && apierror.IsNotFound(err) && tags.IsLocalReference(name) {
 		return nil, err
 	} else if err == nil {
 		ns = image.Namespace

--- a/pkg/server/registry/images/images_test.go
+++ b/pkg/server/registry/images/images_test.go
@@ -1,0 +1,35 @@
+package images
+
+import (
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func TestFindMatchingImage(t *testing.T) {
+	images := []apiv1.Image{
+		{
+			Digest: "sha256:12345678",
+		},
+		{
+			Digest: "sha256:987654321",
+		},
+		{
+			Digest: "sha256:123409876",
+		},
+	}
+	il := apiv1.ImageList{
+		Items: images,
+	}
+
+	image, ref, err := findImageMatch(il, "12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "sha256:12345678", image.Digest)
+	assert.Equal(t, "", ref)
+
+	_, _, err = findImageMatch(il, "123")
+	assert.Error(t, err)
+}

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -21,19 +21,16 @@ const (
 )
 
 var (
-	SHAShortPattern = regexp.MustCompile(`^[a-f\d]{12}$`)
-	SHAPattern      = regexp.MustCompile(`^[a-f\d]{64}$`)
-	tagLock         locker.Locker
+	SHAPermissivePrefixPattern = regexp.MustCompile(`^[a-f\d]{3,64}$`)
+	SHAPattern                 = regexp.MustCompile(`^[a-f\d]{64}$`)
+	tagLock                    locker.Locker
 )
 
 func IsLocalReference(image string) bool {
 	if strings.HasPrefix(image, "sha256:") {
 		return true
 	}
-	if SHAPattern.MatchString(image) {
-		return true
-	}
-	if SHAShortPattern.MatchString(image) {
+	if SHAPermissivePrefixPattern.MatchString(image) {
 		return true
 	}
 	return false


### PR DESCRIPTION
This change allows the user to refer to an image using a SHA prefix with
a length between 3 and 64.

So, a user can run a command like `acorn run 3a2`, rather than having to
use its 12 character short ID or the full 64 character ID.

~This ultimately applies to image Get and Delete calls. Referring to an
image directly in an acorn.cue file by SHA will still require the 12 or
64 character version.~ Applies to all image resolutions that allowed the 12 character shorthand

Addresses #68