### PR TITLE
Improve container port deduplication

### DIFF
--- a/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
@@ -115,7 +115,8 @@ spec:
     acorn.io/container-name: nginx
     acorn.io/managed: "true"
   ports:
-  - protocol: http
+  - port: 80
+    protocol: http
     targetPort: 80
 status: {}
 

--- a/pkg/ports/ports_test.go
+++ b/pkg/ports/ports_test.go
@@ -1,0 +1,134 @@
+package ports
+
+import (
+	"testing"
+
+	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectPorts(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ports    []v1.PortDef
+		expected []v1.PortDef
+	}{
+		{
+			name:     "empty",
+			ports:    []v1.PortDef{},
+			expected: nil,
+		},
+		{
+			name:     "single",
+			ports:    []v1.PortDef{{TargetPort: 80}},
+			expected: []v1.PortDef{{TargetPort: 80, Port: 80}},
+		},
+		{
+			name: "duplicate public port",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000},
+				{TargetPort: 9090, Port: 8000},
+			},
+			expected: []v1.PortDef{{TargetPort: 8080, Port: 8000}},
+		},
+		{
+			name: "duplicate target port",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000},
+				{TargetPort: 8080, Port: 9000},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000},
+				{TargetPort: 8080, Port: 9000},
+			},
+		},
+		{
+			name: "duplicate everything",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+			},
+			expected: []v1.PortDef{{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"}},
+		},
+		{
+			name: "duplicate port and target port with different hostnames",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
+			},
+		},
+		{
+			name: "duplicate port and hostname with different target ports",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 9090, Port: 8000, Hostname: "myapp.local"},
+			},
+			expected: []v1.PortDef{{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"}},
+		},
+		{
+			name: "duplicate target port and hostname with different public ports",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 9000, Hostname: "myapp.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 9000, Hostname: "myapp.local"},
+			},
+		},
+		{
+			name: "duplicate port, different target ports and hostnames",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 9090, Port: 8000, Hostname: "myapp2.local"},
+			},
+			expected: []v1.PortDef{{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"}},
+		},
+		{
+			name: "duplicate target port, different ports and hostnames",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 9000, Hostname: "myapp2.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 9000, Hostname: "myapp2.local"},
+			},
+		},
+		{
+			name: "duplicate hostnames, different ports and target ports",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
+			},
+		},
+		{
+			name: "three completely different PortDefs",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 9090, Port: 9000, Hostname: "myapp2.local"},
+				{TargetPort: 7070, Port: 7000, Hostname: "myapp3.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+				{TargetPort: 9090, Port: 9000, Hostname: "myapp2.local"},
+				{TargetPort: 7070, Port: 7000, Hostname: "myapp3.local"},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := map[int32][]hostnameAndTargetPort{}
+			assert.Equal(t, tt.expected, collectPorts(seen, tt.ports, false))
+		})
+	}
+}

--- a/pkg/ports/ports_test.go
+++ b/pkg/ports/ports_test.go
@@ -43,6 +43,17 @@ func TestCollectPorts(t *testing.T) {
 			},
 		},
 		{
+			name: "one undefined hostname",
+			ports: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+			},
+			expected: []v1.PortDef{
+				{TargetPort: 8080, Port: 8000},
+				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
+			},
+		},
+		{
 			name: "duplicate everything",
 			ports: []v1.PortDef{
 				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
@@ -77,7 +88,6 @@ func TestCollectPorts(t *testing.T) {
 			},
 			expected: []v1.PortDef{
 				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
-				{TargetPort: 8080, Port: 9000, Hostname: "myapp.local"},
 			},
 		},
 		{
@@ -103,11 +113,10 @@ func TestCollectPorts(t *testing.T) {
 			name: "duplicate hostnames, different ports and target ports",
 			ports: []v1.PortDef{
 				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
-				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
+				{TargetPort: 9090, Port: 9000, Hostname: "myapp.local"},
 			},
 			expected: []v1.PortDef{
 				{TargetPort: 8080, Port: 8000, Hostname: "myapp.local"},
-				{TargetPort: 8080, Port: 8000, Hostname: "myapp2.local"},
 			},
 		},
 		{
@@ -128,7 +137,8 @@ func TestCollectPorts(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			seen := map[int32][]hostnameAndTargetPort{}
-			assert.Equal(t, tt.expected, collectPorts(seen, tt.ports, false))
+			seenHostname := map[string]struct{}{}
+			assert.Equal(t, tt.expected, collectPorts(seen, seenHostname, tt.ports, false))
 		})
 	}
 }

