### PR TITLE
Use rcodesign's release page instead of cargo

### DIFF
--- a/tools/notarize
+++ b/tools/notarize
@@ -22,14 +22,14 @@ echo "NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} ZIP=${ZIP}"
 
 sudo apt-get update -y  
 
-# Sign the binary using rcodesign, a Rust implementation of codesign. This
-# requires that gcc and cargo are installed.
+# Sign the binary using rcodesign, a Rust implementation of codesign.
 echo "Signing the binary..."
 
-which curl || sudo apt-get install curl -y
-which gcc || sudo apt-get install gcc -y
-which cargo || sudo curl https://sh.rustup.rs -sSf | sh -s -- -y && bash
-which rcodesign || cargo install apple-codesign
+# Install rcodesign from the release page.
+which wget || sudo apt-get install wget -y
+wget https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
+tar -xvf apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
+mv apple-codesign-0.22.0-x86_64-unknown-linux-musl/rcodesign /usr/local/bin
 
 # Sign the binary using rcodesign.
 echo "Signing ${BINARY}..."


### PR DESCRIPTION
We recently [failed to install `rcodesign`](https://github.com/acorn-io/runtime/actions/runs/5522152735/jobs/10071309623#step:11:695) in our notarization script due to a dependency failing to compile. This is because that dependency had a recent release that is failing. To fix this issue and avoid it in the future, this PR updates that logic to instead download the binary from the official release page.



### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

