### PR TITLE
fix: cleanup `acorn secrets reveal` and general non-table output (#1812)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,8 +23,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}",
-            //"args": ["secret", "reveal", "mytestsec", "-o=json"],
-            "args": ["images", "-o=json"],
+            "args": ["run", "${input:acornfile}"],
             "console": "integratedTerminal",
         },
         {
@@ -38,11 +37,6 @@
         }
     ],
     "inputs": [
-        {
-            "id": "args",
-            "type": "promptStringArray",
-            "description": "Enter any arguments to pass to the program.",
-        },
 		{
 			"id": "acornfile",
 			"type": "promptString",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,8 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}",
-            "args": ["run", "${input:acornfile}"],
+            //"args": ["secret", "reveal", "mytestsec", "-o=json"],
+            "args": ["images", "-o=json"],
             "console": "integratedTerminal",
         },
         {
@@ -37,6 +38,11 @@
         }
     ],
     "inputs": [
+        {
+            "id": "args",
+            "type": "promptStringArray",
+            "description": "Enter any arguments to pass to the program.",
+        },
 		{
 			"id": "acornfile",
 			"type": "promptString",

--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -126,7 +126,7 @@ func toKObject(obj any) (kclient.Object, bool) {
 }
 
 func cleanFields(obj any) any {
-	if ol, ok := obj.(ObjectList); ok {
+	if ol, ok := obj.(objectList); ok {
 		for i, o := range ol.Items {
 			ol.Items[i] = cleanFields(o)
 		}

--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -154,9 +154,36 @@ func cleanFields(obj any) any {
 			}
 		}
 		ro.SetAnnotations(annotations)
+
+		// decode secret values
+		if sec, ok := ro.(*apiv1.Secret); ok {
+			return decodeSecret(sec)
+		}
+
 		return ro
 	}
 	return obj
+}
+
+func decodeSecret(sec *apiv1.Secret) any {
+	decodedSecret := struct {
+		metav1.TypeMeta   `json:",inline"`
+		metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+		Type string            `json:"type,omitempty"`
+		Data map[string]string `json:"data,omitempty"`
+		Keys []string          `json:"keys,omitempty"`
+	}{
+		TypeMeta:   sec.TypeMeta,
+		ObjectMeta: sec.ObjectMeta,
+		Type:       sec.Type,
+		Data:       map[string]string{},
+		Keys:       sec.Keys,
+	}
+	for k, v := range sec.Data {
+		decodedSecret.Data[k] = string(v)
+	}
+	return decodedSecret
 }
 
 func FormatYAML(data any) (string, error) {

--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -126,6 +126,13 @@ func toKObject(obj any) (kclient.Object, bool) {
 }
 
 func cleanFields(obj any) any {
+	if ol, ok := obj.(ObjectList); ok {
+		for i, o := range ol.Items {
+			ol.Items[i] = cleanFields(o)
+		}
+		return ol
+	}
+
 	ro, ok := toKObject(obj)
 	if ok {
 		ro.SetManagedFields(nil)

--- a/pkg/cli/builder/table/writer.go
+++ b/pkg/cli/builder/table/writer.go
@@ -230,7 +230,7 @@ func (t *writer) writeDataObject(objs ...any) error {
 	return errors.Join(t.errs...)
 }
 
-type ObjectList struct {
+type objectList struct {
 	Items []any `json:"items"`
 }
 
@@ -266,7 +266,7 @@ func (t *writer) flush(closing bool) error {
 		if closing {
 			// if we are closing, then we want to print objects its in a proper list
 			// data structure
-			err := t.writeDataObject(ObjectList{Items: objs})
+			err := t.writeDataObject(objectList{Items: objs})
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/builder/table/writer.go
+++ b/pkg/cli/builder/table/writer.go
@@ -230,6 +230,10 @@ func (t *writer) writeDataObject(objs ...any) error {
 	return errors.Join(t.errs...)
 }
 
+type ObjectList struct {
+	Items []any `json:"items"`
+}
+
 func (t *writer) flush(closing bool) error {
 	if len(t.errs) > 0 {
 		return errors.Join(t.errs...)
@@ -262,9 +266,7 @@ func (t *writer) flush(closing bool) error {
 		if closing {
 			// if we are closing, then we want to print objects its in a proper list
 			// data structure
-			err := t.writeDataObject(map[string]any{
-				"items": objs,
-			})
+			err := t.writeDataObject(ObjectList{Items: objs})
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/secret_expose.go
+++ b/pkg/cli/secret_expose.go
@@ -66,6 +66,11 @@ func (a *Reveal) Run(cmd *cobra.Command, args []string) error {
 				Key:   entry.Key,
 				Value: string(entry.Value),
 			}, &secret)
+			if a.Output != "" {
+				// in non-table output, we write the source object to buffer,
+				// so we exit here to not write the same object multiple times (one per data key)
+				break
+			}
 		}
 	}
 

--- a/pkg/cli/secret_test.go
+++ b/pkg/cli/secret_test.go
@@ -184,6 +184,63 @@ func TestSecret(t *testing.T) {
 			wantOut: "NAME      TYPE      KEY       VALUE\n",
 		},
 		{
+			name: "acorn secret reveal secret.withdata", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"reveal", "secret.withdata"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "NAME              TYPE      KEY       VALUE\nsecret.withdata             baz       qux\nsecret.withdata             foo       bar\n",
+		},
+		{
+			name: "acorn secret reveal secret.withdata -o jsoncompact", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"reveal", "secret.withdata", "-o=jsoncompact"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "{\"items\":[{\"metadata\":{\"name\":\"secret.withdata\",\"creationTimestamp\":null},\"data\":{\"baz\":\"qux\",\"foo\":\"bar\"}}]}\n",
+		},
+		{
+			name: "acorn secret reveal secret.withdata secret.withdata2 -o jsoncompact", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"reveal", "secret.withdata", "secret.withdata2", "-o=jsoncompact"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "{\"items\":[{\"metadata\":{\"name\":\"secret.withdata\",\"creationTimestamp\":null},\"data\":{\"baz\":\"qux\",\"foo\":\"bar\"}},{\"metadata\":{\"name\":\"secret.withdata2\",\"creationTimestamp\":null},\"data\":{\"spam\":\"eggs\"}}]}\n",
+		},
+		{
 			name: "acorn secret reveal dne", fields: fields{
 				All:    false,
 				Quiet:  false,

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -379,6 +379,26 @@ func (m *MockClient) SecretReveal(ctx context.Context, name string) (*apiv1.Secr
 			Data:       nil,
 			Keys:       nil,
 		}, nil
+	case "secret.withdata":
+		return &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret.withdata",
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+				"baz": []byte("qux"),
+			},
+		}, nil
+	case "secret.withdata2":
+		return &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret.withdata2",
+			},
+			Data: map[string][]byte{
+				"spam": []byte("eggs"),
+			},
+		}, nil
+
 	}
 	return nil, nil
 }

--- a/pkg/cli/testdata/all/all_test_json.txt
+++ b/pkg/cli/testdata/all/all_test_json.txt
@@ -63,11 +63,7 @@ VOLUMES:
         {
             "metadata": {
                 "name": "found.vol",
-                "creationTimestamp": null,
-                "labels": {
-                    "acorn.io/app-name": "found",
-                    "acorn.io/volume-name": "vol"
-                }
+                "creationTimestamp": null
             },
             "spec": {},
             "status": {

--- a/pkg/cli/testdata/all/all_test_yaml.txt
+++ b/pkg/cli/testdata/all/all_test_yaml.txt
@@ -44,9 +44,6 @@ VOLUMES:
 items:
 - metadata:
     creationTimestamp: null
-    labels:
-      acorn.io/app-name: found
-      acorn.io/volume-name: vol
     name: found.vol
   spec: {}
   status:

--- a/pkg/cli/volumes_test.go
+++ b/pkg/cli/volumes_test.go
@@ -113,7 +113,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "{\n    \"items\": [\n        {\n            \"metadata\": {\n                \"name\": \"found.vol\",\n                \"creationTimestamp\": null,\n                \"labels\": {\n                    \"acorn.io/app-name\": \"found\",\n                    \"acorn.io/volume-name\": \"vol\"\n                }\n            },\n            \"spec\": {},\n            \"status\": {\n                \"appName\": \"found\",\n                \"appPublicName\": \"found\",\n                \"volumeName\": \"vol\",\n                \"columns\": {}\n            }\n        }\n    ]\n}\n\n",
+			wantOut: "{\n    \"items\": [\n        {\n            \"metadata\": {\n                \"name\": \"found.vol\",\n                \"creationTimestamp\": null\n            },\n            \"spec\": {},\n            \"status\": {\n                \"appName\": \"found\",\n                \"appPublicName\": \"found\",\n                \"volumeName\": \"vol\",\n                \"columns\": {}\n            }\n        }\n    ]\n}\n\n",
 		},
 		{
 			name: "acorn volume -o yaml", fields: fields{
@@ -126,7 +126,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "---\nitems:\n- metadata:\n    creationTimestamp: null\n    labels:\n      acorn.io/app-name: found\n      acorn.io/volume-name: vol\n    name: found.vol\n  spec: {}\n  status:\n    appName: found\n    appPublicName: found\n    columns: {}\n    volumeName: vol\n\n",
+			wantOut: "---\nitems:\n- metadata:\n    creationTimestamp: null\n    name: found.vol\n  spec: {}\n  status:\n    appName: found\n    appPublicName: found\n    columns: {}\n    volumeName: vol\n\n",
 		},
 		{
 			name: "acorn volume found.vol", fields: fields{


### PR DESCRIPTION
We had 3 problems here:

1. Secret was printed twice because we were putting the source object into buffer once for every secret data key
2. [General] Due to the `map[string]any` type output, the object fields (e.g. managed fields) were not cleaned anymore
3. Secret data values were not encoded as it printed the plain objects, where the secret data values fields are []byte

Ref #1812

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

