### PR TITLE
Use loglevel to dynamically change logrus' log level during runtime (#752)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN apk -U add curl
 RUN curl -sfL https://github.com/loft-sh/devspace/archive/refs/tags/v6.3.2.tar.gz | tar xzf - --strip-components=1
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /usr/local/bin/acorn-helper -ldflags "-s -w" ./helper
 
+FROM ghcr.io/acorn-io/images-mirror/golang:1.20-alpine AS loglevel
+WORKDIR /usr/src
+RUN apk -U add curl
+RUN curl -sfL https://github.com/rancher/loglevel/archive/refs/tags/v0.1.5.tar.gz | tar xzf - --strip-components=1
+RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /usr/local/bin/loglevel -ldflags "-s -w"
+
 FROM ghcr.io/acorn-io/images-mirror/golang:1.20 AS build
 COPY / /src
 WORKDIR /src
@@ -31,6 +37,7 @@ COPY --from=klipper-lb /usr/bin/entry /usr/local/bin/klipper-lb
 COPY ./scripts/ds-containerd-config-path-entry /usr/local/bin
 COPY ./scripts/setup-binfmt /usr/local/bin
 COPY --from=helper /usr/local/bin/acorn-helper /usr/local/bin/
+COPY --from=loglevel /usr/local/bin/loglevel /usr/local/bin/
 VOLUME /var/lib/buildkit
 
 COPY /scripts/acorn-helper-init /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-
 FROM ghcr.io/acorn-io/images-mirror/golang:1.20-alpine AS loglevel
 WORKDIR /usr/src
 RUN apk -U add curl
-RUN curl -sfL https://github.com/rancher/loglevel/archive/refs/tags/v0.1.5.tar.gz | tar xzf - --strip-components=1
+RUN curl -sfL https://github.com/acorn-io/loglevel/archive/refs/tags/v0.1.6.tar.gz | tar xzf - --strip-components=1
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /usr/local/bin/loglevel -ldflags "-s -w"
 
 FROM ghcr.io/acorn-io/images-mirror/golang:1.20 AS build

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	cuelang.org/go v0.5.0
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20230619192500-1f56a8955db2
-	github.com/acorn-io/baaah v0.0.0-20230617011755-3291c17915f5
+	github.com/acorn-io/baaah v0.0.0-20230628211933-3f682344a78d
 	github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acorn-io/aml v0.0.0-20230619192500-1f56a8955db2 h1:tWz51cHGC6GURkKqA4PdG3ObHz2YBrVzCfxXacNUqVY=
 github.com/acorn-io/aml v0.0.0-20230619192500-1f56a8955db2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
-github.com/acorn-io/baaah v0.0.0-20230617011755-3291c17915f5 h1:NdDW2tFRDHElXpcFeqTDKg6wB0uRLzJ5Kq0YDgYl/Dg=
-github.com/acorn-io/baaah v0.0.0-20230617011755-3291c17915f5/go.mod h1:LtwaWrYK/VuGptWxeD5Sgl0sgJV1ksicpTzyLilow1U=
+github.com/acorn-io/baaah v0.0.0-20230628211933-3f682344a78d h1:a+geMqB3U52a4+iMmLZ9R/EXkgxrp0QCetoqLAUnTD8=
+github.com/acorn-io/baaah v0.0.0-20230628211933-3f682344a78d/go.mod h1:LtwaWrYK/VuGptWxeD5Sgl0sgJV1ksicpTzyLilow1U=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500/go.mod h1:y6aYj2dF/SlU205bDfA43Y5c9sa/aYr4X5GDqYJzJTU=
 github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78 h1:5zs9L/CXNkuTdJSbhFWczAorbmx67nqlqswx5CQi7XI=

--- a/pkg/cli/apiserver.go
+++ b/pkg/cli/apiserver.go
@@ -43,7 +43,9 @@ func (a *APIServer) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	logrus.SetLevel(logrus.InfoLevel)
-	logserver.StartServerWithDefaults()
+	if err := logserver.StartServerWithDefaults(); err != nil {
+		logrus.Warnf("failed to start log server: %v", err)
+	}
 
 	<-cmd.Context().Done()
 	return cmd.Context().Err()

