### PR TITLE
fix: handle "image not allowed error" for both run and update (#1712)

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -2,7 +2,6 @@ package autoupgrade
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -235,7 +234,7 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 			if updated || strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:") != strings.TrimPrefix(digest, "sha256:") {
 				if !updated && digest != "" {
 					if err := d.client.checkImageAllowed(ctx, app.Namespace, nextAppImage); err != nil {
-						if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {
+						if _, ok := err.(*imageallowrules.ErrImageNotAllowed); ok {
 							logrus.Debugf("Updated image %s for %s/%s is not allowed: %v", nextAppImage, app.Namespace, app.Name, err)
 							d.appKeysPrevCheck[appKey] = updateTime
 							continue

--- a/pkg/controller/appdefinition/checkimageallowed.go
+++ b/pkg/controller/appdefinition/checkimageallowed.go
@@ -1,7 +1,6 @@
 package appdefinition
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -39,7 +38,7 @@ func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 		targetImageDigest := appInstance.Status.AppImage.Digest
 
 		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, targetImageDigest, remote.WithTransport(transport)); err != nil {
-			if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {
+			if _, ok := err.(*imageallowrules.ErrImageNotAllowed); ok {
 				cond.Error(err)
 				return nil
 			} else {

--- a/pkg/rulerequest/handle.go
+++ b/pkg/rulerequest/handle.go
@@ -18,6 +18,51 @@ import (
 	"github.com/pterm/pterm"
 )
 
+// handleNotAllowedError handles the case where an image is not allowed by IARs and prompts the user to create a basic one (image pattern only, no signatures, etc.)
+func handleNotAllowedError(ctx context.Context, c client.Client, dangerous bool, image string, err error, app *apiv1.App, opts any) (*apiv1.App, error) {
+	err.(*imageallowrules.ErrImageNotAllowed).Image = image
+
+	// We're checking for images first, since we could run existing images by ID
+	var il []apiv1.Image
+	il, err = c.ImageList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var existingImg *apiv1.Image
+	var existingImgTag, existingImgName string
+
+	existingImg, existingImgTag, err = images.FindImageMatch(apiv1.ImageList{Items: il}, image)
+	if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
+		return nil, err
+	} else if err == nil {
+		image = existingImg.Name
+		existingImgName = existingImg.Name
+		if existingImgTag != "" {
+			image = existingImgTag
+		}
+	}
+
+	// Prompt user to create an simple IAR for this image
+	if choice, promptErr := handleNotAllowed(dangerous, image); promptErr != nil {
+		return nil, fmt.Errorf("%s: %w", promptErr.Error(), err)
+	} else if choice != "NO" {
+		iarErr := createImageAllowRule(ctx, c, image, choice, existingImgName) // existingImgName to ensure that this exact image ID is allowed in addition to whatever pattern we're allowing
+		if iarErr != nil {
+			return nil, iarErr
+		}
+		switch opts := opts.(type) {
+		case *client.AppRunOptions:
+			return c.AppRun(ctx, image, opts)
+		case *client.AppUpdateOptions:
+			return c.AppUpdate(ctx, app.Name, opts)
+		default:
+			return app, fmt.Errorf("unknown opts type: %T", opts)
+		}
+	}
+
+	return app, nil
+}
+
 func PromptRun(ctx context.Context, c client.Client, dangerous bool, image string, opts client.AppRunOptions) (*apiv1.App, error) {
 	app, err := c.AppRun(ctx, image, &opts)
 
@@ -33,38 +78,7 @@ func PromptRun(ctx context.Context, c client.Client, dangerous bool, image strin
 
 	// ImageAllowRules are enabled and this image is not allowed
 	if naErr := (*imageallowrules.ErrImageNotAllowed)(nil); errors.As(err, &naErr) {
-		err.(*imageallowrules.ErrImageNotAllowed).Image = image
-
-		// We're checking for images first, since we could run existing images by ID
-		var il []apiv1.Image
-		il, err = c.ImageList(ctx)
-		if err != nil {
-			return nil, err
-		}
-		var existingImg *apiv1.Image
-		var existingImgTag, existingImgName string
-
-		existingImg, existingImgTag, err = images.FindImageMatch(apiv1.ImageList{Items: il}, image)
-		if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
-			return nil, err
-		} else if err == nil {
-			image = existingImg.Name
-			existingImgName = existingImg.Name
-			if existingImgTag != "" {
-				image = existingImgTag
-			}
-		}
-
-		// Prompt user to create an simple IAR for this image
-		if choice, promptErr := handleNotAllowed(dangerous, image); promptErr != nil {
-			return nil, fmt.Errorf("%s: %w", promptErr.Error(), err)
-		} else if choice != "NO" {
-			iarErr := createImageAllowRule(ctx, c, image, choice, existingImgName) // existingImgName to ensure that this exact image ID is allowed in addition to whatever pattern we're allowing
-			if iarErr != nil {
-				return nil, iarErr
-			}
-			app, err = c.AppRun(ctx, image, &opts)
-		}
+		app, err = handleNotAllowedError(ctx, c, dangerous, image, err, app, &opts)
 	}
 	return app, err
 }
@@ -79,6 +93,16 @@ func PromptUpdate(ctx context.Context, c client.Client, dangerous bool, name str
 			app, err = c.AppUpdate(ctx, name, &opts)
 		}
 	}
+
+	// ImageAllowRules are enabled and this image is not allowed
+	if naErr := (*imageallowrules.ErrImageNotAllowed)(nil); errors.As(err, &naErr) {
+		image := opts.Image
+		if image == "" {
+			image = app.Spec.Image
+		}
+		app, err = handleNotAllowedError(ctx, c, dangerous, image, err, app, &opts)
+	}
+
 	return app, err
 }
 

--- a/pkg/rulerequest/handle.go
+++ b/pkg/rulerequest/handle.go
@@ -19,6 +19,7 @@ import (
 )
 
 // handleNotAllowedError handles the case where an image is not allowed by IARs and prompts the user to create a basic one (image pattern only, no signatures, etc.)
+// @param opts can be either *client.AppRunOptions or *client.AppUpdateOptions and based on that we'll call either AppRun or AppUpdate in the end
 func handleNotAllowedError(ctx context.Context, c client.Client, dangerous bool, image string, err error, app *apiv1.App, opts any) (*apiv1.App, error) {
 	err.(*imageallowrules.ErrImageNotAllowed).Image = image
 


### PR DESCRIPTION
Ref #1712


### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

