### PR TITLE
Improve linking docs (#1536)

### DIFF
--- a/docs/docs/50-running/06-linking-acorns.md
+++ b/docs/docs/50-running/06-linking-acorns.md
@@ -2,7 +2,7 @@
 title: Linking Acorn Apps
 ---
 
-Acorns can be linked with other running Acorns at runtime to provide supporting services. For instance if you have an Acorn running Postgresql, it can be used to provide the `db` service to another app.
+Acorn apps can link to containers from other Acorn apps at runtime to provide supporting services. For instance, if you have an Acorn running PostgreSQL, it can be used to provide the `db` service to another app.
 
 If you have an Acorn that defines a `web` container and a `redis` container, you can consume a separate Acorn to provide the redis service from an already running Acorn.
 
@@ -10,8 +10,31 @@ If you have an Acorn that defines a `web` container and a `redis` container, you
 acorn run --link my-other-redis-acorn:redis [IMAGE]
 ```
 
-In the above example the container service from the running Acorn will be available within the new Acorn as `redis`. Your new instance will be able to resolve the `redis` name and it will connect to the remote service defined by the link.
+In the above example, the container service from the running Acorn will be available within the new Acorn as `redis`. Your new instance will be able to resolve the `redis` name and it will connect to the remote service defined by the link.
 
-:::note 
+:::note
 The port from the container being linked to must be explicitly exposed in the `Acornfile` i.e. `ports: expose: "5432/tcp"`.
+:::
+
+The more general linking syntax is as follows:
+
+```shell
+acorn run --link <source>:<alias> [IMAGE]
+```
+
+`<alias>` is the name that the new Acorn app can use to resolve the linked service.
+
+`<source>` is one of the following:
+
+- The name of another Acorn in the same project, if that Acorn only has one container
+- A reference to a particular container in a different Acorn in the same project, in the format `<acorn>.<container>`
+
+For example, if I have an Acorn called `my-app` with two containers `nginx` and `db`, I can link the `db` container to another Acorn in the same project:
+
+```shell
+acorn run --link my-app.db:db [IMAGE]
+```
+
+:::note
+If you set the `<alias>` to a name identical to the name of one of the containers in the new app, then that container in the new app will not be created, since the linked container takes its place.
 :::

--- a/pkg/controller/appdefinition/service.go
+++ b/pkg/controller/appdefinition/service.go
@@ -7,8 +7,8 @@ import (
 	"github.com/acorn-io/runtime/pkg/services"
 )
 
-func addServices(req router.Request, app *v1.AppInstance, interpolar *secrets.Interpolator, resp router.Response) error {
-	objs, err := services.ToAcornServices(req.Ctx, req.Client, interpolar, app)
+func addServices(req router.Request, app *v1.AppInstance, interpolator *secrets.Interpolator, resp router.Response) error {
+	objs, err := services.ToAcornServices(req.Ctx, req.Client, interpolator, app)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
for #1536

I also found a random typo in the code that I fixed.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

