### PR TITLE
Rename hub to manager

### DIFF
--- a/integration/projectconfig/projectconfig_test.go
+++ b/integration/projectconfig/projectconfig_test.go
@@ -146,7 +146,7 @@ func TestCLIConfig(t *testing.T) {
 			wantNamespace: "something",
 		},
 		{
-			name: "User set hub reference",
+			name: "User set manager reference",
 			opt: project.Options{
 				Project: "example.com/foo/bar",
 				CLIConfig: &config.CLIConfig{

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestAppsThenContainersCompletion(t *testing.T) {
-	appNames := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
-	containerNames := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "hub.container", "hub.other-container", "test-2.container-1"}
+	appNames := []string{"test-1", "acorn-1", "acorn-2", "manager", "test-2"}
+	containerNames := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "manager.container", "manager.other-container", "test-2.container-1"}
 	apps := make([]apiv1.App, 0, len(appNames))
 	for _, name := range appNames {
 		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
@@ -68,9 +68,9 @@ func TestAppsThenContainersCompletion(t *testing.T) {
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete hub, only hub returned",
-			toComplete:    "hub",
-			wantNames:     []string{"hub"},
+			name:          "Complete manager, only manager returned",
+			toComplete:    "manager",
+			wantNames:     []string{"manager"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
@@ -80,27 +80,27 @@ func TestAppsThenContainersCompletion(t *testing.T) {
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete starting with hub.",
-			toComplete:    "hub.",
-			wantNames:     []string{"hub.container", "hub.other-container"},
+			name:          "Complete starting with manager.",
+			toComplete:    "manager.",
+			wantNames:     []string{"manager.container", "manager.other-container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete starting with hub.c",
-			toComplete:    "hub.c",
-			wantNames:     []string{"hub.container"},
+			name:          "Complete starting with manager.c",
+			toComplete:    "manager.c",
+			wantNames:     []string{"manager.container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete hub.container, only hub.container returned",
-			toComplete:    "hub.container",
-			wantNames:     []string{"hub.container"},
+			name:          "Complete manager.container, only manager.container returned",
+			toComplete:    "manager.container",
+			wantNames:     []string{"manager.container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete hub.c, but hub.container already in args",
-			args:          []string{"hub.container"},
-			toComplete:    "hub.c",
+			name:          "Complete manager.c, but manager.container already in args",
+			args:          []string{"manager.container"},
+			toComplete:    "manager.c",
 			wantNames:     []string{},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
@@ -129,7 +129,7 @@ func TestAppsThenContainersCompletion(t *testing.T) {
 }
 
 func TestAppsCompletion(t *testing.T) {
-	names := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
+	names := []string{"test-1", "acorn-1", "acorn-2", "manager", "test-2"}
 	apps := make([]apiv1.App, 0, len(names))
 	for _, name := range names {
 		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
@@ -173,9 +173,9 @@ func TestAppsCompletion(t *testing.T) {
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete hub, only hub returned",
-			toComplete:    "hub",
-			wantNames:     []string{"hub"},
+			name:          "Complete manager, only manager returned",
+			toComplete:    "manager",
+			wantNames:     []string{"manager"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
@@ -203,7 +203,7 @@ func TestAppsCompletion(t *testing.T) {
 }
 
 func TestContainersCompletion(t *testing.T) {
-	names := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "hub.container", "hub.other-container", "test-2.container-1"}
+	names := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "manager.container", "manager.other-container", "test-2.container-1"}
 	containers := make([]apiv1.ContainerReplica, 0, len(names))
 	for _, name := range names {
 		containers = append(containers, apiv1.ContainerReplica{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: apiv1.ContainerReplicaSpec{AppName: strings.Split(name, ".")[0]}})
@@ -246,21 +246,21 @@ func TestContainersCompletion(t *testing.T) {
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete starting with hub.",
-			toComplete:    "hub.",
-			wantNames:     []string{"hub.container", "hub.other-container"},
+			name:          "Complete starting with manager.",
+			toComplete:    "manager.",
+			wantNames:     []string{"manager.container", "manager.other-container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete starting with hub.c",
-			toComplete:    "hub.c",
-			wantNames:     []string{"hub.container"},
+			name:          "Complete starting with manager.c",
+			toComplete:    "manager.c",
+			wantNames:     []string{"manager.container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
-			name:          "Complete hub.container, only hub.container returned",
-			toComplete:    "hub.container",
-			wantNames:     []string{"hub.container"},
+			name:          "Complete manager.container, only manager.container returned",
+			toComplete:    "manager.container",
+			wantNames:     []string{"manager.container"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
@@ -423,7 +423,7 @@ func TestAcornContainerCompletion(t *testing.T) {
 		"test-2": {
 			"container-1": {},
 		},
-		"hub": {
+		"manager": {
 			"web":        {},
 			"db":         {},
 			"controller": {},
@@ -488,7 +488,7 @@ func TestOnlyAppsWithAcornContainer(t *testing.T) {
 		"test-2": {
 			"container-1": {},
 		},
-		"hub": {
+		"manager": {
 			"web":        {},
 			"db":         {},
 			"controller": {},
@@ -528,12 +528,12 @@ func TestOnlyAppsWithAcornContainer(t *testing.T) {
 	}{
 		{
 			name:          "Nothing to complete and no container, return apps",
-			wantNames:     []string{"hub", "test-1", "test-2"},
+			wantNames:     []string{"manager", "test-1", "test-2"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
 			name:          "Nothing to complete and no container, return apps except those in args",
-			args:          []string{"hub", "test-2"},
+			args:          []string{"manager", "test-2"},
 			wantNames:     []string{"test-1"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
@@ -545,15 +545,15 @@ func TestOnlyAppsWithAcornContainer(t *testing.T) {
 		},
 		{
 			name:          "Something with '.' to complete and no container should be the k8s container completion",
-			toComplete:    "hub.",
-			wantNames:     []string{"hub.controller", "hub.db", "hub.web"},
+			toComplete:    "manager.",
+			wantNames:     []string{"manager.controller", "manager.db", "manager.web"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{
 			name:          "Something with '.' to complete and no container should be the k8s container completion except those in args",
-			toComplete:    "hub.",
-			args:          []string{"hub.db"},
-			wantNames:     []string{"hub.controller", "hub.web"},
+			toComplete:    "manager.",
+			args:          []string{"manager.db"},
+			wantNames:     []string{"manager.controller", "manager.web"},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{

--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -12,7 +12,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/credentials"
-	"github.com/acorn-io/runtime/pkg/hub"
+	"github.com/acorn-io/runtime/pkg/manager"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -54,8 +54,8 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 
 	var serverAddress string
 	if len(args) == 0 && a.Password != "" {
-		// HubServer slice length is guaranteed to be >=1 by the ReadCLIConfig method
-		serverAddress = cfg.HubServers[0]
+		// ManagerServer slice length is guaranteed to be >=1 by the ReadCLIConfig method
+		serverAddress = cfg.AcornServers[0]
 	} else if len(args) > 0 {
 		serverAddress = args[0]
 	}
@@ -92,13 +92,13 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	isHub, err := hub.IsHub(cfg, serverAddress)
+	isManager, err := manager.IsManager(cfg, serverAddress)
 	if err != nil {
 		return err
 	}
 
-	if isHub {
-		user, pass, err := hub.Login(cmd.Context(), a.Password, serverAddress)
+	if isManager {
+		user, pass, err := manager.Login(cmd.Context(), a.Password, serverAddress)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if isHub {
+	if isManager {
 		// reload config, could have changed
 		cfg, err = config.ReadCLIConfig()
 		if err != nil {
@@ -142,7 +142,7 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		var projectSet bool
-		def, err := hub.DefaultProject(cmd.Context(), serverAddress, a.Username, a.Password)
+		def, err := manager.DefaultProject(cmd.Context(), serverAddress, a.Username, a.Password)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/credential_logout.go
+++ b/pkg/cli/credential_logout.go
@@ -41,8 +41,8 @@ func (a *CredentialLogout) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	var client client.Client
-	if slices.Contains(cfg.HubServers, args[0]) {
-		// force local storage for known hub addresses
+	if slices.Contains(cfg.AcornServers, args[0]) {
+		// force local storage for known manager addresses
 		a.LocalStorage = true
 	}
 

--- a/pkg/cli/testdata/info/info_test-a.txt
+++ b/pkg/cli/testdata/info/info_test-a.txt
@@ -1,7 +1,7 @@
 ---
 client:
   cli:
-    hubServers:
+    acornServers:
     - acorn.io
   version:
     tag: v0.0.0-dev

--- a/pkg/cli/testdata/info/info_test.txt
+++ b/pkg/cli/testdata/info/info_test.txt
@@ -1,7 +1,7 @@
 ---
 client:
   cli:
-    hubServers:
+    acornServers:
     - acorn.io
   version:
     tag: v0.0.0-dev

--- a/pkg/cli/testdata/info/info_test_empty.txt
+++ b/pkg/cli/testdata/info/info_test_empty.txt
@@ -1,7 +1,7 @@
 ---
 client:
   cli:
-    hubServers:
+    acornServers:
     - acorn.io
   version:
     tag: v0.0.0-dev

--- a/pkg/cli/testdata/info/info_test_json.txt
+++ b/pkg/cli/testdata/info/info_test_json.txt
@@ -4,7 +4,7 @@
             "tag": "v0.0.0-dev"
         },
         "cli": {
-            "hubServers": [
+            "acornServers": [
                 "acorn.io"
             ]
         }

--- a/pkg/cli/testdata/info/info_test_yaml.txt
+++ b/pkg/cli/testdata/info/info_test_yaml.txt
@@ -1,8 +1,7 @@
 ---
 client:
   cli:
-
-    hubServers:
+    acornServers:
     - acorn.io
   version:
     tag: v0.0.0-dev

--- a/pkg/config/cliconfig.go
+++ b/pkg/config/cliconfig.go
@@ -47,7 +47,7 @@ type CLIConfig struct {
 	Auths             map[string]AuthConfig `json:"auths,omitempty"`
 	CredentialsStore  string                `json:"credsStore,omitempty"`
 	CredentialHelpers map[string]string     `json:"credHelpers,omitempty"`
-	HubServers        []string              `json:"hubServers,omitempty"`
+	AcornServers      []string              `json:"acornServers,omitempty"`
 	Kubeconfigs       map[string]string     `json:"-"`
 	ProjectAliases    map[string]string     `json:"projectAliases,omitempty"`
 	CurrentProject    string                `json:"currentProject,omitempty"`
@@ -136,8 +136,8 @@ func ReadCLIConfig() (*CLIConfig, error) {
 
 	result.filename = filename
 
-	if len(result.HubServers) == 0 {
-		result.HubServers = []string{system.DefaultHubAddress}
+	if len(result.AcornServers) == 0 {
+		result.AcornServers = []string{system.DefaultHubAddress}
 	}
 
 	result.Kubeconfigs = map[string]string{}
@@ -201,15 +201,15 @@ func RemoveServer(cfg *CLIConfig, serverAddress string) error {
 		modified = true
 	}
 
-	var newHubServers []string
-	for _, server := range cfg.HubServers {
+	var newAcornServer []string
+	for _, server := range cfg.AcornServers {
 		if server != serverAddress {
-			newHubServers = append(newHubServers, server)
+			newAcornServer = append(newAcornServer, server)
 		}
 	}
 
-	if len(newHubServers) != len(cfg.HubServers) {
-		cfg.HubServers = newHubServers
+	if len(newAcornServer) != len(cfg.AcornServers) {
+		cfg.AcornServers = newAcornServer
 		modified = true
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,7 @@ func complete(ctx context.Context, c *apiv1.Config, getter kclient.Reader) error
 
 // shouldLookupAcornDNSDomain determines if given the current configuration, Acorn DNS domain should be used if
 // found. Extra care is taken to ensure we only do extra API object lookups when necessary. Most importantly some objects
-// like v1.Node won't exist in hub and will fail there, so there should be a user configuration that will make lookups
+// like v1.Node won't exist in manager and will fail there, so there should be a user configuration that will make lookups
 // not happen.
 func shouldLookupAcornDNSDomain(ctx context.Context, c *apiv1.Config, getter kclient.Reader) (bool, error) {
 	if strings.EqualFold(*c.AcornDNS, "enabled") {
@@ -181,7 +181,7 @@ func useLocalWildcardDomain(ctx context.Context, getter kclient.Reader) (bool, e
 	var nodes corev1.NodeList
 	if err := getter.List(ctx, &nodes); err != nil {
 		if meta.IsNoMatchError(err) {
-			// Node type doesn't exist probably because we are running against hub
+			// Node type doesn't exist probably because we are running against manager
 			return false, nil
 		}
 		return false, err

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -151,7 +151,7 @@ func ensureSignatureArtifact(ctx context.Context, c client.Reader, namespace str
 
 // VerifySignature checks if the image is signed with the given key and if the annotations match the given rules
 // This does a lot of image and image manifest juggling to fetch artifacts, digests, etc. from the registry, so we have to be
-// careful to not do too many GET requests that count against registry rate limits (e.g. for DockerHub).
+// careful to not do too many GET requests that count against registry rate limits (e.g. for Docker Hub).
 // Crane uses HEAD (with GET as a fallback) wherever it can, so it's a good choice here e.g. for fetching digests.
 func VerifySignature(ctx context.Context, opts VerifyOpts) error {
 	sigs, err := ociremote.Signatures(opts.SignatureRef, opts.OciRemoteOpts...) // this runs against our internal registry, so it should not count against the rate limits

--- a/pkg/manager/client.go
+++ b/pkg/manager/client.go
@@ -1,4 +1,4 @@
-package hub
+package manager
 
 import (
 	"context"

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,4 +1,4 @@
-package hub
+package manager
 
 import (
 	"context"
@@ -16,8 +16,8 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-func IsHub(cfg *config.CLIConfig, address string) (bool, error) {
-	if slices.Contains(cfg.HubServers, address) {
+func IsManager(cfg *config.CLIConfig, address string) (bool, error) {
+	if slices.Contains(cfg.AcornServers, address) {
 		return true, nil
 	}
 
@@ -45,7 +45,7 @@ func IsHub(cfg *config.CLIConfig, address string) (bool, error) {
 		return false, nil
 	}
 
-	cfg.HubServers = append(cfg.HubServers, address)
+	cfg.AcornServers = append(cfg.AcornServers, address)
 	return true, cfg.Save()
 }
 

--- a/pkg/manager/urls.go
+++ b/pkg/manager/urls.go
@@ -1,4 +1,4 @@
-package hub
+package manager
 
 import (
 	"fmt"
@@ -10,15 +10,15 @@ func isLocal(address string) bool {
 }
 
 func toDiscoverURL(address string) string {
-	return fmt.Sprintf("%s://%s/apis/hub.acorn.io/v1", scheme(address), address)
+	return fmt.Sprintf("%s://%s/apis/manager.acorn.io/v1", scheme(address), address)
 }
 
 func toProjectMembershipURL(address string) string {
-	return fmt.Sprintf("%s://%s/apis/hub.acorn.io/v1/projectmemberships", scheme(address), address)
+	return fmt.Sprintf("%s://%s/apis/manager.acorn.io/v1/projectmemberships", scheme(address), address)
 }
 
 func toAccountURL(address, account string) string {
-	return fmt.Sprintf("%s://%s/apis/hub.acorn.io/v1/accounts/%s", scheme(address), address, account)
+	return fmt.Sprintf("%s://%s/apis/manager.acorn.io/v1/accounts/%s", scheme(address), address, account)
 }
 
 func scheme(address string) string {
@@ -33,5 +33,5 @@ func toLoginURL(address, password string) string {
 }
 
 func toTokenRequestURL(address, password string) string {
-	return fmt.Sprintf("%s://%s/apis/hub.acorn.io/v1/tokenrequests/%s", scheme(address), address, password)
+	return fmt.Sprintf("%s://%s/apis/manager.acorn.io/v1/tokenrequests/%s", scheme(address), address, password)
 }

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/credentials"
-	"github.com/acorn-io/runtime/pkg/hub"
+	"github.com/acorn-io/runtime/pkg/manager"
 	"github.com/acorn-io/runtime/pkg/system"
 	"k8s.io/client-go/rest"
 )
@@ -210,7 +210,7 @@ func getClient(ctx context.Context, cfg *config.CLIConfig, opts Options, project
 		New: func() (client.Client, error) {
 			url := cfg.TestProjectURLs[serverOrKubeconfig+"/"+account]
 			if url == "" {
-				url, err = hub.ProjectURL(ctx, serverOrKubeconfig, account, cred.Password)
+				url, err = manager.ProjectURL(ctx, serverOrKubeconfig, account, cred.Password)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/project/client_test.go
+++ b/pkg/project/client_test.go
@@ -24,25 +24,25 @@ func TestParseProject(t *testing.T) {
 			wantNamespace: "foo",
 		},
 		{
-			name: "Hub reference",
+			name: "Manager reference",
 			args: args{
-				project: "hub.example.com/account/project",
+				project: "manager.example.com/account/project",
 			},
 			wantNamespace: "project",
 			wantAccount:   "account",
-			wantServer:    "hub.example.com",
+			wantServer:    "manager.example.com",
 		},
 		{
-			name: "Hub reference",
+			name: "Manager reference",
 			args: args{
-				project: "hub.example.com/account/project",
+				project: "manager.example.com/account/project",
 			},
 			wantNamespace: "project",
 			wantAccount:   "account",
-			wantServer:    "hub.example.com",
+			wantServer:    "manager.example.com",
 		},
 		{
-			name: "Hub default reference",
+			name: "Manager default reference",
 			args: args{
 				project: "account/project",
 			},

--- a/pkg/publish/ingress.go
+++ b/pkg/publish/ingress.go
@@ -211,8 +211,7 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 			continue
 		}
 		// For custom domain, always use cert-manager to provision certificate.
-		defaulClusterIssuer := *cfg.CertManagerIssuer
-		secrets, ingressTLS, ingressAnnotation, err := setupCertsForRules(req, svc, rules.rules, rules.name == customDomain, defaulClusterIssuer)
+		secrets, ingressTLS, ingressAnnotation, err := setupCertsForRules(req, svc, rules.rules, rules.name == customDomain, *cfg.CertManagerIssuer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
+++ b/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
@@ -31,7 +31,7 @@ func (s *ConfirmUpgradeStrategy) Create(ctx context.Context, obj types.Object) (
 		return obj, nil
 	}
 
-	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// Use app instance here because in Manager this request is forwarded to the workload cluster.
 	// The app validation logic should not run there.
 	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)

--- a/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
+++ b/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
@@ -34,7 +34,7 @@ func (s *ignoreCleanupStrategy) Create(ctx context.Context, obj types.Object) (t
 		return obj, nil
 	}
 
-	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// Use app instance here because in Manager this request is forwarded to the workload cluster.
 	// The app validation logic should not run there.
 	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)

--- a/pkg/server/registry/apigroups/acorn/apps/pull.go
+++ b/pkg/server/registry/apigroups/acorn/apps/pull.go
@@ -36,7 +36,7 @@ func (s *PullAppImageStrategy) Create(ctx context.Context, obj types.Object) (ty
 	p := obj.(*apiv1.AppPullImage)
 	ri, _ := request.RequestInfoFrom(ctx)
 
-	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// Use app instance here because in Manager this request is forwarded to the workload cluster.
 	// The app validation logic should not run there.
 	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -107,7 +107,7 @@ var (
 	Info = [][]string{
 		{"Version", "Client.Version"},
 		{"Current Project", "Client.CLI.CurrentProject"},
-		{"Hub Servers", "{{ arrayNoSpace .Client.CLI.HubServers }}"},
+		{"Manager Servers", "{{ arrayNoSpace .Client.CLI.AcornServers }}"},
 	}
 	InfoConverter = MustConverter(Info)
 


### PR DESCRIPTION
The public-facing references to Hub are renamed to Acorn

