### PR TITLE
 Clarify namespace cleanup on uninstall

### DIFF
--- a/docs/docs/30-Installation/02-uninstalling.md
+++ b/docs/docs/30-Installation/02-uninstalling.md
@@ -16,6 +16,10 @@ These two commands will delete the acorn control plane, but leave the resources 
 The following will remain: 
 - The `appinstance.acorn.io` CRD
 - The `acorn` namespace and any resources created in it. This is where `appinstance` CRs reside.
-- The workloads, services, and other resources created for running your acorn apps. These are contained in namespaces with names like `bold-water-624fb33e`.
+- The workloads, services, and other resources created for running your acorn apps. These are contained in namespaces created by acorn with names like `bold-water-624fb33e`.
 
-You can delete the above to fully purge your cluster of all acorn related resources.
+You can delete the above to fully purge your cluster of all acorn related resources. To delete all namespaces created by acorn, you can run:
+```
+kubectl delete namespace -l acorn.io/managed=true
+```
+


### PR DESCRIPTION
Add the command to delete all the namespaces created by acorn.
