### PR TITLE
Add "completed" to the appStatus

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appstatus.go
+++ b/pkg/apis/internal.acorn.io/v1/appstatus.go
@@ -13,6 +13,7 @@ type AppStatus struct {
 
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
 	Stopped   bool       `json:"stopped,omitempty"`
+	Completed bool       `json:"completed,omitempty"`
 }
 
 type DependencyNotFound struct {

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -55,7 +55,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, app := range apps {
-		if (app.Status.AppStatus.Stopped || inactive(app)) && !a.All {
+		if (app.Status.AppStatus.Stopped || app.Status.AppStatus.Completed) && !a.All {
 			continue
 		}
 		if len(args) > 0 {
@@ -68,14 +68,6 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return out.Err()
-}
-
-func inactive(app apiv1.App) bool {
-	return strings.Contains(app.Name, ".") &&
-		app.Status.Ready &&
-		app.Status.Columns.Healthy == "0" &&
-		app.Status.Columns.UpToDate == "0" &&
-		app.Status.Columns.Message == "OK"
 }
 
 func writeApp(ctx context.Context, app *apiv1.App, out table.Writer, c client.Client) {

--- a/pkg/controller/appstatus/cli_status.go
+++ b/pkg/controller/appstatus/cli_status.go
@@ -17,6 +17,17 @@ func CLIStatus(req router.Request, resp router.Response) (err error) {
 	app.Status.Columns.Healthy = healthy(app)
 	app.Status.Columns.Message = message(app)
 	app.Status.Columns.Endpoints, err = endpoints(req, app)
+
+	// There's clearly a better way to do this, but it works and I'm lazy. The intention is that we want
+	// to detect that the acorn doesn't have any running containers (or needs to run containers) and has
+	// produced whatever it needs to and the status is not really helpful anymore, because it's done.
+	app.Status.AppStatus.Completed = strings.Contains(app.Name, ".") &&
+		app.Status.Ready &&
+		app.Status.Columns.Healthy == "0" &&
+		app.Status.Columns.UpToDate == "0" &&
+		app.Status.Columns.Message == "OK" &&
+		app.Status.Columns.Endpoints == ""
+
 	resp.Objects(app)
 	return
 }

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6405,6 +6405,12 @@ func schema_pkg_apis_internalacornio_v1_AppStatus(ref common.ReferenceCallback) 
 							Format: "",
 						},
 					},
+					"completed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The completed flag indicates that this acorn is not running any containers
or needs to run any containers. This is typically for acorns that just
generate some resources like services, secrets, or volumes.
