### PR TITLE
 Always return event details (#1906)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -44,12 +44,6 @@ acorn events [flags] [PREFIX]
   # Get a single event by name
   acorn events 4b2ba097badf2031c4718609b9179fb5
 
-  # Getting Details 
-  # The 'details' field provides additional information about an event.
-  # By default, this field is elided from this command's output, but can be enabled via the '--details' flag.
-  # This flag must be used in conjunction with a non-table output format, like '-o=yaml'.
-  acorn events --details -o yaml
-
 ```
 
 ### Options

--- a/docs/docs/50-running/90-events.md
+++ b/docs/docs/50-running/90-events.md
@@ -18,9 +18,6 @@ acorn events --tail 10
 
 # List the last 5 events and follow the event log
 acorn events --tail 5 -f
-
-# Print more information about each event
-acorn events --details -o yaml
 ```
 
 The command prints events in chronological order, printing the oldest events first.

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -46,12 +46,6 @@ func NewEvent(c CommandContext) *cobra.Command {
 
   # Get a single event by name
   acorn events 4b2ba097badf2031c4718609b9179fb5
-
-  # Getting Details 
-  # The 'details' field provides additional information about an event.
-  # By default, this field is elided from this command's output, but can be enabled via the '--details' flag.
-  # This flag must be used in conjunction with a non-table output format, like '-o=yaml'.
-  acorn events --details -o yaml
 `})
 	return cmd
 }
@@ -71,9 +65,8 @@ func (e *Events) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := &client.EventStreamOptions{
-		Tail:    e.Tail,
-		Follow:  e.Follow,
-		Details: e.Details,
+		Tail:   e.Tail,
+		Follow: e.Follow,
 	}
 
 	if len(args) > 0 {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -328,7 +328,6 @@ type ContainerReplicaListOptions struct {
 type EventStreamOptions struct {
 	Tail            int    `json:"tail,omitempty"`
 	Follow          bool   `json:"follow,omitempty"`
-	Details         bool   `json:"details,omitempty"`
 	Prefix          string `json:"prefix,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
@@ -338,9 +337,9 @@ func (o EventStreamOptions) ListOptions() *kclient.ListOptions {
 	if o.Prefix != "" {
 		fieldSet["prefix"] = o.Prefix
 	}
-	if o.Details {
-		fieldSet["details"] = strconv.FormatBool(o.Details)
-	}
+
+	// Set details selector to get details from older runtime APIs that don't return details by default.
+	fieldSet["details"] = strconv.FormatBool(true)
 
 	return &kclient.ListOptions{
 		Limit:         int64(o.Tail),


### PR DESCRIPTION
Modify the runtime events API and acorn cli s.t. the details field is always returned intact, and is no longer elided from list|watch responses.

Vanquishes #1906 

