### PR TITLE
Switch to use a zip instead of a DMG

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ universal_binaries:
         - cmd: ./tools/notarize "{{ .Path }}" "acorn-v{{ .Version }}-macOS-universal"
           output: true
           env:
-            - NOTARIZE={{ if index .Env "NOTARIZE" }}{{ .Env.NOTARIZE }}{{ end }}
+            - NOTARIZE=0 # Always disable Notarization since it is not currently necessary.
             - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
             - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
             - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}

--- a/tools/notarize
+++ b/tools/notarize
@@ -43,6 +43,22 @@ rcodesign sign \
   "${BINARY}"
 echo "Signed ${BINARY}!"
 
+# Currently, NOTARIZE is always set to 0. In effect, this means that the
+# binary is signed, but not zipped up, notarized or stapled. Since all of the 
+# official installation processes are through brew or wget, the notarized DMG we were
+# creating was not necessary. Where this does become a problem is if a user 
+# wants to install from a browser. In this situation, there will need to be 
+# a notarization process otherwise MacOS will mark our binary as unsafe and 
+# the user will need to go through hoops to install it. In this instance,
+# setting NOTARIZE to 1 will create a ZIP file (since it was difficult to create
+# a DMG while not on MacOS) and Notarize it.
+#
+# Note - If you want to staple that ZIP, you will need to staple each individual
+#        item in the zip file.
+#
+# References: 
+# https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
+# https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_rcodesign.html
 if [[ "${NOTARIZE}" == "1" ]]; then
   which zip || sudo apt-get install zip -y
 
@@ -72,6 +88,6 @@ if [[ "${NOTARIZE}" == "1" ]]; then
   echo "Added ${ZIP}'s checksums!"
 
 else
-  echo "Skipping notarizing & disk image creation"
+  echo "Skipping zip creation and notarization"
 fi
 

--- a/tools/notarize
+++ b/tools/notarize
@@ -10,7 +10,7 @@ cd $(dirname $0)/..
 
 BINARY="$1"
 DIR="releases/mac_darwin_all"
-DMG="releases/$2.dmg"
+ZIP="releases/$2.zip"
 CHECKSUMS="releases/checksums.txt"
 
 if [[ -z "${NOTARIZE}" && "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
@@ -18,7 +18,7 @@ if [[ -z "${NOTARIZE}" && "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
   NOTARIZE="1"
 fi
 
-echo "NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} DMG=${DMG}"
+echo "NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} ZIP=${ZIP}"
 
 sudo apt-get update -y  
 
@@ -44,21 +44,15 @@ rcodesign sign \
 echo "Signed ${BINARY}!"
 
 if [[ "${NOTARIZE}" == "1" ]]; then
-  which mkfs.hfsplus || sudo apt-get install hfsprogs -y
+  which zip || sudo apt-get install zip -y
 
-  # Build the DMG
-  echo "Building ${DMG}..."
+  # Zip everything up
+  echo "Building ${ZIP}..."
   cp LICENSE README.md "${DIR}/"
-  SIZE="$(du -sm "${DIR}" | awk '{print $1 + 30}')" # The size of the directory + 30 megabytes for any overhead
-  dd if=/dev/zero of="${DMG}" bs=1M count="${SIZE}"
-  mkfs.hfsplus -v "Acorn" "${DMG}"
-  mkdir -p /tmp/acorn_mount
-  sudo mount -t hfsplus -o loop "${DMG}" /tmp/acorn_mount
-  sudo cp -R "${DIR}"/* /tmp/acorn_mount
-  sudo umount /tmp/acorn_mount
-  echo "Built ${DMG}!"
+  zip -r "${ZIP}" "${DIR}"
+  echo "Built ${ZIP}!"
 
-  # Notarize and staple the DMG
+  # Notarize the ZIP
   echo "Building app-store-connect-api-key..."
   echo "${AC_PRIVATE_KEY}" | base64 --decode > private.p8
   rcodesign encode-app-store-connect-api-key \
@@ -68,14 +62,14 @@ if [[ "${NOTARIZE}" == "1" ]]; then
     private.p8
   echo "Built app-store-connect-api-key!"
 
-  echo "Notarizing and stapling ${DMG}..."
-  rcodesign notary-submit --api-key-path ./key.json "${DMG}" --staple 
-  echo "${DMG} has been notarized and stapled!"
+  echo "Notarizing ${ZIP}..."
+  rcodesign notary-submit --api-key-path ./key.json "${ZIP}"
+  echo "Notarized ${ZIP}!"
 
-  # Add the sha256sum of the DMG to the checksums file
-  echo "Adding ${DMG}'s checksum to the checksums file..."
-  sha256sum "${DMG}" >> "${CHECKSUMS}"
-  echo "Added ${DMG}'s checksums!"
+  # Add the sha256sum of the ZIP to the checksums file
+  echo "Adding ${ZIP}'s checksum to the checksums file..."
+  sha256sum "${ZIP}" >> "${CHECKSUMS}"
+  echo "Added ${ZIP}'s checksums!"
 
 else
   echo "Skipping notarizing & disk image creation"


### PR DESCRIPTION
This PR turns off notarization and stapling. The notarized DMG or Zip files are not necessary for our current installation methods of WGET or Homebrew. I've left some comments that explains further.

In addition, this always switches the notarization logic to create a `zip` file instead of a `dmg`. By using a `zip` file we are able to notarize on Linux without the complexity of creating a `dmg` file on the OS. Instead we can get the 90% of the way there by using and notarizing a `zip` file. The 10% we are missing out on is stapling. This is a feature that allows for binaries to be distributed and verified by MacOS offline. Since you need the internet to download the zip file this seems like an unnecessary complexity addition. 

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

