### PR TITLE
Output short hash with `acorn ps` if the tag no longer exists on the image

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"strings"
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
+	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/tables"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
@@ -43,7 +45,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		out.Write(app)
+		writeApp(cmd.Context(), app, out, c)
 		return out.Err()
 	}
 
@@ -58,10 +60,10 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		}
 		if len(args) > 0 {
 			if slices.Contains(args, app.Name) {
-				out.Write(&app)
+				writeApp(cmd.Context(), &app, out, c)
 			}
 		} else {
-			out.Write(&app)
+			writeApp(cmd.Context(), &app, out, c)
 		}
 	}
 
@@ -74,4 +76,33 @@ func inactive(app apiv1.App) bool {
 		app.Status.Columns.Healthy == "0" &&
 		app.Status.Columns.UpToDate == "0" &&
 		app.Status.Columns.Message == "OK"
+}
+
+func writeApp(ctx context.Context, app *apiv1.App, out table.Writer, c client.Client) {
+	images, err := c.ImageList(ctx)
+	if err != nil {
+		// Give up and write the app
+		out.Write(app)
+		return
+	}
+
+	// Loop through the images and make sure the image name is still a valid tag on that image
+	// If it isn't, set the image name to match the digest instead
+	var tagIsValid bool
+	for _, image := range images {
+		if image.Digest == app.Status.AppImage.Digest {
+			for _, tag := range image.Tags {
+				// Use strings.HasSuffix on Docker Hub images to account for the possible disparity between index.docker.io, docker.io, and no explicitly specified registry
+				if tag == app.Status.AppImage.Name || (strings.Contains(tag, "docker.io") && strings.HasSuffix(tag, app.Status.AppImage.Name)) {
+					tagIsValid = true
+					break
+				}
+			}
+			break
+		}
+	}
+	if !tagIsValid {
+		app.Status.AppImage.Name = strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:")
+	}
+	out.Write(app)
 }

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -119,68 +119,10 @@ func TestApp(t *testing.T) {
 	}
 }
 
-var imageList = []v1.Image{
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
-		Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		Tags:   []string{"myimage:latest"},
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		},
-		Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-		},
-		Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-		Tags:   []string{"docker.io/myotherimage:latest"},
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-		},
-		Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-		Tags:   nil,
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-		},
-		Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-		Tags:   []string{"acorn.io/acornimage:latest"},
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-		},
-		Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-		Tags:   []string{"acornimage:latest"},
-	},
-}
-
 func TestWriteApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	c := mocks.NewMockClient(ctrl)
-	c.EXPECT().ImageGet(gomock.Any(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
-		Return(&imageList[0], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").
-		Return(&imageList[1], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc").
-		Return(&imageList[2], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").
-		Return(&imageList[3], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").
-		Return(&imageList[4], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").
-		Return(&imageList[5], nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "1111111111111111111111111111111111111111111111111111111111111111").
-		Return(nil, fmt.Errorf("dne")).AnyTimes()
+	registerMockCalls(t, c)
 
 	cases := []struct {
 		name           string
@@ -253,4 +195,59 @@ func TestWriteApp(t *testing.T) {
 			assert.Equal(t, tt.expected, string(output))
 		})
 	}
+}
+
+func registerMockCalls(t *testing.T, c *mocks.MockClient) {
+	t.Helper()
+
+	c.EXPECT().ImageGet(gomock.Any(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Tags:   []string{"myimage:latest"},
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+			Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			},
+			Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			Tags:   []string{"docker.io/myotherimage:latest"},
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+			Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Tags:   nil,
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			},
+			Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			Tags:   []string{"acorn.io/acornimage:latest"},
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").
+		Return(&v1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			},
+			Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			Tags:   []string{"acornimage:latest"},
+		}, nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "1111111111111111111111111111111111111111111111111111111111111111").
+		Return(nil, fmt.Errorf("dne")).AnyTimes()
 }

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -118,10 +119,68 @@ func TestApp(t *testing.T) {
 	}
 }
 
+var imageList = []v1.Image{
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Tags:   []string{"myimage:latest"},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		},
+		Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		Tags:   []string{"docker.io/myotherimage:latest"},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		},
+		Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		Tags:   nil,
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		},
+		Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		Tags:   []string{"acorn.io/acornimage:latest"},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		},
+		Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		Tags:   []string{"acornimage:latest"},
+	},
+}
+
 func TestWriteApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	c := mocks.NewMockClient(ctrl)
