### PR TITLE
Increase overhead for DMG to 30 megabytes

### DIFF
--- a/tools/notarize
+++ b/tools/notarize
@@ -48,7 +48,7 @@ if [[ "${NOTARIZE}" == "1" ]]; then
 
   # Build the DMG
   cp LICENSE README.md "${DIR}/"
-  SIZE="$(du -sm "${DIR}" | awk '{print $1 + 1}')" # The size of the directory + 1 megabyte for any overhead
+  SIZE="$(du -sm "${DIR}" | awk '{print $1 + 30}')" # The size of the directory + 30 megabytes for any overhead
   dd if=/dev/zero of="${DMG}" bs=1M count="${SIZE}"
   mkfs.hfsplus -v "Acorn" "${DMG}"
   mkdir -p /tmp/acorn_mount


### PR DESCRIPTION
https://github.com/acorn-io/runtime/actions/runs/5416268615/jobs/9845763422#step:9:787

The size of the DMG was just barely not enough due to compression being slightly different. Adding a larger overhead buffer to ensure this isn't a problem.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

