### PR TITLE
Add server-side defaults for event fields

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -43,7 +43,8 @@ type EventInstance struct {
 	Description string `json:"description,omitempty"`
 
 	// Observed represents the time the Event was first observed.
-	Observed MicroTime `json:"observed" wrangler:"type=string"`
+	// +optional
+	Observed MicroTime `json:"observed,omitempty" wrangler:"type=string"`
 
 	// Details provides additional information about the cluster at the time the Event occurred.
 	//

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -6,9 +6,7 @@ import (
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,16 +22,6 @@ func (r RecorderFunc) Record(ctx context.Context, e *apiv1.Event) error {
 
 func NewRecorder(c kclient.Client) RecorderFunc {
 	return func(ctx context.Context, e *apiv1.Event) error {
-		if e.Actor == "" {
-			// Set actor from ctx if possible
-			logrus.Debug("No Actor set, attempting to set default from ctx")
-			if user, ok := request.UserFrom(ctx); ok {
-				e.Actor = user.GetName()
-			} else {
-				logrus.Debug("Ctx has no user info, generating anonymous event")
-			}
-		}
-
 		// Set a generated name based on the event content.
 		id, err := ContentID(e)
 		if err != nil {

--- a/pkg/event/id.go
+++ b/pkg/event/id.go
@@ -15,7 +15,6 @@ func ContentID(e *apiv1.Event) (string, error) {
 	fieldSet := strings.Join([]string{
 		e.Type,
 		string(e.Severity),
-		e.Actor,
 		e.Source.String(),
 		e.Description,
 		strconv.FormatInt(e.Observed.UnixMicro(), 10),

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3240,7 +3240,7 @@ func schema_pkg_apis_apiacornio_v1_Event(ref common.ReferenceCallback) common.Op
 						},
 					},
 				},
-				Required: []string{"type", "actor", "source", "observed"},
+				Required: []string{"type", "actor", "source"},
 			},
 		},
 		Dependencies: []string{
@@ -7933,7 +7933,7 @@ func schema_pkg_apis_internalacornio_v1_EventInstance(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"type", "actor", "source", "observed"},
+				Required: []string{"type", "actor", "source"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -9,8 +9,10 @@ import (
 	"github.com/acorn-io/mink/pkg/strategy"
 	"github.com/acorn-io/mink/pkg/types"
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/channels"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
@@ -78,6 +80,10 @@ func setDefaults(ctx context.Context, e *apiv1.Event) *apiv1.Event {
 		} else {
 			logrus.Debug("Request context has no user info, creating anonymous event")
 		}
+	}
+
+	if e.Observed.IsZero() {
+		e.Observed = v1.MicroTime(metav1.NowMicro())
 	}
 
 	return e

--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -12,11 +12,20 @@ import (
 	"github.com/acorn-io/runtime/pkg/channels"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
 )
 
 type eventStrategy struct {
 	strategy.CompleteStrategy
+}
+
+func (s *eventStrategy) Create(ctx context.Context, obj types.Object) (types.Object, error) {
+	return s.CompleteStrategy.Create(ctx, setDefaults(ctx, obj.(*apiv1.Event)))
+}
+
+func (s *eventStrategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
+	return s.CompleteStrategy.Update(ctx, setDefaults(ctx, obj.(*apiv1.Event)))
 }
 
 func (s *eventStrategy) Watch(ctx context.Context, namespace string, opts storage.ListOptions) (<-chan watch.Event, error) {
@@ -58,6 +67,20 @@ func (s *eventStrategy) List(ctx context.Context, namespace string, opts storage
 	}
 
 	return q.filterList(unfiltered.(*apiv1.EventList)), nil
+}
+
+func setDefaults(ctx context.Context, e *apiv1.Event) *apiv1.Event {
+	if e.Actor == "" {
+		// Set actor from ctx if possible
+		logrus.Debug("No Actor set, attempting to set default from request context")
+		if user, ok := request.UserFrom(ctx); ok {
+			e.Actor = user.GetName()
+		} else {
+			logrus.Debug("Request context has no user info, creating anonymous event")
+		}
+	}
+
+	return e
 }
 
 type query struct {


### PR DESCRIPTION
Default events fields on create and update s.t.: 
- `actor` is to set to the request user (subject)
- `observed` is set to the current time

This will make it easier for clients to record events.