### PR TITLE
Add sudo to cp in notarize script

### DIFF
--- a/tools/notarize
+++ b/tools/notarize
@@ -53,7 +53,7 @@ if [[ "${NOTARIZE}" == "1" ]]; then
   mkfs.hfsplus -v "Acorn" "${DMG}"
   mkdir -p /tmp/acorn_mount
   sudo mount -t hfsplus -o loop "${DMG}" /tmp/acorn_mount
-  cp -R "${DIR}"/* /tmp/acorn_mount
+  sudo cp -R "${DIR}"/* /tmp/acorn_mount
   sudo umount /tmp/acorn_mount
 
   # Notarize and staple the DMG


### PR DESCRIPTION
Addresses the following error:

https://github.com/acorn-io/runtime/actions/runs/5416022853/jobs/9845156939#step:9:785

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

