### PR TITLE
Fix VolumceClass GVK reported by clients (#1355)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/volumes/class/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/volumes/class/strategy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/acorn-io/mink/pkg/strategy"
 	"github.com/acorn-io/mink/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage"
@@ -64,6 +65,8 @@ func (s *Strategy) list(ctx context.Context, namespace string, opts storage.List
 		if vc.Default {
 			projectDefaultExists = true
 		}
+		// Reset TypeMeta so proper GVK is reported
+		vc.TypeMeta = metav1.TypeMeta{}
 		volumeClasses.Items = append(volumeClasses.Items, apiv1.VolumeClass(vc))
 		projectVolumeClassesSeen[vc.Name] = struct{}{}
 	}
@@ -76,6 +79,8 @@ func (s *Strategy) list(ctx context.Context, namespace string, opts storage.List
 		if projectDefaultExists {
 			cvc.Default = false
 		}
+		// Reset TypeMeta so proper GVK is reported
+		cvc.TypeMeta = metav1.TypeMeta{}
 		volumeClasses.Items = append(volumeClasses.Items, apiv1.VolumeClass(cvc))
 	}
 


### PR DESCRIPTION
There was an issue where the VolumeClass kinds would be reportd incorrectly for the aggregated type. This change ensures the proper kind (VolumeClass) is reported.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/acorn/issues/1355