### PR TITLE
Add config file location to client info

### DIFF
--- a/pkg/cli/info_test.go
+++ b/pkg/cli/info_test.go
@@ -169,6 +169,7 @@ func TestInfo(t *testing.T) {
 
 			r, w, _ := os.Pipe()
 			os.Stdout = w
+			os.Setenv("ACORN_CONFIG_FILE", "/fake-file")
 
 			// Mock client factory just returns the gomock client.
 			cmd := NewInfo(CommandContext{

--- a/pkg/cli/testdata/info/info_test-a.txt
+++ b/pkg/cli/testdata/info/info_test-a.txt
@@ -1,6 +1,7 @@
 ---
 client:
   cli:
+    acornConfig: /fake-file
     acornServers:
     - acorn.io
   version:

--- a/pkg/cli/testdata/info/info_test.txt
+++ b/pkg/cli/testdata/info/info_test.txt
@@ -1,6 +1,7 @@
 ---
 client:
   cli:
+    acornConfig: /fake-file
     acornServers:
     - acorn.io
   version:

--- a/pkg/cli/testdata/info/info_test_empty.txt
+++ b/pkg/cli/testdata/info/info_test_empty.txt
@@ -1,6 +1,7 @@
 ---
 client:
   cli:
+    acornConfig: /fake-file
     acornServers:
     - acorn.io
   version:

--- a/pkg/cli/testdata/info/info_test_json.txt
+++ b/pkg/cli/testdata/info/info_test_json.txt
@@ -6,7 +6,8 @@
         "cli": {
             "acornServers": [
                 "acorn.io"
-            ]
+            ],
+            "acornConfig": "/fake-file"
         }
     },
     "projects": {

--- a/pkg/cli/testdata/info/info_test_yaml.txt
+++ b/pkg/cli/testdata/info/info_test_yaml.txt
@@ -1,6 +1,7 @@
 ---
 client:
   cli:
+    acornConfig: /fake-file
     acornServers:
     - acorn.io
   version:

--- a/pkg/config/cliconfig.go
+++ b/pkg/config/cliconfig.go
@@ -55,6 +55,7 @@ type CLIConfig struct {
 	ProjectAliases    map[string]string     `json:"projectAliases,omitempty"`
 	DefaultContext    string                `json:"defaultContext,omitempty"`
 	CurrentProject    string                `json:"currentProject,omitempty"`
+	AcornConfig       string                `json:"acornConfig,omitempty"`
 
 	// ProjectURLs is used for testing to return EndpointURLs for remote projects
 	ProjectURLs map[string]string `json:"projectURLs,omitempty"`
@@ -128,7 +129,8 @@ func ReadCLIConfig(kubeconfigOnly bool) (*CLIConfig, error) {
 		return nil, err
 	}
 	result := &CLIConfig{
-		authsLock: &sync.Mutex{},
+		authsLock:   &sync.Mutex{},
+		AcornConfig: filename,
 	}
 	if err := yaml.Unmarshal(data, result); err != nil {
 		return nil, err


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)


Adds an acornConfig field to the output of `acorn info`:
```
$ acorn info
---
client:
  cli:
    acornConfig: /Users/cjellick/Library/Application Support/acorn/config.yaml
    acornServers:
    - acorn.io
```
To verify, just check for the above field and check that you can view that field (to prove its real). Note that you can also override via the ACORN_CONFIG_FILE env var:
```
$ ACORN_CONFIG_FILE=xyz acorn info
---
client:
  cli:
    acornConfig: xyz
    acornServers:
```