### PR TITLE
Submit nightly eks tests to datadog

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -64,7 +64,7 @@ jobs:
         id: test_summary
         needs: [test]
         uses: test-summary/action@v2
-        if: success() || failure()
+        if: "!cancelled() && steps.test.conclusion != 'skipped'"
         with:
           paths: test-summary.xml
 
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload test results to Datadog
         uses: datadog/junit-upload-github-action@v1
-        if: '!cancelled()'
+        if: '!cancelled() && steps.test_summary.conclusion != "skipped"'
         needs: [test_summary]
         with:
           api-key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -54,6 +54,7 @@ jobs:
           KUBECONFIG: "/home/runner/.kube/config"
 
       - name: run acorn integration tests
+        id: test
         run: |
           TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml" GO_TEST_FLAGS="-timeout=7m" make integration
         env:
@@ -61,6 +62,7 @@ jobs:
 
       - name: Build test summary
         id: test_summary
+        needs: [test]
         uses: test-summary/action@v2
         if: success() || failure()
         with:
@@ -84,6 +86,17 @@ jobs:
           slack-message: " ✅ Nightly EKS test passed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'
+
+      - name: Upload test results to Datadog
+        uses: datadog/junit-upload-github-action@v1
+        if: '!cancelled()'
+        needs: [test_summary]
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          service: runtime-eks-tests
+          env: ci
+          files: test-summary.xml
+          datadog-site: us3.datadoghq.com
 
       - name: create run artifacts
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,6 @@ jobs:
       - run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml" make integration
       - name: Build test summary
         uses: test-summary/action@v1
-        if: success() || failure()
+        if: "!cancelled() && steps.test.conclusion != 'skipped'"
         with:
           paths: test-summary.xml


### PR DESCRIPTION
This PR submits our test summaries to datadog so that we can keep track of the nightly eks tests overtime. It also fixes a small issue where the `test-summary` creation would occur (and fail) even if tests didn't run.

~~Note - I'll update this description when a datadog api key secret has been added so we know it is ready to merge.~~ Its added!

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

