### PR TITLE
Update MacOS notarization to use app store connect API key

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,6 @@ universal_binaries:
         - cmd: ./tools/notarize "{{ .Path }}" "acorn-v{{ .Version }}-macOS-universal"
           output: true
           env:
-            - SIGN={{ if index .Env "SIGN" }}1{{ end }}
             - NOTARIZE={{ if index .Env "NOTARIZE" }}{{ .Env.NOTARIZE }}{{ end }}
             - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
             - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}

--- a/tools/notarize
+++ b/tools/notarize
@@ -14,49 +14,56 @@ DMG="releases/$2.dmg"
 CHECKSUMS="releases/checksums.txt"
 
 if [[ -z "${NOTARIZE}" && "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
-  echo "Enabling notarize"
+  echo "Enabling notarize..."
   NOTARIZE="1"
 fi
 
-echo "SIGN=${SIGN} NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} DMG=${DMG}"
+echo "NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} DMG=${DMG}"
 
 sudo apt-get update -y  
-exit 0
 
-if [[ "${SIGN}" != "0" ]]; then
-  echo "Signing"
+# Sign the binary using rcodesign, a Rust implementation of codesign. This
+# requires that gcc and cargo are installed.
+echo "Signing the binary..."
 
-  # Install the necessary tools, specifically cargo, to install rcodesign, a Rust 
-  # implementation of codesign.
-  which curl || sudo apt-get install curl -y
-  which gcc || sudo apt-get install gcc -y
-  which cargo || sudo curl https://sh.rustup.rs -sSf | sh -s -- -y && bash
-  which rcodesign || sudo cargo install apple-codesign
+which curl || sudo apt-get install curl -y
+which gcc || sudo apt-get install gcc -y
+which cargo || sudo curl https://sh.rustup.rs -sSf | sh -s -- -y && bash
+which rcodesign || cargo install apple-codesign
 
-  # Sign the binary using rcodesign.
-  echo "${AC_P12}" | base64 --decode > signing.p12
-  rcodesign sign --team-name "${AC_IDENTITY}" --p12-file signing.p12 --p12-password "${AC_P12_PASSWORD}" --code-signature-flags runtime "${BINARY}"
-else
-  echo "Skipping signing"
-fi
+# Sign the binary using rcodesign.
+echo "${AC_P12}" | base64 --decode > signing.p12
+rcodesign sign \
+  --team-name "${AC_IDENTITY}" \
+  --binary-identifier "${AC_BUNDLE}" \
+  --p12-file signing.p12 \
+  --p12-password "${AC_P12_PASSWORD}" \
+  --code-signature-flags runtime \
+  "${BINARY}"
 
 if [[ "${NOTARIZE}" == "1" ]]; then
-  echo "Notarizing…"
+  echo "Building and notarizing the DMG…"
 
   which mkfs.hfsplus || sudo apt-get install hfsprogs -y
 
   # Build the DMG
   cp LICENSE README.md "${DIR}/"
-  SIZE="$(du -s ${DIR} | awk '{print $1 + 1024*1024}')" # The size of the directory + 1MB for any overhead
-  mkfile -n "${SIZE}" "${DMG}"
+  SIZE="$(du -sm "${DIR}" | awk '{print $1 + 1}')" # The size of the directory + 1 megabyte for any overhead
+  dd if=/dev/zero of="${DMG}" bs=1M count="${SIZE}"
   mkfs.hfsplus -v "Acorn" "${DMG}"
   mkdir -p /tmp/acorn_mount
-  mount -t hfsplus -o loop "${DMG}" /tmp/acorn_mount
+  sudo mount -t hfsplus -o loop "${DMG}" /tmp/acorn_mount
   cp -R "${DIR}"/* /tmp/acorn_mount
-  umount /tmp/acorn_mount
+  sudo umount /tmp/acorn_mount
 
   # Notarize and staple the DMG
-  rcodesign notary-submit "${DMG}" --staple 
+  echo "${AC_PRIVATE_KEY}" | base64 --decode > private.p8
+  rcodesign encode-app-store-connect-api-key \
+    -o ./key.json \
+    "${AC_ISSUER_ID}" \
+    "${AC_KEY_ID}" \
+    private.pem
+  rcodesign notary-submit --api-key-path ./key.json "${DMG}" --staple 
 
   # Add the sha256sum of the DMG to the checksums file
   sha256sum "${DMG}" >> "${CHECKSUMS}"


### PR DESCRIPTION
Cleaning the code up a bit, making `sign` always run, and start using app store connect api key information when notarizing DMGs.

> **Note**: I'll be waiting for the current critical path work to calm down before merging this regardless of review.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

