### PR TITLE
Enable filtering acorn events output to a given time span

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -44,6 +44,14 @@ acorn events [flags] [PREFIX]
   # Get a single event by name
   acorn events 4b2ba097badf2031c4718609b9179fb5
 
+  # Filtering by Time
+  # The --since and --until options can be Unix timestamps, date formatted timestamps, or Go duration strings (relative to system time).
+  # List events observed within the last 15 minutes 
+  acorn events --since 15m
+
+  # List events observed between 2023-05-08T15:04:05 and 2023-05-08T15:05:05 (inclusive)
+  acorn events --since '2023-05-08T15:04:05' --until '2023-05-08T15:05:05'
+
 ```
 
 ### Options
@@ -52,7 +60,9 @@ acorn events [flags] [PREFIX]
   -f, --follow          Follow the event log
   -h, --help            help for events
   -o, --output string   Output format (json, yaml, {{gotemplate}})
+  -s, --since string    Show all events created since timestamp
   -t, --tail int        Return this number of latest events
+  -u, --until string    Stream events until this timestamp
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/api.acorn.io/v1/scheme.go
+++ b/pkg/apis/api.acorn.io/v1/scheme.go
@@ -91,7 +91,7 @@ func AddToSchemeWithGV(scheme *runtime.Scheme, schemeGroupVersion schema.GroupVe
 		gvk := schemeGroupVersion.WithKind("Event")
 		flcf := func(label, value string) (string, string, error) {
 			switch label {
-			case "prefix", "details", "metadata.name", "metadata.namespace":
+			case "prefix", "since", "until", "details", "metadata.name", "metadata.namespace":
 				return label, value, nil
 			}
 			return "", "", fmt.Errorf("unsupported field selection [%s]", label)

--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -65,6 +65,14 @@ func (e EventInstance) GetObserved() MicroTime {
 // It extends metav1.MicroTime to allow unmarshaling from RFC3339.
 type MicroTime metav1.MicroTime
 
+func NewMicroTime(t time.Time) MicroTime {
+	return MicroTime(metav1.NewMicroTime(t))
+}
+
+func NowMicro() MicroTime {
+	return NewMicroTime(time.Now())
+}
+
 // DeepCopyInto returns a deep-copy of the MicroTime value.  The underlying time.Time
 // type is effectively immutable in the time API, so it is safe to
 // copy-by-assign, despite the presence of (unexported) Pointer fields.

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -46,6 +46,14 @@ func NewEvent(c CommandContext) *cobra.Command {
 
   # Get a single event by name
   acorn events 4b2ba097badf2031c4718609b9179fb5
+
+  # Filtering by Time
+  # The --since and --until options can be Unix timestamps, date formatted timestamps, or Go duration strings (relative to system time).
+  # List events observed within the last 15 minutes 
+  acorn events --since 15m
+
+  # List events observed between 2023-05-08T15:04:05 and 2023-05-08T15:05:05 (inclusive)
+  acorn events --since '2023-05-08T15:04:05' --until '2023-05-08T15:05:05'
 `})
 	return cmd
 }
@@ -53,6 +61,8 @@ func NewEvent(c CommandContext) *cobra.Command {
 type Events struct {
 	Tail   int    `usage:"Return this number of latest events" short:"t"`
 	Follow bool   `usage:"Follow the event log" short:"f"`
+	Since  string `usage:"Show all events created since timestamp" short:"s"`
+	Until  string `usage:"Stream events until this timestamp" short:"u"`
 	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
 	client ClientFactory
 }
@@ -66,6 +76,8 @@ func (e *Events) Run(cmd *cobra.Command, args []string) error {
 	opts := &client.EventStreamOptions{
 		Tail:   e.Tail,
 		Follow: e.Follow,
+		Since:  e.Since,
+		Until:  e.Until,
 	}
 
 	if len(args) > 0 {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -338,6 +338,8 @@ type EventStreamOptions struct {
 	Tail            int    `json:"tail,omitempty"`
 	Follow          bool   `json:"follow,omitempty"`
 	Prefix          string `json:"prefix,omitempty"`
+	Since           string `json:"since,omitempty"`
+	Until           string `json:"until,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
@@ -345,6 +347,12 @@ func (o EventStreamOptions) ListOptions() *kclient.ListOptions {
 	fieldSet := make(fields.Set)
 	if o.Prefix != "" {
 		fieldSet["prefix"] = o.Prefix
+	}
+	if o.Since != "" {
+		fieldSet["since"] = o.Since
+	}
+	if o.Until != "" {
+		fieldSet["until"] = o.Until
 	}
 
 	// Set details selector to get details from older runtime APIs that don't return details by default.

--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -298,9 +298,9 @@ var (
 func parseTime(raw string) (*internalv1.MicroTime, error) {
 	var errs []error
 	for _, layout := range supportedLayouts {
-		since, err := time.Parse(layout, raw)
+		t, err := time.Parse(layout, raw)
 		if err == nil {
-			return z.P(internalv1.NewMicroTime(since)), nil
+			return z.P(internalv1.NewMicroTime(t)), nil
 		}
 
 		errs = append(errs, err)

--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -250,12 +250,12 @@ func stripQuery(opts storage.ListOptions) (q query, stripped storage.ListOptions
 	return
 }
 
-func parseTimeBound(raw string, now internalv1.MicroTime, lower bool) (*internalv1.MicroTime, error) {
+func parseTimeBound(raw string, now internalv1.MicroTime, since bool) (*internalv1.MicroTime, error) {
 	// Try to parse raw as a duration string
 	var errs []error
 	duration, err := time.ParseDuration(raw)
 	if err == nil {
-		if lower {
+		if since {
 			duration *= -1
 		}
 


### PR DESCRIPTION
Add two new options to the `acorn events` subcommand:
- `--since` will determine the start of the time span; excludes events
  observed before this point when provided
- `--until` will determine the end of the time span; excludes events
  observed after this point when provided

Each option accepts a single argument; arguments can be Unix timestamps,
date formatted timestamps, or Go duration strings(relative to system time).

Addresses #1805 
