### PR TITLE
Fix `acorn update` so that deployArgs are properly updated (#1826)

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -325,11 +325,9 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 		updateOpts.DeployArgs = deployArgs
 	} else if len(imageSource.Args) > 0 {
 		imageSource.Image = app.Status.AppImage.Name
-		_, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)
-		if err != nil {
+		if _, updateOpts.DeployArgs, err = imageSource.GetImageAndDeployArgs(ctx, c); err != nil {
 			return nil, false, err
 		}
-		updateOpts.DeployArgs = deployArgs
 	}
 
 	app, err = rulerequest.PromptUpdate(ctx, c, s.Dangerous, app.Name, updateOpts)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -323,6 +323,13 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 		}
 		updateOpts.Image = image
 		updateOpts.DeployArgs = deployArgs
+	} else if len(imageSource.Args) > 0 {
+		imageSource.Image = app.Status.AppImage.Name
+		_, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)
+		if err != nil {
+			return nil, false, err
+		}
+		updateOpts.DeployArgs = deployArgs
 	}
 
 	app, err = rulerequest.PromptUpdate(ctx, c, s.Dangerous, app.Name, updateOpts)


### PR DESCRIPTION
for #1826

Addressing `3.`, `4.`, and `5.` from the issue linked above:

- `acorn update <app name> --newtext=hello` now works properly
- `acorn run --update --name <app name> -- --newtext=hello` now works properly
- `acorn run --replace` requires you to re-specify the image, so doing this works: `acorn run --replace --name <app name> <image> --newtext=hello`

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issxes*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

