### PR TITLE
add readiness probe to acorn controller

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 60
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ setup-ci-image:
 	docker build -t acorn:v-ci .
 	docker save acorn:v-ci | docker exec -i $$(docker ps | grep k3s | awk '{print $$1}') ctr --address /run/k3s/containerd/containerd.sock images import -
 
-GOLANGCI_LINT_VERSION ?= v1.51.1
+GOLANGCI_LINT_VERSION ?= v1.52.2
 setup-env: 
 	if ! command -v golangci-lint &> /dev/null; then \
   		echo "Could not find golangci-lint, installing version $(GOLANGCI_LINT_VERSION)."; \

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 replace (
 	cloud.google.com/go v0.93.3 => cloud.google.com/go v0.100.2
+	// TODO: Remove the below
+	github.com/acorn-io/baaah => github.com/jacobdonenfeld/acorn-baaah v0.0.0-20230502024523-a31acc2b00c4
 	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220121014307-40bb9831756f+incompatible
 	github.com/rancher/apiserver => github.com/acorn-io/apiserver-1 v0.0.0-20220608053213-0ffc3be57697
 	github.com/rancher/lasso => github.com/acorn-io/lasso v0.0.0-20220519152917-47b14aceb5cf

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/acorn-io/aml v0.0.0-20230428030628-bf98aa39a36a h1:yI6MDJU3pcbieiqvNC
 github.com/acorn-io/aml v0.0.0-20230428030628-bf98aa39a36a/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
 github.com/acorn-io/apiserver v0.25.2-ot-2 h1:drxKtiHh2dGnKlhVYxgPCKkFXRvMFxdflCZ5fHpVp8E=
 github.com/acorn-io/apiserver v0.25.2-ot-2/go.mod h1:qRxmYneSxb8B1FYvgQf6mPeWuwugIzYKN3TeMmL4FVo=
-github.com/acorn-io/baaah v0.0.0-20230428031609-d553bca0d3d8 h1:8DA+z4B0aC+u4x1H+3vlgQHytVlyxlkNdS1aMYE/Y+A=
-github.com/acorn-io/baaah v0.0.0-20230428031609-d553bca0d3d8/go.mod h1:yE5MQ1xi7osIDHNnBdmdTHmtnBbYxHQgQfXm/q2bbkU=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/client/pkg/v3 v3.6.0-ot-1 h1:u2g5S6DbDNyueFeRSAVIBGMrkyLlcBLhTmH8l0a/4DM=
@@ -820,6 +818,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jacobdonenfeld/acorn-baaah v0.0.0-20230502024523-a31acc2b00c4 h1:r96rVSLPRapTVXoeQ0lvMgztMaBTKRQYYoVhONiBSWU=
+github.com/jacobdonenfeld/acorn-baaah v0.0.0-20230502024523-a31acc2b00c4/go.mod h1:iVyy+x5QXfMs1J3wMpS02FiC/ygaVEFT1Mi3Pf6YYYs=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=

--- a/integration/client/depends_test.go
+++ b/integration/client/depends_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"strconv"
 	"testing"
 
@@ -40,7 +39,7 @@ func toRevision(t *testing.T, obj kclient.Object) int {
 }
 
 func TestDependsOn(t *testing.T) {
-	ctx := context.Background()
+	ctx := helper.GetCTX(t)
 	c, _ := helper.ClientAndNamespace(t)
 	k8sclient := helper.MustReturn(k8sclient.Default)
 	image := depImage(t, c)
@@ -53,6 +52,7 @@ func TestDependsOn(t *testing.T) {
 	jobs := map[string]int{}
 	deployments := map[string]int{}
 
+	// first wait for app to exist
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &v1.AppList{}, app, func(app *v1.App) bool {
 		return app.Status.Namespace != ""
 	})
@@ -95,7 +95,7 @@ func TestDependsOn(t *testing.T) {
 
 	_ = eg.Wait()
 
-	assert.Less(t, jobs["job2"], jobs["job1"])
+	assert.Less(t, jobs["job1"], jobs["job2"])
 	assert.Less(t, jobs["job1"], deployments["one"])
 	assert.Less(t, jobs["job2"], deployments["one"])
 	assert.Less(t, deployments["one"], deployments["two"])

--- a/integration/client/testdata/dependson/Acornfile
+++ b/integration/client/testdata/dependson/Acornfile
@@ -20,10 +20,10 @@ jobs: {
 	job1: {
 		image:"ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: "/bin/true"
-		dependsOn: "job2"
 	}
 	job2: {
 		image:"ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: "/bin/true"
+		dependsOn: "job1"
 	}
 }

--- a/integration/controller/health_check_test.go
+++ b/integration/controller/health_check_test.go
@@ -1,0 +1,46 @@
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/acorn-io/acorn/integration/helper"
+	_ "k8s.io/client-go/tools/remotecommand"
+)
+
+func TestReadinessProbeOnController(t *testing.T) {
+	if os.Getenv("TEST_ACORN_CONTROLLER") != "external" {
+		t.Skipf("TEST_ACORN_CONTROLLER != external, skipping")
+	}
+
+	client := helper.MustReturn(kclient.DefaultInterface)
+
+	pods, err := client.CoreV1().Pods("acorn-system").List(context.Background(), metav1.ListOptions{})
+	assert.NoError(t, err, "could not get pods, or no pods in namespace acorn-system")
+	var foundPod *v1.Pod
+	var names []string
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, "acorn-controller") {
+			foundPod = &pod
+			break
+		}
+		names = append(names, pod.Name)
+	}
+	if foundPod == nil {
+		t.Fatal(fmt.Errorf("could not find acorn controller, only found %s", names))
+	}
+	assert.NotNil(t, foundPod.Spec.Containers[0].ReadinessProbe, "missing readiness probe on controller")
+	for _, condition := range foundPod.Status.Conditions {
+		if string(condition.Type) == "Ready" {
+			assert.Equal(t, "True", string(condition.Status), "controller pod is not ready")
+		}
+	}
+}

--- a/pkg/install/controller.yaml
+++ b/pkg/install/controller.yaml
@@ -11,7 +11,7 @@ metadata:
   name: acorn-controller
   namespace: acorn-system
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: acorn-controller
@@ -27,6 +27,12 @@ spec:
             - controller
           securityContext:
             runAsUser: 1000
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 3
       serviceAccountName: acorn-system
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Adding a test to check that the controller has a readiness probe enabled and that it is returning "Ready".

Also refactored a counterintuitive naming order for dependsTest

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Depends on acorn-io/baaah#60
Blocked by acorn-io/baaah#62
