### PR TITLE
Ensure acorn-controller doesn't restart on fresh install (#1868)

### DIFF
--- a/integration/helper/controller.go
+++ b/integration/helper/controller.go
@@ -218,7 +218,7 @@ func StartController(t *testing.T) {
 	}
 
 	lock(context.Background(), k8s, func(ctx context.Context) {
-		c, err := controller.New()
+		c, err := controller.New(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/controller.go
+++ b/pkg/cli/controller.go
@@ -21,7 +21,7 @@ type Controller struct {
 }
 
 func (s *Controller) Run(cmd *cobra.Command, _ []string) error {
-	c, err := controller.New()
+	c, err := controller.New(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,7 +37,14 @@ type Controller struct {
 	apply  apply.Apply
 }
 
-func New() (*Controller, error) {
+func New(ctx context.Context) (*Controller, error) {
+	if err := crds.Create(ctx, scheme.Scheme, v1.SchemeGroupVersion); err != nil {
+		return nil, err
+	}
+	if err := crds.Create(ctx, scheme.Scheme, adminv1.SchemeGroupVersion); err != nil {
+		return nil, err
+	}
+
 	router, err := baaah.DefaultRouter("acorn-controller", scheme.Scheme)
 	if err != nil {
 		return nil, err
@@ -74,12 +81,6 @@ func New() (*Controller, error) {
 }
 
 func (c *Controller) Start(ctx context.Context) error {
-	if err := crds.Create(ctx, c.Scheme, v1.SchemeGroupVersion); err != nil {
-		return err
-	}
-	if err := crds.Create(ctx, c.Scheme, adminv1.SchemeGroupVersion); err != nil {
-		return err
-	}
 	if err := c.initData(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
When a router is created, the RESTMapper is created from the rest config at the same time. If the CRDs don't exist by the time the RESTMapper is created, then starting the router will fail to find the resource for the GVKs. This will cause the acorn-controller to restart.

This change creates the CRDs before creating the router, ensuring that the RESTMapper has all needed data.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/runtime/issues/1868