### PR TITLE
Fixes file mounts for side cars

### DIFF
--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -177,7 +177,14 @@ func toVolumes(appInstance *v1.AppInstance, container v1.Container) (result []co
 		}
 	}
 
-	for _, file := range container.Files {
+	filesForContainer := container.Files
+	for _, sideCar := range container.Sidecars {
+		for fileName, file := range sideCar.Files {
+			filesForContainer[fileName] = file
+		}
+	}
+
+	for _, file := range filesForContainer {
 		if file.Content != "" && file.Secret.Name == "" {
 			result = append(result, corev1.Volume{
 				Name: "files",


### PR DESCRIPTION
When a file was defined on a side car it wasn't being added
to the k8s volume spec. This loops over the container and its side
cars and appends the files.