### PR TITLE
macOS notarization & brew

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,1 @@
+--ignore-dir=docs/build

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -14,7 +14,7 @@ permissions:
   packages: write
 
 jobs:
-  goreleaser:
+  binary:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - name: Checkout
@@ -25,15 +25,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
@@ -54,6 +45,53 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      - name: Upload to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        env:
+          SOURCE_DIR: releases
+          DEST_DIR: cli
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_ENDPOINT: ${{ secrets.AWS_ENDPOINT }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+
+  docker:
+    needs: binary
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v1.4.1"
+      - name: Setup Cosign
+        run: |
+          echo "${COSIGN_KEY}" > "$GITHUB_WORKSPACE/cosign.key"
+        env:
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+      - run: make download-latest-ui
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist -f .goreleaser-docker.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
       - name: Push Docker Images
         run: |
           VERSION=v$(cat releases/metadata.json | jq -r .version)
@@ -65,13 +103,3 @@ jobs:
           docker manifest push ghcr.io/acorn-io/acorn:main
           docker manifest create ghcr.io/acorn-io/acorn:${VERSION} ${IMAGES}
           docker manifest push ghcr.io/acorn-io/acorn:${VERSION}
-      - name: Upload to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        env:
-          SOURCE_DIR: releases
-          DEST_DIR: cli
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_S3_ENDPOINT: ${{ secrets.AWS_ENDPOINT }}
-          AWS_S3_BUCKET: ${{ secrets.AWS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ permissions:
   packages: write
 
 jobs:
-  goreleaser:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+  binary:
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,15 +21,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
@@ -50,3 +41,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          AC_IDENTITY: ${{ secrets.AC_IDENTITY }}
+          AC_PROJECT: ${{ secrets.AC_PROJECT }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+  docker:
+    needs: binary
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v1.4.1"
+      - name: Setup Cosign
+        run: |
+          echo "${COSIGN_KEY}" > "$GITHUB_WORKSPACE/cosign.key"
+        env:
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+      - run: make download-ui
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist -f .goreleaser-docker.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          AC_IDENTITY: ${{ secrets.AC_IDENTITY }}
+          AC_PROJECT: ${{ secrets.AC_PROJECT }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.gon.hcl
+++ b/.gon.hcl
@@ -1,0 +1,10 @@
+source = ["releases/mac_darwin_all/acorn"]
+bundle_id = "io.acorn.cli"
+
+sign {
+  application_identity = "Developer ID Application: Acorn Labs, Inc. (K5HKMU4T9S)"
+}
+
+zip {
+  output_path = "releases/mac_darwin_all/acorn.zip"
+}

--- a/.goreleaser-docker.yml
+++ b/.goreleaser-docker.yml
@@ -1,0 +1,78 @@
+dist: releases
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -s
+      - -w
+      - -X "github.com/acorn-io/acorn/pkg/version.Tag=v{{ .Version }}"
+    # The docker build don't actually use the binaries generated here, so just build something
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
+    build_flag_templates:
+      - "--target=goreleaser"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
+    build_flag_templates:
+      - "--target=goreleaser"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
+      - "--platform=linux/arm64"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
+    build_flag_templates:
+      - "--target=goreleaser"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
+      - "--platform=linux/arm/v7"
+docker_manifests:
+  - use: docker
+    name_template: ghcr.io/acorn-io/acorn:v{{ .Version }}
+    image_templates:
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
+  - use: docker
+    name_template: ghcr.io/acorn-io/acorn:latest
+    image_templates:
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
+      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
+docker_signs:
+  - artifacts: all
+    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+snapshot:
+  name_template: '{{ trimprefix .Summary "v" }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,18 +1,15 @@
 dist: releases
-release:
-  github:
-    owner: acorn-io
-    name: acorn
-  extra_files:
-    - glob: ./cosign.pub
+snapshot:
+  name_template: '{{ trimprefix .Summary "v" }}'
+
 builds:
   - id: default
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
       - windows
+      - darwin
     goarch:
       - amd64
       - arm64
@@ -24,93 +21,50 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
-      - goos: darwin
-        goarch: arm
     ldflags:
       - -s
       - -w
-      - -X 'github.com/acorn-io/acorn/pkg/version.Tag=v{{ .Version }}'
+      - -X "github.com/acorn-io/acorn/pkg/version.Tag=v{{ .Version }}"
+
+universal_binaries:
+  - id: mac
+    ids:
+      - default
+    replace: true
+    hooks:
+       post:
+         - cmd: ./tools/notarize
+           output: true
+           env:
+             - NOTARIZE={{ if index .Env "NOTARIZE" }}1{{ end }}
+             - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
+             - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
+             - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}
+             - AC_PASSWORD={{ if index .Env "AC_PASSWORD" }}{{ .Env.AC_PASSWORD }}{{ end }}
+
 archives:
   - id: default
     builds:
       - default
-    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
+      - mac
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ if eq .Os \"darwin\" }}macOS-universal.zip{{ else }}{{ .Os }}-{{ .Arch }}{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
         format: zip
-dockers:
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
-    build_flag_templates:
-      - "--target=goreleaser"
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
-      - "--platform=linux/amd64"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
-    build_flag_templates:
-      - "--target=goreleaser"
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
-      - "--platform=linux/arm64"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: "7"
-    dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
-    build_flag_templates:
-      - "--target=goreleaser"
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/acorn-io/acorn"
-      - "--platform=linux/arm/v7"
-docker_manifests:
-  - use: docker
-    name_template: ghcr.io/acorn-io/acorn:v{{ .Version }}
-    image_templates:
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
-  - use: docker
-    name_template: ghcr.io/acorn-io/acorn:latest
-    image_templates:
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-amd64
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
-      - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
+      - goos: darwin
+        format: binary
+
+checksum:
+  name_template: "checksums.txt"
+
 signs:
-  - cmd: cosign
+  - id: cosign
+    cmd: cosign
     stdin: "{{ .Env.COSIGN_PASSWORD }}"
     args:
       ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: all
-docker_signs:
-  - artifacts: all
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
-checksum:
-  name_template: "checksums.txt"
-snapshot:
-  name_template: '{{ trimprefix .Summary "v" }}'
+
 changelog:
   sort: asc
   filters:
@@ -118,3 +72,18 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^Merge pull request"
+
+release:
+  github:
+    owner: acorn-io
+    name: acorn
+  extra_files:
+    - glob: ./cosign.pub
+
+brews:
+  - description: "Acorn CLI"
+    homepage: "https://acorn.io"
+    license: "Apache 2.0"
+    tap:
+      owner: acorn-io
+      name: homebrew

--- a/tools/notarize
+++ b/tools/notarize
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+: ${NOTARIZE=""}
+if [[ -z "${NOTARIZE}" && "$(uname)" == "Darwin" && "${GITHUB_REF}" =~ "^refs/tags/v" ]]; then
+  NOTARIZE="1"
+fi
+
+cp LICENSE README.md releases/mac_darwin_all/
+if [[ -n "${NOTARIZE}" ]]; then
+  echo "Notarizing"
+  cp releases/mac_darwin_all/acorn releases/mac_darwin_all/acorn_orig
+
+  which gon || (go install github.com/mitchellh/gon/cmd/gon@latest)
+
+  gon .gon.hcl
+else
+  echo "Skipping notarizing"
+  zip releases/mac_darwin_all/acorn.zip releases/mac_darwin_all/*
+fi
+
+mv releases/mac_darwin_all/acorn releases/mac_darwin_all/acorn_bin
+cp releases/mac_darwin_all/acorn.zip releases/mac_darwin_all/acorn


### PR DESCRIPTION
- Combine intel & arm builds into one universal binary
- Notarize it with Apple, only if building on macOS and secrets set
- Split goreleaser for binaries vs docker
- Build docker tags still on buildjet
- Build release binaries/archives on a github macOS runner because notarizing needs macOS
- Publish homebrew update
- Small chance it even actually works