### PR TITLE
fix: supress unimportant error level log after abort singal(ctrl + c)

### DIFF
--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/acorn-io/baaah/pkg/apply"
 	"github.com/acorn-io/baaah/pkg/router"
@@ -325,10 +326,15 @@ func (c *DefaultClient) AppLog(ctx context.Context, name string, opts *LogOption
 
 	go func() {
 		<-ctx.Done()
+		// Set a past read deadline with `conn.SetReadDeadline`
+		// to trigger a "use of closed network connection" error
+		// for graceful closure handling without printing the error.
+		_ = conn.SetReadDeadline(time.Now())
 		_ = conn.Close()
 	}()
 
 	result := make(chan apiv1.LogMessage)
+
 	go func() {
 		defer close(result)
 		defer conn.Close()


### PR DESCRIPTION
This PR is related to the [discussion](https://github.com/acorn-io/runtime/issues/1865#issuecomment-1632829598) on issue #1865 
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

