### PR TITLE
Always set AutoUpgrade if it is implied (#1459)

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -319,6 +319,15 @@ func AutoUpgradePattern(image string) (string, bool) {
 	return tag, strings.ContainsAny(tag, "#*")
 }
 
+// ImpliedAutoUpgrade returns boolean indicating if auto-upgrade is implied either
+// by a pattern in the app.Spec.image or app.Spec.AutoUpgradeInterval being specified.
+func ImpliedAutoUpgrade(interval, image string) bool {
+	if _, isPattern := AutoUpgradePattern(image); isPattern || interval != "" {
+		return true
+	}
+	return false
+}
+
 func Mode(appSpec v1.AppInstanceSpec) (string, bool) {
 	_, isPat := AutoUpgradePattern(appSpec.Image)
 	on := appSpec.GetAutoUpgrade() || appSpec.GetNotifyUpgrade() || isPat

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -10,6 +10,7 @@ import (
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/autoupgrade"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/dev"
@@ -237,6 +238,11 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
+	}
+
+	// Ensure opts.AutoUpgrade is set if is implied by opts.AutoUpgradeInterval or imageSource.Image's pattern.
+	if opts.AutoUpgrade == nil || !*opts.AutoUpgrade {
+		opts.AutoUpgrade = &[]bool{autoupgrade.ImpliedAutoUpgrade(opts.AutoUpgradeInterval, imageSource.Image)}[0]
 	}
 
 	// Force install prompt if needed

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -96,6 +96,12 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		return
 	}
 
+	au := app.Spec.AutoUpgrade
+	if (au == nil || !*au) && autoupgrade.ImpliedAutoUpgrade(app.Spec.AutoUpgradeInterval, app.Spec.Image) {
+		result = append(result, field.Invalid(field.NewPath("spec", "autoUpgrade"), app.Spec.AutoUpgrade, "must be true if autoupgrade options are set"))
+		return
+	}
+
 	var (
 		imageGrantedPerms []v1.Permissions
 		checkImage        = app.Spec.Image


### PR DESCRIPTION
for #1459 

Prior to this commit, `AutoUpgrade` would not get set for Apps that had implied `AutoUpgrade` behavior. For example, if an `App` came through with `AutoUpgradeInterval` set or a pattern set for its `Image` then `AutoUpgrade` would be false despite it actually being enabled.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