--- a/pkg/ports/ports_test.go
+++ b/pkg/ports/ports_test.go
@@ -136,7 +136,7 @@ func TestCollectPorts(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			seen := map[int32][]hostnameAndTargetPort{}
+			seen := map[int32][]int32{}
 			seenHostname := map[string]struct{}{}
 			assert.Equal(t, tt.expected, collectPorts(seen, seenHostname, tt.ports, false))
 		})

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -206,7 +206,7 @@ func collectPorts(seen map[int32][]hostnameAndTargetPort, seenHostnames map[stri
 		}
 
 		// Can't have any duplicate hostnames, so check for that first
-		if _, exists := seenHostnames[port.Hostname]; exists {
+		if _, exists := seenHostnames[port.Hostname]; port.Hostname != "" && exists {
 			continue
 		}
 

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -248,7 +248,7 @@ func FilterDevPorts(ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
 }
 
 func CollectContainerPorts(container *v1.Container, devMode bool) (result []v1.PortDef) {
-	// seen represents a mapping of public port numbers to a combination of hostname and target port
+	// seen represents a mapping of public port numbers to target port numbers
 	seen := map[int32][]int32{}
 	seenHostnames := map[string]struct{}{}
 

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -194,29 +194,40 @@ func matches(binding v1.PortPublish, port v1.PortDef) bool {
 		portMatches(binding, port)
 }
 
-func collectPorts(seen, seenTargets map[int32]struct{}, ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
+type hostnameAndTargetPort struct {
+	target   int32
+	hostname string
+}
+
+func collectPorts(seen map[int32][]hostnameAndTargetPort, ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
 	for _, port := range ports {
 		if !devMode && port.Dev {
 			continue
 		}
 
-		if _, ok := seen[port.Port]; ok {
-			continue
-		} else if _, ok := seenTargets[port.TargetPort]; ok {
+		// If port.Port is 0, that means only the TargetPort has been defined, and not the public-facing Port.
+		// The public-facing Port will ultimately use the same number as the TargetPort, so we'll set it here
+		// so that the logic is correct for the rest of this function.
+		if port.Port == 0 {
+			port.Port = port.TargetPort
+		}
+
+		if hostnamesWithTarget, ok := seen[port.Port]; ok {
+			// Check for special case: the same port is exposed on multiple hostnames, so keep both.
+			if port.Hostname != "" {
+				for _, h := range hostnamesWithTarget {
+					if h.hostname != port.Hostname && h.target == port.TargetPort {
+						// Same port and target port but different hostnames, so keep both
+						seen[port.Port] = append(hostnamesWithTarget, hostnameAndTargetPort{hostname: port.Hostname, target: port.TargetPort})
+						result = append(result, port)
+						break
+					}
+				}
+			}
 			continue
 		}
 
-		if port.Port != 0 {
-			seen[port.Port] = struct{}{}
-		} else {
-			// If port.Port is 0, that means only the TargetPort has been defined, and not the public-facing Port.
-			// The public-facing Port will ultimately use the same number as the TargetPort, so we add TargetPort to
-			// the Port "seen" map in that case.
-			seen[port.TargetPort] = struct{}{}
-		}
-
-		seenTargets[port.TargetPort] = struct{}{}
-
+		seen[port.Port] = []hostnameAndTargetPort{{hostname: port.Hostname, target: port.TargetPort}}
 		result = append(result, port)
 	}
 	return
@@ -233,12 +244,12 @@ func FilterDevPorts(ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
 }
 
 func CollectContainerPorts(container *v1.Container, devMode bool) (result []v1.PortDef) {
-	seen := map[int32]struct{}{}
-	seenTargets := map[int32]struct{}{}
+	// seen represents a mapping of public port numbers to a combination of hostname and target port
+	seen := map[int32][]hostnameAndTargetPort{}
 
-	result = append(result, collectPorts(seen, seenTargets, container.Ports, devMode)...)
+	result = append(result, collectPorts(seen, container.Ports, devMode)...)
 	for _, entry := range typed.Sorted(container.Sidecars) {
-		result = append(result, collectPorts(seen, seenTargets, entry.Value.Ports, devMode)...)
+		result = append(result, collectPorts(seen, entry.Value.Ports, devMode)...)
 	}
 
 	return


### PR DESCRIPTION
I took a look at this after seeing this message in the users Slack: https://acorn-users.slack.com/archives/C03R9ME0SKC/p1687662529203189

Before this PR, we did not support the ability to publish the same port on multiple hostnames like this: `ports: publish: ["app.path1:80/http", "app.path2:80/http"]`

With this PR, this becomes possible.

While investigating this, I discovered another bug. Before this PR, if you specify the same hostname multiple times for different ports (i.e. `ports: publish: ["app.path:80/http", "app.path:8080/http"]`), Acorn does not return an error and the app is created, but the Kubernetes Service for it does not get created at all.

With this PR, the deduplication logic checks for duplicate hostnames.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

