### PR TITLE
Don't reset timestamps on app context files

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -46,6 +46,26 @@ func TestSimpleBuild(t *testing.T) {
 	assert.True(t, len(image.ImageData.Images["isimple"].Image) > 0)
 }
 
+func TestSimilarBuilds(t *testing.T) {
+	// This tests a scenario where two builds only differ by a single character in the acorn.cue file and otherwise all
+	// the file names and sizes are the same. A caching bug caused the second build to result in the image from the first
+	image, err := build.Build(helper.GetCTX(t), "./testdata/similar/one/acorn.cue", &build.Options{
+		Cwd: "./testdata/similar/one",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image2, err := build.Build(helper.GetCTX(t), "./testdata/similar/two/acorn.cue", &build.Options{
+		Cwd: "./testdata/similar/two",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEqual(t, image.ID, image2.ID)
+}
+
 func TestJobBuild(t *testing.T) {
 	image, err := build.Build(helper.GetCTX(t), "./testdata/jobs/acorn.cue", &build.Options{
 		Cwd: "./testdata/jobs",

--- a/integration/build/testdata/similar/one/acorn.cue
+++ b/integration/build/testdata/similar/one/acorn.cue
@@ -1,0 +1,9 @@
+// This file must match its sibling except for the value of index.txt
+containers: {
+	web: {
+		image: "busybox"
+		files: {
+			"/foo/index.txt": "1"
+		}
+	}
+}

--- a/integration/build/testdata/similar/two/acorn.cue
+++ b/integration/build/testdata/similar/two/acorn.cue
@@ -1,0 +1,9 @@
+// This file must match its sibling except for the value of index.txt
+containers: {
+	web: {
+		image: "busybox"
+		files: {
+			"/foo/index.txt": "2"
+		}
+	}
+}

--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/appdefinition"
@@ -98,10 +97,5 @@ func addFile(tempDir, name string, obj interface{}) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(target, data, 0600)
-	if err != nil {
-		return err
-	}
-
-	return os.Chtimes(target, time.Unix(0, 0), time.Unix(0, 0))
+	return ioutil.WriteFile(target, data, 0600)
 }


### PR DESCRIPTION
In an attempt to ensure fully reproducible builds, when we built the
temp file context for an app build, we were setting the timestamp of
all the files to 0. This caused an issue where transferring the context
to buildkit would not pickup changes in some cases. This is because
that is done based on metadata only, not content of the files. So, a
file change that result in the same file size wouldn't get transferred.

This buildkit issue comment explains the situation even better:
https://github.com/moby/buildkit/issues/2592#issuecomment-1027642738

Addresses: https://github.com/acorn-io/acorn/issues/140

Opened this issue to track the fact that we dont have reproducible builds: https://github.com/acorn-io/acorn/issues/152