### PR TITLE
Prevent Acorn from assuming Docker Hub for auto-upgrade apps with no specified registry (#1427)

### DIFF
--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -325,6 +325,13 @@ func TestImageDetails(t *testing.T) {
 	}
 
 	assert.True(t, strings.Contains(details.AppImage.Acornfile, "nginx"))
+
+	// Test an auto-upgrade pattern that matches no local images, and make sure the proper error is returned
+	_, err = c.ImageDetails(ctx, "dne:v#.#.#", nil)
+	if err == nil {
+		t.Fatal("expected error for auto-upgrade pattern that matches no local images")
+	}
+	assert.ErrorContains(t, err, "unable to find an image for dne:v#.#.# matching pattern v#.#.# - if you are trying to use Docker Hub, use docker.io/dne:v#.#.#")
 }
 
 func TestImageDeleteTwoTags(t *testing.T) {

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -331,7 +331,7 @@ func TestImageDetails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for auto-upgrade pattern that matches no local images")
 	}
-	assert.ErrorContains(t, err, "unable to find an image for dne:v#.#.# matching pattern v#.#.# - if you are trying to use Docker Hub, use docker.io/dne:v#.#.#")
+	assert.ErrorContains(t, err, "unable to find an image for dne:v#.#.# matching pattern v#.#.# - if you are trying to use a remote image, specify the full registry")
 }
 
 func TestImageDeleteTwoTags(t *testing.T) {

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1696,5 +1696,5 @@ func TestAutoUpgradeImageValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when failing to find local image for auto-upgrade app, got no error")
 	}
