### PR TITLE
Remove -A from almost all commands (#1897)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn.md
+++ b/docs/docs/100-reference/01-command-line/acorn.md
@@ -16,7 +16,6 @@ acorn [flags]
 ### Options
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
   -h, --help                help for acorn
@@ -27,7 +26,6 @@ acorn [flags]
 ### SEE ALSO
 
 * [acorn all](acorn_all.md)	 - List (almost) all objects
-* [acorn app](acorn_app.md)	 - List or get apps
 * [acorn build](acorn_build.md)	 - Build an app from a Acornfile file
 * [acorn check](acorn_check.md)	 - Check if the cluster is ready for Acorn
 * [acorn container](acorn_container.md)	 - Manage containers
@@ -46,6 +44,7 @@ acorn [flags]
 * [acorn offerings](acorn_offerings.md)	 - Show infrastructure offerings
 * [acorn port-forward](acorn_port-forward.md)	 - Forward a container port locally
 * [acorn project](acorn_project.md)	 - Manage projects
+* [acorn ps](acorn_ps.md)	 - List or get apps
 * [acorn pull](acorn_pull.md)	 - Pull an image from a remote registry
 * [acorn push](acorn_push.md)	 - Push an image to a remote registry
 * [acorn render](acorn_render.md)	 - Evaluate and display an Acornfile with args

--- a/docs/docs/100-reference/01-command-line/acorn_all.md
+++ b/docs/docs/100-reference/01-command-line/acorn_all.md
@@ -29,7 +29,6 @@ acorn all
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_app.mdx
+++ b/docs/docs/100-reference/01-command-line/acorn_app.mdx
@@ -1,3 +1,5 @@
+<!-- This is a manually added redirect, since we change the primary name of `acorn app` to `acorn ps`, but left `acorn app`
+as an alias. This was not auto-generated. -->
 import {Redirect} from "@docusaurus/router";
 
 <Redirect to="./acorn_ps"/>

--- a/docs/docs/100-reference/01-command-line/acorn_app.mdx
+++ b/docs/docs/100-reference/01-command-line/acorn_app.mdx
@@ -1,0 +1,3 @@
+import {Redirect} from "@docusaurus/router";
+
+<Redirect to="./acorn_ps"/>

--- a/docs/docs/100-reference/01-command-line/acorn_app.mdx
+++ b/docs/docs/100-reference/01-command-line/acorn_app.mdx
@@ -1,4 +1,4 @@
-<!-- This is a manually added redirect, since we change the primary name of `acorn app` to `acorn ps`, but left `acorn app`
+<!-- This is a manually added redirect, since we changed the primary name of `acorn app` to `acorn ps`, but left `acorn app`
 as an alias. This was not auto-generated. -->
 import {Redirect} from "@docusaurus/router";
 

--- a/docs/docs/100-reference/01-command-line/acorn_build.md
+++ b/docs/docs/100-reference/01-command-line/acorn_build.md
@@ -35,7 +35,6 @@ acorn build .
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_check.md
+++ b/docs/docs/100-reference/01-command-line/acorn_check.md
@@ -30,7 +30,6 @@ acorn check
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_container.md
+++ b/docs/docs/100-reference/01-command-line/acorn_container.md
@@ -28,7 +28,6 @@ acorn containers
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_container_kill.md
+++ b/docs/docs/100-reference/01-command-line/acorn_container_kill.md
@@ -26,7 +26,6 @@ acorn container kill app-name.containername-generated-hash
 
 ```
   -a, --all                 Include stopped containers
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_copy.md
@@ -38,7 +38,6 @@ acorn copy [flags] SOURCE DESTINATION
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_credential.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential.md
@@ -27,7 +27,6 @@ acorn credential
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_credential_login.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential_login.md
@@ -30,7 +30,6 @@ acorn login ghcr.io
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_credential_logout.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential_logout.md
@@ -26,7 +26,6 @@ acorn logout ghcr.io
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_dev.md
+++ b/docs/docs/100-reference/01-command-line/acorn_dev.md
@@ -38,7 +38,6 @@ acorn dev --name wandering-sound <IMAGE>
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -58,7 +58,6 @@ acorn events [flags] [PREFIX]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_exec.md
+++ b/docs/docs/100-reference/01-command-line/acorn_exec.md
@@ -26,7 +26,6 @@ acorn exec [flags] APP_NAME|CONTAINER_NAME CMD
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_fmt.md
+++ b/docs/docs/100-reference/01-command-line/acorn_fmt.md
@@ -18,7 +18,6 @@ acorn fmt [flags] [ACORNFILE]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_image.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image.md
@@ -30,7 +30,6 @@ acorn images
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_image_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_copy.md
@@ -38,7 +38,6 @@ acorn image copy [flags] SOURCE DESTINATION
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_image_details.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_details.md
@@ -25,7 +25,6 @@ acorn image details my-image
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_image_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_rm.md
@@ -25,7 +25,6 @@ acorn image rm my-image
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_info.md
+++ b/docs/docs/100-reference/01-command-line/acorn_info.md
@@ -19,7 +19,6 @@ acorn info [flags]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -76,7 +76,6 @@ acorn install
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_login.md
+++ b/docs/docs/100-reference/01-command-line/acorn_login.md
@@ -30,7 +30,6 @@ acorn login ghcr.io
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_logout.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logout.md
@@ -26,7 +26,6 @@ acorn logout ghcr.io
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -22,7 +22,6 @@ acorn logs [flags] [APP_NAME|CONTAINER_REPLICA_NAME]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_offerings.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings.md
@@ -27,7 +27,6 @@ acorn offerings
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_computeclasses.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_computeclasses.md
@@ -27,7 +27,6 @@ acorn computeclasses
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_regions.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_regions.md
@@ -27,7 +27,6 @@ acorn offering regions
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_volumeclasses.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_volumeclasses.md
@@ -27,7 +27,6 @@ acorn offering volumeclasses
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_port-forward.md
+++ b/docs/docs/100-reference/01-command-line/acorn_port-forward.md
@@ -24,7 +24,6 @@ acorn port-forward [flags] APP_NAME|CONTAINER_NAME PORT
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_project.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project.md
@@ -27,7 +27,6 @@ acorn project
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_project_create.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_create.md
@@ -32,7 +32,6 @@ acorn project create acorn.io/username/new-project
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_project_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_rm.md
@@ -26,7 +26,6 @@ acorn project rm my-project
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_project_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_update.md
@@ -28,7 +28,6 @@ acorn project update my-project
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_project_use.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_use.md
@@ -25,7 +25,6 @@ acorn project use acorn.io/my-user/acorn
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_ps.md
+++ b/docs/docs/100-reference/01-command-line/acorn_ps.md
@@ -20,7 +20,7 @@ acorn ps
 
 ```
   -a, --all             Include stopped apps
-  -A, --all-projects    Include all projects
+  -A, --all-projects    Include all projects in same Acorn instance as the current default project
   -h, --help            help for ps
   -o, --output string   Output format (json, yaml, {{gotemplate}})
   -q, --quiet           Output only names

--- a/docs/docs/100-reference/01-command-line/acorn_ps.md
+++ b/docs/docs/100-reference/01-command-line/acorn_ps.md
@@ -1,26 +1,27 @@
 ---
-title: "acorn app"
+title: "acorn ps"
 ---
-## acorn app
+## acorn ps
 
 List or get apps
 
 ```
-acorn app [flags] [APP_NAME...]
+acorn ps [flags] [APP_NAME...]
 ```
 
 ### Examples
 
 ```
 
-acorn app
+acorn ps
 ```
 
 ### Options
 
 ```
   -a, --all             Include stopped apps
-  -h, --help            help for app
+  -A, --all-projects    Include all projects
+  -h, --help            help for ps
   -o, --output string   Output format (json, yaml, {{gotemplate}})
   -q, --quiet           Output only names
 ```
@@ -28,7 +29,6 @@ acorn app
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_pull.md
+++ b/docs/docs/100-reference/01-command-line/acorn_pull.md
@@ -18,7 +18,6 @@ acorn pull [flags] IMAGE
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_push.md
+++ b/docs/docs/100-reference/01-command-line/acorn_push.md
@@ -18,7 +18,6 @@ acorn push [flags] IMAGE
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_render.md
+++ b/docs/docs/100-reference/01-command-line/acorn_render.md
@@ -21,7 +21,6 @@ acorn render [flags] DIRECTORY [acorn args]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_rm.md
@@ -30,7 +30,6 @@ acorn rm -t volume,container APP_NAME
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -72,7 +72,6 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_secret.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret.md
@@ -27,7 +27,6 @@ acorn secret
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_secret_create.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_create.md
@@ -35,7 +35,6 @@ acorn secret create --data @key-name=secret.yaml my-secret
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_secret_encrypt.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_encrypt.md
@@ -20,7 +20,6 @@ acorn secret encrypt [flags] STRING
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
@@ -27,7 +27,6 @@ acorn secret
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_secret_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_rm.md
@@ -25,7 +25,6 @@ acorn secret rm my-secret
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_start.md
+++ b/docs/docs/100-reference/01-command-line/acorn_start.md
@@ -27,7 +27,6 @@ acorn start my-app1 my-app2
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_stop.md
+++ b/docs/docs/100-reference/01-command-line/acorn_stop.md
@@ -27,7 +27,6 @@ acorn stop my-app1 my-app2
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_tag.md
+++ b/docs/docs/100-reference/01-command-line/acorn_tag.md
@@ -18,7 +18,6 @@ acorn tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_uninstall.md
+++ b/docs/docs/100-reference/01-command-line/acorn_uninstall.md
@@ -31,7 +31,6 @@ acorn uninstall -f
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -43,7 +43,6 @@ acorn update [flags] APP_NAME [deploy flags]
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_version.md
+++ b/docs/docs/100-reference/01-command-line/acorn_version.md
@@ -24,7 +24,6 @@ acorn version
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_volume.md
+++ b/docs/docs/100-reference/01-command-line/acorn_volume.md
@@ -27,7 +27,6 @@ acorn volume
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
@@ -24,7 +24,6 @@ acorn volume rm my-volume
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/docs/100-reference/01-command-line/acorn_wait.md
+++ b/docs/docs/100-reference/01-command-line/acorn_wait.md
@@ -19,7 +19,6 @@ acorn wait [flags] APP_NAME
 ### Options inherited from parent commands
 
 ```
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Explicitly use kubeconfig file, overriding current project

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -99,7 +99,6 @@ const sidebars = {
           "items": [
             "reference/command-line/acorn",
             "reference/command-line/acorn_all",
-            "reference/command-line/acorn_app",
             "reference/command-line/acorn_build",
             "reference/command-line/acorn_check",
             "reference/command-line/acorn_container",
@@ -120,6 +119,7 @@ const sidebars = {
             "reference/command-line/acorn_project_create",
             "reference/command-line/acorn_project_rm",
             "reference/command-line/acorn_project_use",
+            "reference/command-line/acorn_ps",
             "reference/command-line/acorn_pull",
             "reference/command-line/acorn_push",
             "reference/command-line/acorn_offerings",

--- a/integration/projectconfig/projectconfig_test.go
+++ b/integration/projectconfig/projectconfig_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSlashBreaksList(t *testing.T) {
-	p, _, err := project.List(context.Background(), project.Options{
+	p, _, err := project.List(context.Background(), false, project.Options{
 		Project: "acorn.io/fake/fake",
 	})
 	assert.Nil(t, err)

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -35,7 +35,6 @@ func New() *cobra.Command {
 	root.AddCommand(
 		NewAll(cmdContext),
 		NewApiServer(cmdContext),
-		NewApp(cmdContext),
 		NewBuild(cmdContext),
 		NewBuildServer(cmdContext),
 		NewCheck(cmdContext),
@@ -58,6 +57,7 @@ func New() *cobra.Command {
 		NewCredentialLogin(true, cmdContext),
 		NewCredentialLogout(true, cmdContext),
 		NewProject(cmdContext),
+		NewPs(cmdContext),
 		NewPull(cmdContext),
 		NewPush(cmdContext),
 		NewRm(cmdContext),
@@ -81,11 +81,10 @@ func New() *cobra.Command {
 }
 
 type Acorn struct {
-	Kubeconfig  string `usage:"Explicitly use kubeconfig file, overriding current project"`
-	Project     string `usage:"Project to work in" short:"j" env:"ACORN_PROJECT"`
-	AllProjects bool   `usage:"Use all known projects" short:"A" env:"ACORN_ALL_PROJECTS"`
-	Debug       bool   `usage:"Enable debug logging" env:"ACORN_DEBUG"`
-	DebugLevel  int    `usage:"Debug log level (valid 0-9) (default 7)" env:"ACORN_DEBUG_LEVEL"`
+	Kubeconfig string `usage:"Explicitly use kubeconfig file, overriding current project"`
+	Project    string `usage:"Project to work in" short:"j" env:"ACORN_PROJECT"`
+	Debug      bool   `usage:"Enable debug logging" env:"ACORN_DEBUG"`
+	DebugLevel int    `usage:"Debug log level (valid 0-9) (default 7)" env:"ACORN_DEBUG_LEVEL"`
 }
 
 func setEnv(key, value string) error {

--- a/pkg/cli/all.go
+++ b/pkg/cli/all.go
@@ -31,13 +31,13 @@ func (a *All) Run(cmd *cobra.Command, args []string) error {
 		fmt.Println("")
 		fmt.Println("APPS:")
 	}
-	app := &App{
+	ps := &Ps{
 		Quiet:  a.Quiet,
 		Output: a.Output,
 		All:    a.All,
 		client: a.client,
 	}
-	appErr := app.Run(cmd, nil)
+	psErr := ps.Run(cmd, nil)
 
 	con := &Container{
 		Quiet:  a.Quiet,
@@ -89,5 +89,5 @@ func (a *All) Run(cmd *cobra.Command, args []string) error {
 		imgErr = img.Run(cmd, nil)
 	}
 
-	return merr.NewErrors(appErr, conErr, volErr, secErr, imgErr)
+	return merr.NewErrors(psErr, conErr, volErr, secErr, imgErr)
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -263,7 +263,7 @@ func projectsCompletion(ctx context.Context, c client.Client, toComplete string)
 		return nil, err
 	}
 
-	projects, _, err := project.List(ctx, project.Options{
+	projects, _, err := project.List(ctx, false, project.Options{
 		CLIConfig: cfg,
 	})
 	if err != nil {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -18,6 +18,7 @@ type CommandContext struct {
 
 type ClientFactory interface {
 	CreateDefault() (client.Client, error)
+	CreateWithAllProjects() (client.Client, error)
 	Options() project.Options
 }
 
@@ -28,13 +29,18 @@ type CommandClientFactory struct {
 
 func (c *CommandClientFactory) Options() project.Options {
 	return project.Options{
-		Project:     c.acorn.Project,
-		Kubeconfig:  c.acorn.Kubeconfig,
-		ContextEnv:  os.Getenv("CONTEXT"),
-		AllProjects: c.acorn.AllProjects,
+		Project:    c.acorn.Project,
+		Kubeconfig: c.acorn.Kubeconfig,
+		ContextEnv: os.Getenv("CONTEXT"),
 	}
 }
 
 func (c *CommandClientFactory) CreateDefault() (client.Client, error) {
 	return project.Client(c.cmd.Context(), c.Options())
+}
+
+func (c *CommandClientFactory) CreateWithAllProjects() (client.Client, error) {
+	opts := c.Options()
+	opts.AllProjects = true
+	return project.Client(c.cmd.Context(), opts)
 }

--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -60,7 +60,7 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 		}
 		projectNames = append(projectNames, args[0])
 	} else {
-		projects, warnings, err := project.List(cmd.Context(), a.client.Options().WithCLIConfig(cfg))
+		projects, warnings, err := project.List(cmd.Context(), false, a.client.Options().WithCLIConfig(cfg))
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/ps.go
+++ b/pkg/cli/ps.go
@@ -3,32 +3,42 @@ package cli
 import (
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
+	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/tables"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
 )
 
-func NewApp(c CommandContext) *cobra.Command {
-	return cli.Command(&App{client: c.ClientFactory}, cobra.Command{
-		Use:     "app [flags] [APP_NAME...]",
-		Aliases: []string{"apps", "a", "ps"},
+func NewPs(c CommandContext) *cobra.Command {
+	return cli.Command(&Ps{client: c.ClientFactory}, cobra.Command{
+		Use:     "ps [flags] [APP_NAME...]",
+		Aliases: []string{"app", "apps", "a"},
 		Example: `
-acorn app`,
+acorn ps`,
 		SilenceUsage:      true,
 		Short:             "List or get apps",
 		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
 	})
 }
 
