### PR TITLE
Add sudo to notarize script commands

### DIFF
--- a/tools/notarize
+++ b/tools/notarize
@@ -4,7 +4,7 @@ set -e
 cd $(dirname $0)/..
 
 : ${KEYCHAIN="build.keychain"}
-: ${SIGN="1"}
+: ${SIGN=""}
 : ${NOTARIZE=""}
 : ${AC_BUNDLE="io.acorn.cli"}
 
@@ -20,17 +20,17 @@ fi
 
 echo "SIGN=${SIGN} NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} DMG=${DMG}"
 
-apt-get update -y  
+sudo apt-get update -y  
 
-if [[ "${SIGN}" == 1 ]]; then
+if [[ "${SIGN}" != "0" ]]; then
   echo "Signing"
 
   # Install the necessary tools, specifically cargo, to install rcodesign, a Rust 
   # implementation of codesign.
-  which curl || apt-get install curl -y
-  which gcc || apt-get install gcc -y
-  which cargo || curl https://sh.rustup.rs -sSf | sh -s -- -y && bash
-  which rcodesign || cargo install apple-codesign
+  which curl || sudo apt-get install curl -y
+  which gcc || sudo apt-get install gcc -y
+  which cargo || sudo curl https://sh.rustup.rs -sSf | sh -s -- -y && bash
+  which rcodesign || sudo cargo install apple-codesign
 
   # Sign the binary using rcodesign.
   echo "${AC_P12}" | base64 --decode > signing.p12
@@ -39,10 +39,10 @@ else
   echo "Skipping signing"
 fi
 
-if [[ "${NOTARIZE}" == 1 ]]; then
+if [[ "${NOTARIZE}" == "1" ]]; then
   echo "Notarizing…"
 
-  which mkfs.hfsplus || apt-get install hfsprogs -y
+  which mkfs.hfsplus || sudo apt-get install hfsprogs -y
 
   # Build the DMG
   cp LICENSE README.md "${DIR}/"


### PR DESCRIPTION
Adding sudo to `notarize` script.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

