### PR TITLE
Fix: Add image tag validation prior to building the image (#1875)

### DIFF
--- a/pkg/cli/build_test.go
+++ b/pkg/cli/build_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/acorn-io/runtime/pkg/cli/testdata"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildBadTag(t *testing.T) {
+	type args struct {
+		cmd    *cobra.Command
+		args   []string
+		client *testdata.MockClient
+	}
+	var _, w, _ = os.Pipe()
+
+	test := struct {
+		name           string
+		args           args
+		wantErr        bool
+		wantOut        string
+		commandContext CommandContext
+	}{
+		name: "acorn build --tag -bad-tag",
+		commandContext: CommandContext{
+			ClientFactory: &testdata.MockClientFactory{},
+			StdOut:        w,
+			StdErr:        w,
+			StdIn:         strings.NewReader("y\n"),
+		},
+		args: args{
+			args:   []string{"--tag", "-bad-tag"},
+			client: &testdata.MockClient{},
+		},
+		wantErr: true,
+		wantOut: "invalid image tag: -bad-tag",
+	}
+	t.Run(test.name, func(t *testing.T) {
+		test.args.cmd = NewBuild(test.commandContext)
+		test.args.cmd.SetArgs(test.args.args)
+		err := test.args.cmd.Execute()
+		assert.Equal(t, test.wantOut, err.Error())
+	})
+}

--- a/pkg/server/registry/apigroups/acorn/images/tag.go
+++ b/pkg/server/registry/apigroups/acorn/images/tag.go
@@ -80,6 +80,10 @@ func (t *TagStrategy) ImageTag(ctx context.Context, namespace, imageName string,
 	}
 	set := sets.NewString(res...)
 
+	if strings.HasPrefix(tagToAdd, "-") {
+		return nil, fmt.Errorf("invalid image tag: %v", tagToAdd)
+	}
+
 	imageRef, err := name.ParseReference(tagToAdd, name.WithDefaultRegistry(""))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is fixes issue #1875.
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

