### PR TITLE
Delete all cli md files before regenerating

### DIFF
--- a/tools/gendocs/main.go
+++ b/tools/gendocs/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,18 @@ title: "%s"
 func main() {
 	cmd := acorn.New()
 	cmd.DisableAutoGenTag = true
-	err := doc.GenMarkdownTreeCustom(cmd, "docs/docs/100-Reference/01-command-line", filePrepender, linkHandler)
+
+	files, err := filepath.Glob("docs/docs/100-Reference/01-command-line/acorn_*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, f := range files {
+		if err := os.Remove(f); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	err = doc.GenMarkdownTreeCustom(cmd, "docs/docs/100-Reference/01-command-line", filePrepender, linkHandler)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The docs generator wont delete md files for commands that have been
removed. We need to delete the files in the directory to ensure we
aren't keeping around old files that we shouldn't.
