### PR TITLE
add acorn manual pages on brew install (#1464)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 apiserver.local.config
 /.envrc
 **/.DS_Store
+manpages
+signing.*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,11 @@ dist: releases
 snapshot:
   name_template: '{{ trimprefix .Summary "v" }}'
 
+before:
+  hooks:
+    - go mod tidy
+    - ./scripts/manpages.sh
+
 builds:
   - id: default
     env:
@@ -25,27 +30,28 @@ builds:
       - -s
       - -w
       - -X "github.com/acorn-io/acorn/pkg/version.Tag=v{{ .Version }}"
-      - -X "github.com/acorn-io/acorn/pkg/config.AcornDNSEndpointDefault={{ .Env.ACORN_DNS_ENDPOINT }}"
+#      - -X "github.com/acorn-io/acorn/pkg/config.AcornDNSEndpointDefault={{ .Env.ACORN_DNS_ENDPOINT }}"
 
 universal_binaries:
   - id: mac
     ids:
       - default
     replace: true
-    hooks:
-      post:
-        - cmd: ./tools/notarize "{{ .Path }}" "{{ .ProjectName }}-v{{ .Version }}-macOS-universal"
-          output: true
-          env:
-            - SIGN={{ if index .Env "SIGN" }}1{{ end }}
-            - NOTARIZE={{ if index .Env "NOTARIZE" }}{{ .Env.NOTARIZE }}{{ end }}
-            - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
-            - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
-            - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}
-            - AC_PASSWORD={{ if index .Env "AC_PASSWORD" }}{{ .Env.AC_PASSWORD }}{{ end }}
+#    hooks:
+#      post:
+#        - cmd: ./tools/notarize "{{ .Path }}" "{{ .ProjectName }}-v{{ .Version }}-macOS-universal"
+#          output: true
+#          env:
+#            - SIGN={{ if index .Env "SIGN" }}1{{ end }}
+#            - NOTARIZE={{ if index .Env "NOTARIZE" }}{{ .Env.NOTARIZE }}{{ end }}
+#            - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
+#            - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
+#            - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}
+#            - AC_PASSWORD={{ if index .Env "AC_PASSWORD" }}{{ .Env.AC_PASSWORD }}{{ end }}
 
 archives:
   - id: default
+    rlcp: true
     builds:
       - default
       - mac
