### PR TITLE
Fix output of `acorn apps` to show image names properly for Nested and Service Acorns (#1774)

### DIFF
--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -9,6 +9,7 @@ import (
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	adminv1 "github.com/acorn-io/runtime/pkg/apis/internal.admin.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/labels"
 	"github.com/acorn-io/runtime/pkg/tags"
 	"github.com/rancher/wrangler/pkg/data/convert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ var (
 		"memoryToRange": MemoryToRange,
 		"defaultMemory": DefaultMemory,
 		"ownerName":     OwnerReferenceName,
+		"imageName":     ImageName,
 	}
 )
 
@@ -291,4 +293,16 @@ func OwnerReferenceName(obj metav1.Object) string {
 	}
 
 	return owners[0].Name
+}
+
+func ImageName(obj metav1.Object) string {
+	app, ok := obj.(*apiv1.App)
+	if !ok {
+		return ""
+	}
+
+	if original, exists := app.ObjectMeta.Annotations[labels.AcornOriginalImage]; exists {
+		return original
+	}
+	return app.Status.AppImage.Name
 }

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -9,7 +9,7 @@ var (
 
 	App = [][]string{
 		{"Name", "{{ . | name }}"},
-		{"Image", "{{ trunc .Status.AppImage.Name }}"},
+		{"Image", "{{ . | imageName }}"},
 		{"Healthy", "Status.Columns.Healthy"},
 		{"Up-To-Date", "Status.Columns.UpToDate"},
 		{"Created", "{{ago .CreationTimestamp}}"},

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -9,7 +9,7 @@ var (
 
 	App = [][]string{
 		{"Name", "{{ . | name }}"},
-		{"Image", "{{ . | imageName }}"},
+		{"Image", "{{ . | imageName | trunc }}"},
 		{"Healthy", "Status.Columns.Healthy"},
 		{"Up-To-Date", "Status.Columns.UpToDate"},
 		{"Created", "{{ago .CreationTimestamp}}"},


### PR DESCRIPTION
for #1774

Before:

```
❯ acorn ps
NAME               IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE
misty-bird.nginx   585983fbdfbf   1         1            8s ago                OK
```

After:

```
❯ acorn ps
NAME               IMAGE                                        HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE
misty-bird.nginx   index.docker.io/grantlinville/nginx:latest   1         1            27s ago               OK
```

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

