### PR TITLE
Drop details flag from acorn events subcommand (#1906)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -49,7 +49,6 @@ acorn events [flags] [PREFIX]
 ### Options
 
 ```
-  -d, --details         Don't strip event details from response
   -f, --follow          Follow the event log
   -h, --help            help for events
   -o, --output string   Output format (json, yaml, {{gotemplate}})

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -51,11 +51,10 @@ func NewEvent(c CommandContext) *cobra.Command {
 }
 
 type Events struct {
-	Tail    int    `usage:"Return this number of latest events" short:"t"`
-	Follow  bool   `usage:"Follow the event log" short:"f"`
-	Details bool   `usage:"Don't strip event details from response" short:"d"`
-	Output  string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
-	client  ClientFactory
+	Tail   int    `usage:"Return this number of latest events" short:"t"`
+	Follow bool   `usage:"Follow the event log" short:"f"`
+	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+	client ClientFactory
 }
 
 func (e *Events) Run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Remove the non-functional `--details` flag that was left exposed by #1908 on
the acorn events subcommand.

Completes #1906 
