### PR TITLE
Don't hide inactive top level acorn

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"strings"
+
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
@@ -67,7 +69,8 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 }
 
 func inactive(app apiv1.App) bool {
-	return app.Status.Ready &&
+	return strings.Contains(app.Name, ".") &&
+		app.Status.Ready &&
 		app.Status.Columns.Healthy == "0" &&
 		app.Status.Columns.UpToDate == "0" &&
 		app.Status.Columns.Message == "OK"


### PR DESCRIPTION
By default we hide apps that have nothing running in it. We don't
want to do that for top level acorns, just nested.

Signed-off-by: Darren Shepherd <darren@acorn.io>
