### PR TITLE
Rename event severity warn to error and rm critical

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -97,15 +97,10 @@ func (t *MicroTime) UnmarshalJSON(b []byte) error {
 
 const (
 	// EventSeverityInfo indicates an event describes a system operating "as expected".
-	// It is the lowest severity level.
 	EventSeverityInfo EventSeverity = "info"
 
-	// EventSeverityWarn indicates an event describes a recoverable error.
-	EventSeverityWarn EventSeverity = "warn"
-
-	// EventSeverityCritical indicates an event describes an unrecoverable error.
-	// It is the highest severity level.
-	EventSeverityCritical EventSeverity = "critical"
+	// EventSeverityError indicates an event describes an error.
+	EventSeverityError EventSeverity = "warn"
 )
 
 // EventSeverity indicates the severity of an event.

--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -100,7 +100,7 @@ const (
 	EventSeverityInfo EventSeverity = "info"
 
 	// EventSeverityError indicates an event describes an error.
-	EventSeverityError EventSeverity = "warn"
+	EventSeverityError EventSeverity = "error"
 )
 
 // EventSeverity indicates the severity of an event.

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -226,7 +226,7 @@ func recordPullEvent(ctx context.Context, recorder event.Recorder, observed meta
 	if err != nil {
 		// It's a failure, overwrite with failure event values
 		e.Type = AppImagePullFailureEventType
-		e.Severity = v1.EventSeverityWarn
+		e.Severity = v1.EventSeverityError
 		e.Description = fmt.Sprintf("Failed to pull %s", target.Name)
 		details.Err = err.Error()
 	}

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -171,7 +171,7 @@ func TestPullAppImageEvents(t *testing.T) {
 		&apiv1.Event{
 			Type:        AppImagePullFailureEventType,
 			Actor:       "acorn-system",
-			Severity:    v1.EventSeverityWarn,
+			Severity:    v1.EventSeverityError,
 			Description: "Failed to pull acorn.io/img:1",
 			Source:      v1.EventSource{Kind: "app", Name: "foo"},
 			Observed:    now,


### PR DESCRIPTION
Refactor event severity such that only two levels remain:
1. "info"
2. "error"

This means removing the unused "critical" severity and renaming "warn"
to "error".

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
