### PR TITLE
Add AutoUpgrade status field to replace API Server validation

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -196,6 +196,7 @@ type AppInstanceStatus struct {
 	DevSession             *DevSessionInstanceSpec `json:"devSession,omitempty"`
 	ObservedGeneration     int64                   `json:"observedGeneration,omitempty"`
 	ObservedImageDigest    string                  `json:"observedImageDigest,omitempty"`
+	ObservedAutoUpgrade    bool                    `json:"observedAutoUpgrade,omitempty"`
 	Columns                AppColumns              `json:"columns,omitempty"`
 	Ready                  bool                    `json:"ready,omitempty"`
 	Namespace              string                  `json:"namespace,omitempty"`

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"io"
 
+	"github.com/acorn-io/runtime/pkg/autoupgrade"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/dev"
 	"github.com/acorn-io/runtime/pkg/imagesource"
+	"github.com/acorn-io/z"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +64,11 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
+	}
+
+	// Ensure opts.AutoUpgrade is set if is implied by opts.AutoUpgradeInterval or imageSource.Image's pattern.
+	if opts.AutoUpgrade == nil || !*opts.AutoUpgrade {
+		opts.AutoUpgrade = z.P(autoupgrade.ImpliedAutoUpgrade(opts.AutoUpgradeInterval, imageSource.Image))
 	}
 
 	return dev.Dev(cmd.Context(), c, &dev.Options{

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -3,11 +3,9 @@ package cli
 import (
 	"io"
 
-	"github.com/acorn-io/runtime/pkg/autoupgrade"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/dev"
 	"github.com/acorn-io/runtime/pkg/imagesource"
-	"github.com/acorn-io/z"
 	"github.com/spf13/cobra"
 )
 
@@ -64,11 +62,6 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
-	}
-
-	// Ensure opts.AutoUpgrade is set if is implied by opts.AutoUpgradeInterval or imageSource.Image's pattern.
-	if opts.AutoUpgrade == nil || !*opts.AutoUpgrade {
-		opts.AutoUpgrade = z.P(autoupgrade.ImpliedAutoUpgrade(opts.AutoUpgradeInterval, imageSource.Image))
 	}
 
 	return dev.Dev(cmd.Context(), c, &dev.Options{

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -18,7 +18,6 @@ import (
 	"github.com/acorn-io/runtime/pkg/imagesource"
 	"github.com/acorn-io/runtime/pkg/rulerequest"
 	"github.com/acorn-io/runtime/pkg/wait"
-	"github.com/acorn-io/z"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -241,11 +240,6 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
-	}
-
-	// Ensure opts.AutoUpgrade is set if is implied by opts.AutoUpgradeInterval or imageSource.Image's pattern.
-	if opts.AutoUpgrade == nil || !*opts.AutoUpgrade {
-		opts.AutoUpgrade = z.P(autoupgrade.ImpliedAutoUpgrade(opts.AutoUpgradeInterval, imageSource.Image))
 	}
 
 	// Force install prompt if needed

--- a/pkg/controller/appdefinition/generation.go
+++ b/pkg/controller/appdefinition/generation.go
@@ -3,11 +3,21 @@ package appdefinition
 import (
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/autoupgrade"
 )
 
 func UpdateObservedFields(req router.Request, resp router.Response) error {
 	app := req.Object.(*v1.AppInstance)
 	app.Status.ObservedImageDigest = app.Status.AppImage.Digest
 	app.Status.ObservedGeneration = app.Generation
+	app.Status.ObservedAutoUpgrade = impliedAutoUpgrade(app.Spec)
 	return nil
+}
+
+func impliedAutoUpgrade(appSpec v1.AppInstanceSpec) bool {
+	au := appSpec.AutoUpgrade != nil && *appSpec.AutoUpgrade
+	if !au && autoupgrade.ImpliedAutoUpgrade(appSpec.AutoUpgradeInterval, appSpec.Image) {
+		au = true
+	}
+	return au
 }

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6099,6 +6099,12 @@ func schema_pkg_apis_internalacornio_v1_AppInstanceStatus(ref common.ReferenceCa
 							Format: "",
 						},
 					},
+					"observedAutoUpgrade": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"columns": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -96,12 +96,6 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		return
 	}
 
-	au := app.Spec.AutoUpgrade
-	if (au == nil || !*au) && autoupgrade.ImpliedAutoUpgrade(app.Spec.AutoUpgradeInterval, app.Spec.Image) {
-		result = append(result, field.Invalid(field.NewPath("spec", "autoUpgrade"), app.Spec.AutoUpgrade, "must be true if autoupgrade options are set"))
-		return
-	}
-
 	var (
 		imageGrantedPerms []v1.Permissions
 		checkImage        = app.Spec.Image


### PR DESCRIPTION
As talked about during stand-up towards the end, this updates the AutoUpgrade implication logic to write to the App's status instead of failing on the API Server. This allows for there for be no friction from the API server when `autoupgrade` is not set but is implied.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