-	c.EXPECT().ImageList(gomock.Any()).Return(buildImageList(), nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
+		Return(&imageList[0], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").
+		Return(&imageList[1], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc").
+		Return(&imageList[2], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").
+		Return(&imageList[3], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").
+		Return(&imageList[4], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").
+		Return(&imageList[5], nil).AnyTimes()
+	c.EXPECT().ImageGet(gomock.Any(), "1111111111111111111111111111111111111111111111111111111111111111").
+		Return(nil, fmt.Errorf("dne")).AnyTimes()
 
 	cases := []struct {
 		name           string
@@ -193,52 +252,5 @@ func TestWriteApp(t *testing.T) {
 			output, _ := io.ReadAll(r)
 			assert.Equal(t, tt.expected, string(output))
 		})
-	}
-}
-
-func buildImageList() []v1.Image {
-	return []v1.Image{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			},
-			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			Tags:   []string{"myimage:latest"},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			},
-			Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			},
-			Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			Tags:   []string{"docker.io/myotherimage:latest"},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-			},
-			Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-			Tags:   nil,
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-			},
-			Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-			Tags:   []string{"acorn.io/acornimage:latest"},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-			},
-			Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-			Tags:   []string{"acornimage:latest"},
-		},
 	}
 }

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -1,14 +1,23 @@
 package cli
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	v1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/cli/builder/table"
 	"github.com/acorn-io/runtime/pkg/cli/testdata"
+	"github.com/acorn-io/runtime/pkg/mocks"
+	"github.com/acorn-io/runtime/pkg/tables"
+	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestApp(t *testing.T) {
@@ -106,5 +115,130 @@ func TestApp(t *testing.T) {
 				assert.Equal(t, tt.wantOut, string(out))
 			}
 		})
+	}
+}
+
+func TestWriteApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := mocks.NewMockClient(ctrl)
+	c.EXPECT().ImageList(gomock.Any()).Return(buildImageList(), nil).AnyTimes()
+
+	cases := []struct {
+		name           string
+		appImageName   string
+		appImageDigest string
+		expected       string
+	}{
+		{
+			name:           "basic",
+			appImageName:   "myimage:latest",
+			appImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expected:       "NAME      IMAGE            HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     myimage:latest                          60m ago               \n",
+		},
+		{
+			name:           "docker.io => index.docker.io",
+			appImageName:   "docker.io/myimage:latest",
+			appImageDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			expected:       "NAME      IMAGE                      HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     docker.io/myimage:latest                          60m ago               \n",
+		},
+		{
+			name:           "implicit docker.io",
+			appImageName:   "myotherimage:latest",
+			appImageDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			expected:       "NAME      IMAGE                 HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     myotherimage:latest                          60m ago               \n",
+		},
+		{
+			name:           "tag moved",
+			appImageName:   "myimage:latest",
+			appImageDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     dddddddddddd                          60m ago               \n",
+		},
+		{
+			name:           "not found",
+			appImageName:   "dne:v1",
+			appImageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     111111111111                          60m ago               \n",
+		},
+		{
+			name:           "no implicit assumption for other registries",
+			appImageName:   "acornimage:latest",
+			appImageDigest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     eeeeeeeeeeee                          60m ago               \n",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			out := table.NewWriter(tables.App, false, "")
+
+			app := &v1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myapp",
+					CreationTimestamp: metav1.Time{
+						Time: time.Now().Add(-1 * time.Hour),
+					},
+				},
+				Status: internalv1.AppInstanceStatus{
+					AppImage: internalv1.AppImage{
+						Name:   tt.appImageName,
+						Digest: tt.appImageDigest,
+					},
+				},
+			}
+			writeApp(context.Background(), app, out, c)
+			out.Flush()
+			w.Close()
+			output, _ := io.ReadAll(r)
+			assert.Equal(t, tt.expected, string(output))
+		})
+	}
+}
+
+func buildImageList() []v1.Image {
+	return []v1.Image{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Tags:   []string{"myimage:latest"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+			Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			},
+			Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			Tags:   []string{"docker.io/myotherimage:latest"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			},
+			Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Tags:   nil,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			},
+			Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			Tags:   []string{"acorn.io/acornimage:latest"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			},
+			Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			Tags:   []string{"acornimage:latest"},
+		},
 	}
 }


### PR DESCRIPTION
Before this PR, `acorn ps` would always display the `IMAGE` field as the `.Status.AppImage.Name` from the app. This value always equals what the user specified as the image when they first ran the app.

Say I run `acorn run -n app1 index.docker.io/grantlinville/nginx:latest` in a fresh project. `acorn ps` should show `index.docker.io/grantlinville/nginx:latest` as the image for `app1`. If I build a new, different image in this project and tag it as `index.docker.io/grantlinville/nginx:latest`, then `acorn ps` should show the short hash as the image for `app1` instead of `index.docker.io/grantlinville/nginx:latest`, since that tag is no longer present on its image. That is what this PR accomplishes.

There is no issue (that I am aware of) created for this, but this is something that we decided we wanted when reviewing the behavior of images.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