--- a/pkg/cli/apiserver.go
+++ b/pkg/cli/apiserver.go
@@ -3,7 +3,9 @@ package cli
 import (
 	minkserver "github.com/acorn-io/mink/pkg/server"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
+	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/server"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +41,9 @@ func (a *APIServer) Run(cmd *cobra.Command, args []string) error {
 	if err := cfg.Run(cmd.Context()); err != nil {
 		return err
 	}
+
+	logrus.SetLevel(logrus.InfoLevel)
+	logserver.StartServerWithDefaults()
 
 	<-cmd.Context().Done()
 	return cmd.Context().Err()

--- a/pkg/cli/apiserver.go
+++ b/pkg/cli/apiserver.go
@@ -43,9 +43,7 @@ func (a *APIServer) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	logrus.SetLevel(logrus.InfoLevel)
-	if err := logserver.StartServerWithDefaults(); err != nil {
-		logrus.Warnf("failed to start log server: %v", err)
-	}
+	logserver.StartServerWithDefaults()
 
 	<-cmd.Context().Done()
 	return cmd.Context().Err()

--- a/pkg/cli/apiserver.go
+++ b/pkg/cli/apiserver.go
@@ -5,7 +5,6 @@ import (
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/server"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +41,6 @@ func (a *APIServer) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	logrus.SetLevel(logrus.InfoLevel)
 	logserver.StartServerWithDefaults()
 
 	<-cmd.Context().Done()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,7 +106,10 @@ func (c *Controller) Start(ctx context.Context) error {
 		go wait.UntilWithContext(ctx, dnsInit.RenewAndSync, dnsRenewPeriodHours)
 
 		autoupgrade.StartSync(ctx, c.Router.Backend())
-		logserver.StartServerWithDefaults()
+		if err := logserver.StartServerWithDefaults(); err != nil {
+			logrus.Warnf("failed to start log server: %v", err)
+			return
+		}
 	}()
 
 	return c.Router.Start(ctx)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,7 +17,9 @@ import (
 	"github.com/acorn-io/runtime/pkg/event"
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/acorn-io/runtime/pkg/k8sclient"
+	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/scheme"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,6 +76,8 @@ func New() (*Controller, error) {
 }
 
 func (c *Controller) Start(ctx context.Context) error {
+	logrus.SetLevel(logrus.InfoLevel)
+
 	if err := crds.Create(ctx, c.Scheme, v1.SchemeGroupVersion); err != nil {
 		return err
 	}
@@ -102,6 +106,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		go wait.UntilWithContext(ctx, dnsInit.RenewAndSync, dnsRenewPeriodHours)
 
 		autoupgrade.StartSync(ctx, c.Router.Backend())
+		logserver.StartServerWithDefaults()
 	}()
 
 	return c.Router.Start(ctx)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/acorn-io/runtime/pkg/k8sclient"
 	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/scheme"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,8 +75,6 @@ func New() (*Controller, error) {
 }
 
 func (c *Controller) Start(ctx context.Context) error {
-	logrus.SetLevel(logrus.InfoLevel)
-
 	if err := crds.Create(ctx, c.Scheme, v1.SchemeGroupVersion); err != nil {
 		return err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,10 +106,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		go wait.UntilWithContext(ctx, dnsInit.RenewAndSync, dnsRenewPeriodHours)
 
 		autoupgrade.StartSync(ctx, c.Router.Backend())
-		if err := logserver.StartServerWithDefaults(); err != nil {
-			logrus.Warnf("failed to start log server: %v", err)
-			return
-		}
+		logserver.StartServerWithDefaults()
 	}()
 
 	return c.Router.Start(ctx)

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -1,0 +1,75 @@
+// Adapted from https://github.com/rancher/log/blob/52031d45f5fdb71cecb9a314865624b42514dbed/server/server.go
+// The only real difference here is that we are using logrus directly instead of a wrapper around it.
+// This is still compatible with the client: https://github.com/rancher/loglevel
+
+package logserver
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	DefaultSocketLocation = "/tmp/log.sock"
+)
+
+// Server structure is used to the store backend information
+type Server struct {
+	SocketLocation string
+	Debug          bool
+}
+
+// StartServerWithDefaults starts the server with default values
+func StartServerWithDefaults() {
+	s := Server{
+		SocketLocation: DefaultSocketLocation,
+	}
+	s.Start()
+}
+
+// Start the server
+func (s *Server) Start() {
+	os.Remove(s.SocketLocation)
+	go s.ListenAndServe()
+}
+
+// ListenAndServe is used to setup handlers and
+// start listening on the specified location
+func (s *Server) ListenAndServe() error {
+	logrus.Infof("Listening on %s", s.SocketLocation)
+	server := http.Server{}
+	http.HandleFunc("/v1/loglevel", s.loglevel)
+	socketListener, err := net.Listen("unix", s.SocketLocation)
+	if err != nil {
+		return err
+	}
+	return server.Serve(socketListener)
+}
+
+func (s *Server) loglevel(rw http.ResponseWriter, req *http.Request) {
+	// curl -X POST -d "level=debug" localhost:12345/v1/loglevel
+	logrus.Debugf("Received loglevel request")
+	if req.Method == http.MethodGet {
+		level := logrus.GetLevel().String()
+		rw.Write([]byte(fmt.Sprintf("%s\n", level)))
+	}
+
+	if req.Method == http.MethodPost {
+		if err := req.ParseForm(); err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			rw.Write([]byte(fmt.Sprintf("Failed to parse form: %v\n", err)))
+		}
+		level, err := logrus.ParseLevel(req.Form.Get("level"))
+		if err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			rw.Write([]byte(fmt.Sprintf("Failed to parse loglevel: %v\n", err)))
+		} else {
+			logrus.SetLevel(level)
+			rw.Write([]byte("OK\n"))
+		}
+	}
+}

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -24,25 +24,19 @@ type Server struct {
 }
 
 // StartServerWithDefaults starts the server with default values
