### PR TITLE
Remove image lookups from acorn ps

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"strings"
-
-	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
 	"github.com/acorn-io/runtime/pkg/tables"
@@ -66,12 +63,4 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return out.Err()
-}
-
-func inactive(app apiv1.App) bool {
-	return strings.Contains(app.Name, ".") &&
-		app.Status.Ready &&
-		app.Status.Columns.Healthy == "0" &&
-		app.Status.Columns.UpToDate == "0" &&
-		app.Status.Columns.Message == "OK"
 }

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"context"
 	"strings"
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
-	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/tables"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
@@ -45,7 +43,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		writeApp(cmd.Context(), app, out, c)
+		out.Write(app)
 		return out.Err()
 	}
 
@@ -60,35 +58,20 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		}
 		if len(args) > 0 {
 			if slices.Contains(args, app.Name) {
-				writeApp(cmd.Context(), &app, out, c)
+				out.Write(&app)
 			}
 		} else {
-			writeApp(cmd.Context(), &app, out, c)
+			out.Write(&app)
 		}
 	}
 
 	return out.Err()
 }
 
-func writeApp(ctx context.Context, app *apiv1.App, out table.Writer, c client.Client) {
-	image, err := c.ImageGet(ctx, strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:"))
-	if err != nil {
-		// Give up and write the app with its digest as its name
-		app.Status.AppImage.Name = strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:")
-		out.Write(app)
-		return
-	}
-
-	var tagIsValid bool
-	for _, tag := range image.Tags {
-		if tag == app.Status.AppImage.Name || (strings.Contains(tag, "docker.io") && strings.HasSuffix(tag, app.Status.AppImage.Name)) {
-			tagIsValid = true
-			break
-		}
-	}
-	if !tagIsValid {
-		app.Status.AppImage.Name = strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:")
-	}
-
-	out.Write(app)
+func inactive(app apiv1.App) bool {
+	return strings.Contains(app.Name, ".") &&
+		app.Status.Ready &&
+		app.Status.Columns.Healthy == "0" &&
+		app.Status.Columns.UpToDate == "0" &&
+		app.Status.Columns.Message == "OK"
 }

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -1,24 +1,14 @@
 package cli
 
 import (
-	"context"
-	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
-	v1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
-	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
-	"github.com/acorn-io/runtime/pkg/cli/builder/table"
 	"github.com/acorn-io/runtime/pkg/cli/testdata"
-	"github.com/acorn-io/runtime/pkg/mocks"
-	"github.com/acorn-io/runtime/pkg/tables"
-	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestApp(t *testing.T) {
@@ -117,137 +107,4 @@ func TestApp(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestWriteApp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	c := mocks.NewMockClient(ctrl)
-	registerMockCalls(t, c)
-
-	cases := []struct {
-		name           string
-		appImageName   string
-		appImageDigest string
-		expected       string
-	}{
-		{
-			name:           "basic",
-			appImageName:   "myimage:latest",
-			appImageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			expected:       "NAME      IMAGE            HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     myimage:latest                          60m ago               \n",
-		},
-		{
-			name:           "docker.io => index.docker.io",
-			appImageName:   "docker.io/myimage:latest",
-			appImageDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			expected:       "NAME      IMAGE                      HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     docker.io/myimage:latest                          60m ago               \n",
-		},
-		{
-			name:           "implicit docker.io",
-			appImageName:   "myotherimage:latest",
-			appImageDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			expected:       "NAME      IMAGE                 HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     myotherimage:latest                          60m ago               \n",
-		},
-		{
-			name:           "tag moved",
-			appImageName:   "myimage:latest",
-			appImageDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     dddddddddddd                          60m ago               \n",
-		},
-		{
-			name:           "not found",
-			appImageName:   "dne:v1",
-			appImageDigest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     111111111111                          60m ago               \n",
-		},
-		{
-			name:           "no implicit assumption for other registries",
-			appImageName:   "acornimage:latest",
-			appImageDigest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-			expected:       "NAME      IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS   MESSAGE\nmyapp     eeeeeeeeeeee                          60m ago               \n",
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-			out := table.NewWriter(tables.App, false, "")
-
-			app := &v1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "myapp",
-					CreationTimestamp: metav1.Time{
-						Time: time.Now().Add(-1 * time.Hour),
-					},
-				},
-				Status: internalv1.AppInstanceStatus{
-					AppImage: internalv1.AppImage{
-						Name:   tt.appImageName,
-						Digest: tt.appImageDigest,
-					},
-				},
-			}
-			writeApp(context.Background(), app, out, c)
-			out.Flush()
-			w.Close()
-			output, _ := io.ReadAll(r)
-			assert.Equal(t, tt.expected, string(output))
-		})
-	}
-}
-
-func registerMockCalls(t *testing.T, c *mocks.MockClient) {
-	t.Helper()
-
-	c.EXPECT().ImageGet(gomock.Any(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			},
-			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			Tags:   []string{"myimage:latest"},
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			},
-			Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			Tags:   []string{"index.docker.io/myimage:latest", "myimage:v1"},
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			},
-			Digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			Tags:   []string{"docker.io/myotherimage:latest"},
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-			},
-			Digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-			Tags:   nil,
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-			},
-			Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-			Tags:   []string{"acorn.io/acornimage:latest"},
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").
-		Return(&v1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-			},
-			Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-			Tags:   []string{"acornimage:latest"},
-		}, nil).AnyTimes()
-	c.EXPECT().ImageGet(gomock.Any(), "1111111111111111111111111111111111111111111111111111111111111111").
-		Return(nil, fmt.Errorf("dne")).AnyTimes()
 }

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -48,7 +48,7 @@ func TestApp(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "NAME      IMAGE     HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE\nfound                                      292y ago               \n",
+			wantOut: "NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE\nfound                                                292y ago               \n",
 		},
 		{
 			name: "acorn app found", fields: fields{
@@ -67,7 +67,7 @@ func TestApp(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "NAME      IMAGE     HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE\nfound                                      292y ago               \n",
+			wantOut: "NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE\nfound                                                292y ago               \n",
 		},
 		{
 			name: "acorn app dne", fields: fields{

--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -42,6 +42,7 @@ var (
 		"defaultMemory": DefaultMemory,
 		"ownerName":     OwnerReferenceName,
 		"imageName":     ImageName,
+		"imageDigest":   ImageDigest,
 	}
 )
 
@@ -305,4 +306,13 @@ func ImageName(obj metav1.Object) string {
 		return original
 	}
 	return app.Status.AppImage.Name
+}
+
+func ImageDigest(obj metav1.Object) string {
+	app, ok := obj.(*apiv1.App)
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimPrefix(app.Status.AppImage.Digest, "sha256:")
 }

--- a/pkg/cli/testdata/all/all_test.txt
+++ b/pkg/cli/testdata/all/all_test.txt
@@ -1,7 +1,7 @@
 
 APPS:
-NAME      IMAGE     HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
-found                                      292y ago               
+NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
+found                                                292y ago
 
 CONTAINERS:
 NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAGE

--- a/pkg/cli/testdata/all/all_test.txt
+++ b/pkg/cli/testdata/all/all_test.txt
@@ -1,7 +1,7 @@
 
 APPS:
 NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
-found                                                292y ago
+found                                                292y ago               
 
 CONTAINERS:
 NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAGE

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -1,7 +1,7 @@
 
 APPS:
-NAME      IMAGE     HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
-found                                      292y ago               
+NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
+found                                                292y ago
 
 CONTAINERS:
 NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAGE

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -1,7 +1,7 @@
 
 APPS:
 NAME      IMAGE     DIGEST    HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS   MESSAGE
-found                                                292y ago
+found                                                292y ago               
 
 CONTAINERS:
 NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAGE

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -10,6 +10,7 @@ var (
 	App = [][]string{
 		{"Name", "{{ . | name }}"},
 		{"Image", "{{ . | imageName | trunc }}"},
+		{"Digest", "{{ . | imageDigest | trunc }}"},
 		{"Healthy", "Status.Columns.Healthy"},
 		{"Up-To-Date", "Status.Columns.UpToDate"},
 		{"Created", "{{ago .CreationTimestamp}}"},


### PR DESCRIPTION
In a previous PR, I changed `acorn ps` so that it would output the short digest instead of the tag if the tag on an app's image got moved to a newer version of the image. This resulted in a massive performance hit and needed to be undone.

I spoke with Craig and Darren, and they are okay with having the image digest as a separate column in the output so that users can differentiate between apps running different versions of an Acorn image that are using the same tag.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

