### PR TITLE
Use Github hosted runners in CI for MacOS

### DIFF
--- a/.github/workflows/main-mac-smoke-test.yaml
+++ b/.github/workflows/main-mac-smoke-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    runs-on: [self-hosted, macOS]
+    runs-on: macos-12-xl
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,8 +20,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          cache: false
+          cache: true
           go-version: "1.20"
+      - name: Install Docker CLI
+        run: brew install docker
+      - name: Start Colima # Starts the Docker Daemon without Docker Desktop
+        run: colima start
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
This PR switches from self-hosted to GitHub hosted MacOS runners. In particular, the `macos-12-xl` runner is used to increase the speed of the action.

Just in case its this easy to get our MacOS notarization into the cloud 🤞🏻 
### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

