### PR TITLE
Add option to delete all images in acron image rm command

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_rm.md
@@ -18,6 +18,7 @@ acorn image rm my-image
 ### Options
 
 ```
+  -a, --all     Delete all images
   -f, --force   Force Delete
   -h, --help    help for rm
 ```
@@ -25,7 +26,6 @@ acorn image rm my-image
 ### Options inherited from parent commands
 
 ```
-  -a, --all                 Include untagged images
   -A, --all-projects        Use all known projects
   -c, --containers          Show containers for images
       --debug               Enable debug logging

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -22,6 +22,7 @@ func NewImageDelete(c CommandContext) *cobra.Command {
 type ImageDelete struct {
 	client ClientFactory
 	Force  bool `usage:"Force Delete" short:"f"`
+	All    bool `usage:"Delete all images" short:"a"`
 }
 
 func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
@@ -30,7 +31,22 @@ func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for _, image := range args {
+	var imageNames []string
+
+	if a.All {
+		images, err := c.ImageList(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		for _, image := range images {
+			imageNames = append(imageNames, image.Name)
+		}
+	} else {
+		imageNames = args
+	}
+
+	for _, image := range imageNames {
 		deleted, err := c.ImageDelete(cmd.Context(), image, &client.ImageDeleteOptions{Force: a.Force})
 
 		if err != nil {

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -428,6 +428,25 @@ func TestImage(t *testing.T) {
 			wantErr: false,
 			wantOut: "found-image-two-tags1234567\n",
 		},
+		{
+			name: "acorn image rm -a -f", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"rm", "-a", "-f"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "found-image1234567\nfound-image-no-tag\nfound-image-two-tags1234567\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -492,6 +492,10 @@ func (m *MockClient) ImageDelete(ctx context.Context, name string, opts *client.
 				Tags:       []string{"testtag1:latest", "testtag2:latest"},
 			}, nil
 		}
+	case "found-image-no-tag":
+		return &apiv1.Image{}, nil
+	case "found-image1234567":
+		return &apiv1.Image{}, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Hello,

This PR adds the ability to delete all images by passing the -a option when calling
`acorn images rm`.

I think so far you could only delete images one by one (or purge everything).
To test this simply create a couple of images and run
`acorn images rm -a -f`
which should delete all images one by one.
Hope this is useful.

Regards
Richard