### PR TITLE
Add support for filtering events by source (#1802)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -6,7 +6,7 @@ title: "acorn events"
 List events about Acorn resources
 
 ```
-acorn events [flags] [EVENT_NAME]
+acorn events [flags] [PREFIX]
 ```
 
 ### Examples
@@ -18,14 +18,31 @@ acorn events [flags] [EVENT_NAME]
   # List events across all projects
   acorn -A events
 
-  # Get a single event by name
-  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # List the last 10 events 
   acorn events --tail 10
 
   # List the last 5 events and follow the event log
   acorn events --tail 5 -f
+
+  # Filter by Event Source 
+  # If a PREFIX is given in the form '<kind>/<name>', the results of this command are pruned to include
+  # only those events sourced by resources matching the given kind and name.
+  # List events sourced by the 'hello' app in the current project
+  acorn events app/hello
+  
+  # If the '/<name>' suffix is omitted, '<kind>' will match events sourced by any resource of the given kind.
+  # List events related to any app in the current project
+  acorn events app 
+
+  # Filter by Event Name
+  # If the PREFIX '/<name>' suffix is omitted, and the '<kind>' doesn't match a known event source, its value
+  # is interpreted as an event name prefix.
+  # List events with names that begin with '4b2b' 
+  acorn events 4b2b
+
+  # Get a single event by name
+  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # Getting Details 
   # The 'details' field provides additional information about an event.

--- a/pkg/apis/api.acorn.io/v1/scheme.go
+++ b/pkg/apis/api.acorn.io/v1/scheme.go
@@ -90,7 +90,7 @@ func AddToSchemeWithGV(scheme *runtime.Scheme, schemeGroupVersion schema.GroupVe
 		gvk := schemeGroupVersion.WithKind("Event")
 		flcf := func(label, value string) (string, string, error) {
 			switch label {
-			case "details", "metadata.name", "metadata.namespace":
+			case "prefix", "details", "metadata.name", "metadata.namespace":
 				return label, value, nil
 			}
 			return "", "", fmt.Errorf("unsupported field selection [%s]", label)

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -10,7 +10,7 @@ import (
 
 func NewEvent(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Events{client: c.ClientFactory}, cobra.Command{
-		Use:               "events [flags] [EVENT_NAME]",
+		Use:               "events [flags] [PREFIX]",
 		SilenceUsage:      true,
 		Short:             "List events about Acorn resources",
 		Args:              cobra.MaximumNArgs(1),
@@ -21,14 +21,31 @@ func NewEvent(c CommandContext) *cobra.Command {
   # List events across all projects
   acorn -A events
 
-  # Get a single event by name
-  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # List the last 10 events 
   acorn events --tail 10
 
   # List the last 5 events and follow the event log
   acorn events --tail 5 -f
+
+  # Filter by Event Source 
+  # If a PREFIX is given in the form '<kind>/<name>', the results of this command are pruned to include
+  # only those events sourced by resources matching the given kind and name.
+  # List events sourced by the 'hello' app in the current project
+  acorn events app/hello
+  
+  # If the '/<name>' suffix is omitted, '<kind>' will match events sourced by any resource of the given kind.
+  # List events related to any app in the current project
+  acorn events app 
+
+  # Filter by Event Name
+  # If the PREFIX '/<name>' suffix is omitted, and the '<kind>' doesn't match a known event source, its value
+  # is interpreted as an event name prefix.
+  # List events with names that begin with '4b2b' 
+  acorn events 4b2b
+
+  # Get a single event by name
+  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # Getting Details 
   # The 'details' field provides additional information about an event.
@@ -60,7 +77,7 @@ func (e *Events) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) > 0 {
-		opts.Name = args[0]
+		opts.Prefix = args[0]
 	}
 
 	events, err := c.EventStream(cmd.Context(), opts)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -327,14 +327,14 @@ type EventStreamOptions struct {
 	Tail            int    `json:"tail,omitempty"`
 	Follow          bool   `json:"follow,omitempty"`
 	Details         bool   `json:"details,omitempty"`
-	Name            string `json:"name,omitempty"`
+	Prefix          string `json:"prefix,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
 func (o EventStreamOptions) ListOptions() *kclient.ListOptions {
 	fieldSet := make(fields.Set)
-	if o.Name != "" {
-		fieldSet["metadata.name"] = o.Name
+	if o.Prefix != "" {
+		fieldSet["prefix"] = o.Prefix
 	}
 	if o.Details {
 		fieldSet["details"] = strconv.FormatBool(o.Details)


### PR DESCRIPTION
Add support for filtering events by source kind and name to the `acorn events` command.

To this end, the `NAME` argument is renamed `PREFIX` and extended to accept both fully and partially qualified references to event sources.

What does that mean?

A _partially qualified reference_ matches events sourced by any resource of a given kind.

e.g. List events sourced by any app:

```sh
$ acorn events app
```

A _fully qualified reference_ matches events sourced by a specific resource.

e.g. List events sourced by an app named "hello":

```sh
$ acorn events app/hello
``` 

In addition to source references, the `PREFIX` argument also supports filtering events by name prefix.

e.g. List events with names that begin with "4b2b":

```sh
$ acorn events 4b2b
```

Addresses: #1802