### PR TITLE
Replace deprecated goreleaser flag

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --snapshot
+          args: release --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
`--rm-dist` has been deprecated, replace it with `--clean`, see
https://goreleaser.com/deprecations#-rm-dist for more details.