@@ -53,18 +59,22 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - LICENSE
+      - README.md
+      - manpages/*
 
 checksum:
   name_template: "checksums.txt"
   extra_files:
     - glob: "./releases/*.dmg"
 
-signs:
-  - id: cosign
-    cmd: cosign
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
-    args: ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
-    artifacts: checksum
+#signs:
+#  - id: cosign
+#    cmd: cosign
+#    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+#    args: ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+#    artifacts: checksum
 
 changelog:
   use: github
@@ -93,6 +103,12 @@ brews:
       owner: acorn-io
       name: homebrew-cli
       token: "{{ .Env.GH_PROJECT_TOKEN }}"
+    test: |
+      system "#{bin}/acorn -v"
+    install: |-
+      bin1.install "acorn"
+      prefix.install "LICENSE", "README.md"
+      man1.install "manpages/acorn.1.gz"
 
 dockers:
   - use: buildx
@@ -165,6 +181,6 @@ docker_manifests:
       - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm64
       - ghcr.io/acorn-io/acorn:v{{ .Version }}-arm32v7
 
-docker_signs:
-  - artifacts: all
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+#docker_signs:
+#  - artifacts: all
+#    stdin: "{{ .Env.COSIGN_PASSWORD }}"

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -66,6 +66,7 @@ func New() *cobra.Command {
 		NewTag(cmdContext),
 		NewVolume(cmdContext),
 		NewWait(cmdContext),
+		NewMan(cmdContext),
 	)
 	// This will produce an error if the project flag doesn't exist or a completion function has already
 	// been registered for this flag. Not returning the error since neither of these is likely occur.
@@ -73,6 +74,7 @@ func New() *cobra.Command {
 		root.Printf("Error registering completion function for -j flag: %v\n", err)
 	}
 	root.InitDefaultHelpCmd()
+
 	return root
 }
 

--- a/pkg/cli/man.go
+++ b/pkg/cli/man.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func NewMan(c CommandContext) *cobra.Command {
+	return cli.Command(&Man{client: c.ClientFactory}, cobra.Command{
+		Use: "man",
+		Example: `
+acorn man`,
+		SilenceUsage: true,
+		Short:        "Generate acorn man pages",
+		Hidden:       true,
+	})
+}
+
+type Man struct {
+	Directory string `usage:"Directory to generate man files" short:"d"`
+	client    ClientFactory
+}
+
+func (m *Man) Run(cmd *cobra.Command, args []string) error {
+	// Create root command to create pages from
+	rootCmd := New()
+
+	var manDir string
+	if m.Directory == "" {
+		exePath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("Could not find executable directory: %v\n", err)
+		}
+
+		// Get the directory containing the binary file
+		exeDir := filepath.Dir(exePath)
+
+		// Determine the directory to place the manual files in
+		manDir = filepath.Join(exeDir, "manpages")
+		// Create subfolders if they don't exist
+		fmt.Printf("creating %v", manDir)
+		err = os.MkdirAll(manDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("Could not generate necessary directories: %v\n", err)
+		}
+	} else {
+		manDir = m.Directory
+	}
+
+	//file, err := os.OpenFile(filepath.Join(manDir, "acorn.txt"), os.O_TRUNC, 0777)
+	//defer file.Close()
+	//if err != nil {
+	//	return fmt.Errorf("Can't open file for writing: %v\n", err)
+	//}
+	//err = doc.GenMan(rootCmd, &doc.GenManHeader{
+	//	Title:   "Acorn",
+	//	Section: "",
+	//	Date:    nil,
+	//	Source:  "docs.acorn.io",
+	//	Manual:  "",
+	//},
+	//	file)
+	//if err != nil {
+	//	return fmt.Errorf("Can't open file for writing: %v\n", err)
+	//}
+
+	err := doc.GenManTree(rootCmd, &doc.GenManHeader{
+		Title:  "Acorn",
+		Manual: "Acorn Docs",
+		Source: "docs.acorn.io",
+	}, manDir)
+	if err != nil {
+		return fmt.Errorf("Error generating manual pages for acorn in installation directory: %v\n", err)
+	}
+	return nil
+}

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -196,14 +196,14 @@ func (m *MockClient) AppRun(ctx context.Context, image string, opts *client.AppR
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{Ready: true},
 		}, nil
 	case "found.container":
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	}
@@ -221,14 +221,14 @@ func (m *MockClient) AppUpdate(ctx context.Context, name string, opts *client.Ap
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	case "found.container":
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	}
@@ -607,7 +607,7 @@ func (m *MockClient) ImageTag(ctx context.Context, image, tag string) error {
 func (m *MockClient) ImageDetails(ctx context.Context, imageName string, opts *client.ImageDetailsOptions) (*client.ImageDetails, error) {
 	return &client.ImageDetails{
 		AppImage: v1.AppImage{ID: imageName, ImageData: v1.ImagesData{
-			Containers: map[string]v1.ContainerData{"test-image-running-container": v1.ContainerData{
+			Containers: map[string]v1.ContainerData{"test-image-running-container": {
 				Image:    "test-image-running-container",
 				Sidecars: nil,
 			}},

--- a/scripts/manpages.sh
+++ b/scripts/manpages.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# https://carlosbecker.com/posts/golang-completions-cobra/
+set -e
+rm -rf manpages
+mkdir manpages
+go run ./ man | gzip -c -9 >manpages/acorn.1.gz


### PR DESCRIPTION
Partially tested.

We could rename the hidden function to "generatemanual" and unhide it potentially.

## Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Addresses #1464
