### PR TITLE
    Add full project name and CLI default to the acorn project json output

### DIFF
--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/acorn-io/baaah/pkg/typed"
@@ -99,13 +100,22 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		if projectItem.Project != nil {
+			if projectItem.Project.Annotations == nil {
+				projectItem.Project.Annotations = map[string]string{}
+			}
+			projectItem.Project.Annotations["project-name"] = projectItem.FullName
+			projectItem.Project.Annotations["default-project"] = fmt.Sprint(defaultProject == projectItem.FullName)
+
 			supportedRegions := projectItem.Project.Status.SupportedRegions
 			defaultRegion := projectItem.Project.Status.DefaultRegion
-			for i, supportedRegion := range supportedRegions {
-				if supportedRegion == defaultRegion {
-					supportedRegions[i] = supportedRegion + "*"
+			if len(supportedRegions) > 1 {
+				for i, supportedRegion := range supportedRegions {
+					if supportedRegion == defaultRegion {
+						supportedRegions[i] = supportedRegion + "*"
+					}
 				}
 			}
+
 			out.WriteFormatted(projectEntry{
 				Name:    projectItem.FullName,
 				Default: defaultProject == projectItem.FullName,


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

