### PR TITLE
Add new secrets to env for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,9 @@ jobs:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_P12: ${{ secrets.AC_P12 }}
           AC_P12_PASSWORD: ${{ secrets.AC_P12_PASSWORD }}
+          AC_ISSUER_ID: ${{ secrets.AC_ISSUER_ID }}
+          AC_KEY_ID: ${{ secrets.AC_KEY_ID }}
+          AC_PRIVATE_KEY: ${{ secrets.AC_PRIVATE_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
       - name: report failure to slack
         if: failure()


### PR DESCRIPTION
The latest error was due to the fact that the new secrets are not actually set as environment variables for goreleaser.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