-	assert.ErrorContains(t, err, "could not find local image for myimage:latest - if you are trying to use Docker Hub, use docker.io/myimage:latest")
+	assert.ErrorContains(t, err, "could not find local image for myimage:latest - if you are trying to use a remote image, specify the full registry")
 }

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -78,7 +78,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 					}
 					if ref.Context().RegistryStr() == defaultNoReg {
 						// Prevent this from being resolved remotely, as we should never assume Docker Hub for auto-upgrade apps
-						return fmt.Errorf("no local image found for %v\nif you are trying to use Docker Hub, use docker.io/%v", target, target)
+						return fmt.Errorf("no local image found for %v - if you are trying to use Docker Hub, use docker.io/%v", target, target)
 					}
 				}
 

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -20,8 +20,6 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const defaultNoReg = "xxx-no-reg"
-
 func PullAppImage(transport http.RoundTripper, recorder event.Recorder) router.HandlerFunc {
 	return pullAppImage(transport, pullClient{
 		recorder: recorder,
@@ -72,11 +70,11 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			}
 			if !isLocal {
 				if autoUpgradeOn && !tags.IsLocalReference(target) {
-					ref, err := imagename.ParseReference(target, imagename.WithDefaultRegistry(defaultNoReg))
+					ref, err := imagename.ParseReference(target, imagename.WithDefaultRegistry(images.NoDefaultRegistry))
 					if err != nil {
 						return err
 					}
-					if ref.Context().RegistryStr() == defaultNoReg {
+					if ref.Context().RegistryStr() == images.NoDefaultRegistry {
 						// Prevent this from being resolved remotely, as we should never assume Docker Hub for auto-upgrade apps
 						return fmt.Errorf("no local image found for %v - if you are trying to use Docker Hub, use docker.io/%v", target, target)
 					}

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -76,7 +76,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 					}
 					if ref.Context().RegistryStr() == images.NoDefaultRegistry {
 						// Prevent this from being resolved remotely, as we should never assume Docker Hub for auto-upgrade apps
-						return fmt.Errorf("no local image found for %v - if you are trying to use Docker Hub, use docker.io/%v", target, target)
+						return fmt.Errorf("no local image found for %v - if you are trying to use a remote image, specify the full registry", target)
 					}
 				}
 

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -297,7 +297,7 @@ func TestAutoUpgradeImageResolution(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error when no local image was found for auto-upgrade app without a specified registry")
 	}
-	assert.ErrorContains(t, err, "no local image found for myimage:latest - if you are trying to use Docker Hub, use docker.io/myimage:latest")
+	assert.ErrorContains(t, err, "no local image found for myimage:latest - if you are trying to use a remote image, specify the full registry")
 }
 
 func testPullAppImage(transport http.RoundTripper, recorder event.Recorder) router.HandlerFunc {

--- a/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/existing.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: api.acorn.io/v1
+kind: Image
+metadata:
+  name: myimage:latest
+  namespace: app-namespace
+digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+tags:
+  - myimage:latest

--- a/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/expected.golden
+++ b/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/expected.golden
@@ -1,0 +1,27 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  autoUpgrade: true
+  image: myimage:latest
+status:
+  appImage:
+    digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    imageData: {}
+    name: myimage:latest
+    vcs: {}
+  appSpec: {}
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: image-pull
+  defaults: {}
+  namespace: app-created-namespace
+`

--- a/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/input.yaml
+++ b/pkg/controller/appdefinition/testdata/autoupgrade/with-local-image/input.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  autoUpgrade: true
+  image: myimage:latest
+status:
+  namespace: app-created-namespace

--- a/pkg/controller/appdefinition/testdata/autoupgrade/without-local-image/input.yaml
+++ b/pkg/controller/appdefinition/testdata/autoupgrade/without-local-image/input.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  autoUpgrade: true
+  image: myimage:latest
+status:
+  namespace: app-created-namespace

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -17,8 +17,6 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const defaultNoReg = "xxx-no-reg"
-
 func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName string, profiles []string, deployArgs map[string]any, nested string, opts ...remote.Option) (*apiv1.ImageDetails, error) {
 	imageName = strings.ReplaceAll(imageName, "+", "/")
 	name := strings.ReplaceAll(imageName, "/", "+")
@@ -29,8 +27,8 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 		} else if !found {
 			// Check and see if no registry was specified on the image.
 			// If this is the case, notify the user that they need to explicitly specify docker.io if that is what they are trying to use.
-			ref, err := imagename.ParseReference(strings.TrimSuffix(imageName, ":"+tagPattern), imagename.WithDefaultRegistry(defaultNoReg))
-			if err == nil && ref.Context().Registry.Name() == defaultNoReg {
+			ref, err := imagename.ParseReference(strings.TrimSuffix(imageName, ":"+tagPattern), imagename.WithDefaultRegistry(images.NoDefaultRegistry))
+			if err == nil && ref.Context().Registry.Name() == images.NoDefaultRegistry {
 				return nil, fmt.Errorf("unable to find an image for %v matching pattern %v - if you are trying to use Docker Hub, use docker.io/%v", imageName, tagPattern, imageName)
 			}
 

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -29,7 +29,7 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 			// If this is the case, notify the user that they need to explicitly specify docker.io if that is what they are trying to use.
 			ref, err := imagename.ParseReference(strings.TrimSuffix(imageName, ":"+tagPattern), imagename.WithDefaultRegistry(images.NoDefaultRegistry))
 			if err == nil && ref.Context().Registry.Name() == images.NoDefaultRegistry {
-				return nil, fmt.Errorf("unable to find an image for %v matching pattern %v - if you are trying to use Docker Hub, use docker.io/%v", imageName, tagPattern, imageName)
+				return nil, fmt.Errorf("unable to find an image for %v matching pattern %v - if you are trying to use a remote image, specify the full registry", imageName, tagPattern)
 			}
 
 			return nil, fmt.Errorf("unable to find an image for %v matching pattern %v", imageName, tagPattern)

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -31,7 +31,7 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 			// If this is the case, notify the user that they need to explicitly specify docker.io if that is what they are trying to use.
 			ref, err := imagename.ParseReference(strings.TrimSuffix(imageName, ":"+tagPattern), imagename.WithDefaultRegistry(defaultNoReg))
 			if err == nil && ref.Context().Registry.Name() == defaultNoReg {
-				return nil, fmt.Errorf("unable to find an image for %v matching pattern %v\nif you are trying to use Docker Hub, use docker.io/%v", imageName, tagPattern, imageName)
+				return nil, fmt.Errorf("unable to find an image for %v matching pattern %v - if you are trying to use Docker Hub, use docker.io/%v", imageName, tagPattern, imageName)
 			}
 
 			return nil, fmt.Errorf("unable to find an image for %v matching pattern %v", imageName, tagPattern)

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -87,15 +87,15 @@ func PullAppImage(ctx context.Context, c client.Reader, namespace, image, nested
 	return appImage, nil
 }
 
-const DefaultRegistry = "NO_DEFAULT"
+const NoDefaultRegistry = "xxx-no-reg"
 
 func ParseReferenceNoDefault(name string) (imagename.Reference, error) {
-	ref, err := imagename.ParseReference(name, imagename.WithDefaultRegistry(DefaultRegistry))
+	ref, err := imagename.ParseReference(name, imagename.WithDefaultRegistry(NoDefaultRegistry))
 	if err != nil {
 		return nil, err
 	}
 
-	if ref.Context().RegistryStr() == DefaultRegistry {
+	if ref.Context().RegistryStr() == NoDefaultRegistry {
 		return nil, fmt.Errorf("missing registry host in the tag [%s] (ie ghcr.io or docker.io)", name)
 	}
 	return ref, nil

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -99,7 +99,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 
 				if ref.Context().RegistryStr() == defaultNoReg {
 					result = append(result, field.Invalid(field.NewPath("spec", "image"), params.Spec.Image,
-						fmt.Sprintf("could not find local image for %v\nif you are trying to use Docker Hub, use docker.io/%v", params.Spec.Image, params.Spec.Image)))
+						fmt.Sprintf("could not find local image for %v - if you are trying to use Docker Hub, use docker.io/%v", params.Spec.Image, params.Spec.Image)))
 				}
 			}
 

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/computeclasses"
 	apiv1config "github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/imageallowrules"
+	"github.com/acorn-io/runtime/pkg/images"
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/acorn-io/runtime/pkg/labels"
 	"github.com/acorn-io/runtime/pkg/pullsecret"
@@ -35,8 +36,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const defaultNoReg = "xxx-no-reg"
 
 type Validator struct {
 	client        kclient.Client
@@ -91,13 +90,13 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 			if _, autoUpgradeOn := autoupgrade.Mode(params.Spec); autoUpgradeOn {
 				// Make sure there is a registry specified here
 				// If there isn't one, return an error in order to avoid checking Docker Hub implicitly
-				ref, err := name.ParseReference(params.Spec.Image, name.WithDefaultRegistry(defaultNoReg))
+				ref, err := name.ParseReference(params.Spec.Image, name.WithDefaultRegistry(images.NoDefaultRegistry))
 				if err != nil {
 					result = append(result, field.InternalError(field.NewPath("spec", "image"), err))
 					return
 				}
 
-				if ref.Context().RegistryStr() == defaultNoReg {
+				if ref.Context().RegistryStr() == images.NoDefaultRegistry {
 					result = append(result, field.Invalid(field.NewPath("spec", "image"), params.Spec.Image,
 						fmt.Sprintf("could not find local image for %v - if you are trying to use Docker Hub, use docker.io/%v", params.Spec.Image, params.Spec.Image)))
 				}

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -98,7 +98,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 
 				if ref.Context().RegistryStr() == images.NoDefaultRegistry {
 					result = append(result, field.Invalid(field.NewPath("spec", "image"), params.Spec.Image,
-						fmt.Sprintf("could not find local image for %v - if you are trying to use Docker Hub, use docker.io/%v", params.Spec.Image, params.Spec.Image)))
+						fmt.Sprintf("could not find local image for %v - if you are trying to use a remote image, specify the full registry", params.Spec.Image)))
 				}
 			}
 


### PR DESCRIPTION
for #1427

This change ensures that apps with auto-upgrade enabled will never implicitly pull images from Docker Hub.

This is important in order to avoid dependency confusion. Since auto-upgrade apps, unlike normal apps, will give priority to remote images when resolving, it would be possible for an attacker to create a public image that matches the name of a private, local-only image, and Acorn would pick it up and auto-upgrade to that. This PR prevents that from being possible.

Unfortunately, there were three separate areas where I had to implement this logic:
- Get image details
- App validation in the apiserver
- Pull app image

I wrote tests (two unit, one integration) to check for this logic in all three places.

Currently, prior to this PR, it is possible for auto-upgrade apps to implicitly use Docker Hub as long as they aren't using a tag pattern (e.g. `acorn run -n nginx grantlinville/nginx:latest` works and uses my image from Docker Hub). This will no longer work as soon as this is merged. For running apps that are like this, they will continue to run, but there will be an error in their status until their image is updated using `acorn update` (or until a local image that matches the auto-upgrade is built).

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

