### PR TITLE
Make the project namespace check configurable

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apigroup.go
+++ b/pkg/server/registry/apigroups/acorn/apigroup.go
@@ -88,7 +88,7 @@ func Stores(c kclient.WithWatch, cfg, localCfg *clientgo.Config) (map[string]res
 		"images/push":                   images.NewImagePush(c, transport),
 		"images/pull":                   images.NewImagePull(c, clientFactory, transport),
 		"images/details":                images.NewImageDetails(c, transport),
-		"projects":                      projects.NewStorage(c),
+		"projects":                      projects.NewStorage(c, true),
 		"volumes":                       volumesStorage,
 		"volumeclasses":                 class.NewClassStorage(c),
 		"containerreplicas":             containersStorage,


### PR DESCRIPTION
In certain situations, we may not be able to do the namespace check associated with create projects. This change adds a parameter to make this configurable by the caller.