-func StartServerWithDefaults() error {
+func StartServerWithDefaults() {
 	s := Server{
 		SocketLocation: DefaultSocketLocation,
 	}
-	return s.Start()
+	s.Start()
 }
 
 // Start the server
-func (s *Server) Start() error {
-	if err := os.Remove(s.SocketLocation); err != nil {
-		return err
-	}
+func (s *Server) Start() {
+	_ = os.Remove(s.SocketLocation)
 	go func() {
-		err := s.ListenAndServe()
-		if err != nil {
-			return
-		}
+		_ = s.ListenAndServe()
 	}()
-	return nil
 }
 
 // ListenAndServe is used to setup handlers and

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	DefaultSocketLocation = "\x00loglevel"
+	DefaultSocketLocation = "\x00logserver"
 )
 
 // Server structure is used to the store backend information

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -1,6 +1,7 @@
 // Adapted from https://github.com/rancher/log/blob/52031d45f5fdb71cecb9a314865624b42514dbed/server/server.go
-// The only real difference here is that we are using logrus directly instead of a wrapper around it.
-// This is still compatible with the client: https://github.com/rancher/loglevel
+// The only real differences here are that we are using logrus directly instead of a wrapper around it,
+// and that we are using an abstract namespace (non-file) socket.
+// This is only compatible with our fork of the client: https://github.com/acorn-io/loglevel
 
 package logserver
 

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -25,6 +25,7 @@ type Server struct {
 
 // StartServerWithDefaults starts the server with default values
 func StartServerWithDefaults() {
+	logrus.SetLevel(logrus.InfoLevel)
 	s := Server{
 		SocketLocation: DefaultSocketLocation,
 	}

--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	DefaultSocketLocation = "/tmp/log.sock"
+	DefaultSocketLocation = "\x00loglevel"
 )
 
 // Server structure is used to the store backend information


### PR DESCRIPTION
for #752

This adds a little server to the controller and the api-server that listens on a local socket for requests to change the log level, and sets the logrus log level accordingly.

This also adds the `loglevel` binary to `/usr/local/bin` in the container image, which can be used like `loglevel --set info` to set the log level, or just `loglevel` to print the current log level.

This also bumps the baaah dependency in order to get the new changes that reduce the log severity on some of the common logs, as also described in #752.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

