### PR TITLE
Fix MacOS release name after rename

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,7 @@ universal_binaries:
   - id: mac
     ids:
       - default
+    name_template: acorn
     replace: true
     hooks:
       post:


### PR DESCRIPTION
Prior to this change, the release for MacOS was getting called `runtime` because it defaults to the project name. Adding this `name_template` field set to `acorn` should bring it back to what it originally was.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