-type App struct {
-	All    bool   `usage:"Include stopped apps" short:"a"`
-	Quiet  bool   `usage:"Output only names" short:"q"`
-	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
-	client ClientFactory
+type Ps struct {
+	All         bool   `usage:"Include stopped apps" short:"a"`
+	AllProjects bool   `usage:"Include all projects" short:"A"`
+	Quiet       bool   `usage:"Output only names" short:"q"`
+	Output      string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+	client      ClientFactory
 }
 
-func (a *App) Run(cmd *cobra.Command, args []string) error {
-	c, err := a.client.CreateDefault()
+func (a *Ps) Run(cmd *cobra.Command, args []string) error {
+	var (
+		c   client.Client
+		err error
+	)
+	if a.AllProjects {
+		c, err = a.client.CreateWithAllProjects()
+	} else {
+		c, err = a.client.CreateDefault()
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/ps.go
+++ b/pkg/cli/ps.go
@@ -23,7 +23,7 @@ acorn ps`,
 
 type Ps struct {
 	All         bool   `usage:"Include stopped apps" short:"a"`
-	AllProjects bool   `usage:"Include all projects" short:"A"`
+	AllProjects bool   `usage:"Include all projects in same Acorn instance as the current default project" short:"A"`
 	Quiet       bool   `usage:"Output only names" short:"q"`
 	Output      string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
 	client      ClientFactory

--- a/pkg/cli/ps_test.go
+++ b/pkg/cli/ps_test.go
@@ -93,7 +93,7 @@ func TestApp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
-			tt.args.cmd = NewApp(tt.commandContext)
+			tt.args.cmd = NewPs(tt.commandContext)
 			tt.args.cmd.SetArgs(tt.args.args)
 			err := tt.args.cmd.Execute()
 			if err != nil && !tt.wantErr {

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -30,6 +30,10 @@ func (dc *MockClientFactoryManual) CreateDefault() (client.Client, error) {
 	return dc.Client, nil
 }
 
+func (dc *MockClientFactoryManual) CreateWithAllProjects() (client.Client, error) {
+	return dc.Client, nil
+}
+
 type MockClientFactory struct {
 	AppList          []apiv1.App
 	AppItem          *apiv1.App
@@ -84,6 +88,10 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 		Events:           dc.EventList,
 		EventItem:        dc.EventItem,
 	}, nil
+}
+
+func (dc *MockClientFactory) CreateWithAllProjects() (client.Client, error) {
+	return dc.CreateDefault()
 }
 
 type MockClient struct {

--- a/pkg/cli/testdata/acorn/acorn_test_info.txt
+++ b/pkg/cli/testdata/acorn/acorn_test_info.txt
@@ -6,7 +6,6 @@ Usage:
 
 Available Commands:
   all          List (almost) all objects
-  app          List or get apps
   build        Build an app from a Acornfile file
   check        Check if the cluster is ready for Acorn
   container    Manage containers
@@ -26,6 +25,7 @@ Available Commands:
   offerings    Show infrastructure offerings
   port-forward Forward a container port locally
   project      Manage projects
+  ps           List or get apps
   pull         Pull an image from a remote registry
   push         Push an image to a remote registry
   render       Evaluate and display an Acornfile with args
@@ -42,7 +42,6 @@ Available Commands:
   wait         Wait an app to be ready then exit with status code 0
 
 Flags:
-  -A, --all-projects        Use all known projects
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
   -h, --help                help for acorn

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -150,8 +150,29 @@ func ParseProject(project string, kubeconfigs map[string]string) (serverOrKubeco
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
 	if opts.AllProjects {
 		projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
-		return projects, err
+		if err != nil {
+			return nil, err
+		}
+
+		// If the current project belongs to a Manager instance, only show projects from that Manager instance.
+		// Otherwise, remove all projects that contain a '/' since they belong to a Manager instance.
+		if managerHost, _, exists := strings.Cut(cfg.CurrentProject, "/"); exists {
+			for _, p := range projects {
+				if strings.HasPrefix(p, managerHost) {
+					result = append(result, p)
+				}
+			}
+		} else {
+			for _, p := range projects {
+				if !strings.Contains(p, "/") {
+					result = append(result, p)
+				}
+			}
+		}
+
+		return result, err
 	}
+
 	p := strings.TrimSpace(opts.Project)
 	if p == "" {
 		p = strings.TrimSpace(cfg.CurrentProject)

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -150,27 +150,7 @@ func ParseProject(project string, kubeconfigs map[string]string) (serverOrKubeco
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
 	if opts.AllProjects {
 		projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
-		if err != nil {
-			return nil, err
-		}
-
-		// If the current project belongs to a Manager instance, only show projects from that Manager instance.
-		// Otherwise, remove all projects that contain a '/' since they belong to a Manager instance.
-		if managerHost, _, exists := strings.Cut(cfg.CurrentProject, "/"); exists {
-			for _, p := range projects {
-				if strings.HasPrefix(p, managerHost) {
-					result = append(result, p)
-				}
-			}
-		} else {
-			for _, p := range projects {
-				if !strings.Contains(p, "/") {
-					result = append(result, p)
-				}
-			}
-		}
-
-		return result, err
+		return projects, err
 	}
 
 	p := strings.TrimSpace(opts.Project)

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -149,7 +149,7 @@ func ParseProject(project string, kubeconfigs map[string]string) (serverOrKubeco
 
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
 	if opts.AllProjects {
-		projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
+		projects, _, err := List(ctx, true, opts.WithCLIConfig(cfg))
 		return projects, err
 	}
 

--- a/pkg/project/operations.go
+++ b/pkg/project/operations.go
@@ -143,8 +143,7 @@ func List(ctx context.Context, opts Options) (projects []string, warnings map[st
 	var (
 		cfg = opts.CLIConfig
 		// if the user sets --kubeconfig we only consider kubeconfig and no other source for listing
-		onlyListLocalKubeconfig           = opts.Kubeconfig != ""
-		managerHost, _, managerHostExists = strings.Cut(cfg.CurrentProject, "/")
+		onlyListLocalKubeconfig = opts.Kubeconfig != ""
 	)
 
 	if cfg == nil {
@@ -153,6 +152,8 @@ func List(ctx context.Context, opts Options) (projects []string, warnings map[st
 			return nil, nil, err
 		}
 	}
+
+	managerHost, _, managerHostExists := strings.Cut(cfg.CurrentProject, "/")
 
 	creds, err := credentials.NewLocalOnlyStore(cfg)
 	if err != nil {

--- a/tools/gendocs/main.go
+++ b/tools/gendocs/main.go
@@ -21,7 +21,7 @@ func main() {
 	cmd := acorn.New()
 	cmd.DisableAutoGenTag = true
 
-	files, err := filepath.Glob("docs/docs/100-reference/01-command-line/acorn_*")
+	files, err := filepath.Glob("docs/docs/100-reference/01-command-line/acorn_*.md")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
for #1897

`-A` is now only supported for `acorn ps`. Also, `ps` is the main name for that command now, instead of `apps` (which is still a valid alias).

Additionally, the behavior of `-A` will now only include other projects in the same Acorn "instance" (one installation of Runtime, or one instance of Manager).

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

