### PR TITLE
add: ImageAllowRules Prompt for autoupgrade patterns (#1698)

### DIFF
--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -244,14 +244,14 @@ func translateErr(err error) error {
 		return e
 	}
 
-	if e := translateNotAllowed(err); e != nil {
+	if e := TranslateNotAllowed(err); e != nil {
 		return e
 	}
 
 	return err
 }
 
-func translateNotAllowed(err error) error {
+func TranslateNotAllowed(err error) error {
 	if err == nil {
 		return err
 	}

--- a/pkg/imageallowrules/util/helpers.go
+++ b/pkg/imageallowrules/util/helpers.go
@@ -45,7 +45,7 @@ func GenerateSimpleAllowRule(namespace string, name string, image string, scope 
 	}, nil
 }
 
-func buildImageScope(image imagename.Reference, scope string, tagPattern string) (string, error) {
+func buildImageScope(image imagename.Reference, scope, tagPattern string) (string, error) {
 	var is string
 
 	switch SimpleImageScope(scope) {

--- a/pkg/imageallowrules/util/helpers.go
+++ b/pkg/imageallowrules/util/helpers.go
@@ -1,10 +1,11 @@
-package imageallowrules
+package util
 
 import (
 	"fmt"
 	"strings"
 
 	v1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/autoupgrade"
 	imagename "github.com/google/go-containerregistry/pkg/name"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,12 +20,18 @@ const (
 )
 
 func GenerateSimpleAllowRule(namespace string, name string, image string, scope string) (*v1.ImageAllowRule, error) {
+	pattern, isPattern := autoupgrade.AutoUpgradePattern(image)
+
+	if isPattern {
+		image = strings.TrimRight(image, ":"+pattern)
+	}
+
 	ref, err := imagename.ParseReference(image, imagename.WithDefaultTag(""), imagename.WithDefaultRegistry(""))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing image: %w", err)
 	}
 
-	is, err := buildImageScope(ref, scope)
+	is, err := buildImageScope(ref, scope, pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +45,7 @@ func GenerateSimpleAllowRule(namespace string, name string, image string, scope 
 	}, nil
 }
 
-func buildImageScope(image imagename.Reference, scope string) (string, error) {
+func buildImageScope(image imagename.Reference, scope string, tagPattern string) (string, error) {
 	var is string
 
 	switch SimpleImageScope(scope) {
@@ -48,6 +55,9 @@ func buildImageScope(image imagename.Reference, scope string) (string, error) {
 		is = fmt.Sprintf("%s/%s:**", image.Context().RegistryStr(), image.Context().RepositoryStr())
 	case SimpleImageScopeExact:
 		is = strings.TrimSuffix(image.Name(), ":")
+		if tagPattern != "" {
+			is = image.Context().Tag(tagPattern).Name()
+		}
 	case SimpleImageScopeAll:
 		is = "**"
 	default:


### PR DESCRIPTION
Ref #1698 

`acorn run my.reg.org/library/hello-world:v#.#.#` would fail before, because it failed to find a valid tag as all are disallowed by default. This lookup happens earlier than we usually prompt the user to allow the image, so now we're doing the prompt a little earlier during the first image details lookup.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

