### PR TITLE
Use credentials when checking to see if an image is remote

### DIFF
--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -62,7 +62,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			isLocal          bool
 		)
 		// Only attempt to resolve locally if auto-upgrade is not on, or if auto-upgrade is on but we know the image is not remote.
-		if !autoUpgradeOn || !images.IsImageRemote(target, true, remote.WithTransport(transport)) {
+		if !autoUpgradeOn || !images.IsImageRemote(req.Ctx, req.Client, appInstance.Namespace, target, true, remote.WithTransport(transport)) {
 			resolved, isLocal, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
 			if err != nil {
 				cond.Error(err)

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -119,7 +119,7 @@ func ResolveTag(tag imagename.Reference, image string) string {
 // IsImageRemote checks the remote registry to see if the given image name exists.
 // If noDefaultRegistry is true, and the image does not have a specified registry, this function will return false
 // without attempting to check any remote registries.
-func IsImageRemote(image string, noDefaultRegistry bool, opts ...remote.Option) bool {
+func IsImageRemote(ctx context.Context, c client.Reader, namespace, image string, noDefaultRegistry bool, opts ...remote.Option) bool {
 	var (
 		ref imagename.Reference
 		err error
@@ -131,6 +131,11 @@ func IsImageRemote(image string, noDefaultRegistry bool, opts ...remote.Option) 
 	}
 
 	if err != nil || ref.Context().RegistryStr() == NoDefaultRegistry {
+		return false
+	}
+
+	opts, err = GetAuthenticationRemoteOptions(ctx, c, namespace, opts...)
+	if err != nil {
 		return false
 	}
 


### PR DESCRIPTION
I totally forgot to add this when I first implemented this change.
This should fix the failing e2e test called `TestExtRegAutoUpgradeOptionWithPull`. I believe it will also fix `TestExtRegAutoUpgradeOptionWithLocalImage`.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

