### PR TITLE
Add top-level app field to events

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -36,6 +36,10 @@ type EventInstance struct {
 	// +optional
 	Actor string `json:"actor,omitempty"`
 
+	// AppName is the name of the app that the event is related to, if any.
+	// +optional
+	AppName string `json:"appName,omitempty"`
+
 	// Source identifies the object the Event is regarding.
 	Source EventSource `json:"source"`
 

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -210,6 +210,7 @@ func recordPullEvent(ctx context.Context, recorder event.Recorder, observed meta
 		Type:        AppImagePullSuccessEventType,
 		Severity:    v1.EventSeverityInfo,
 		Description: fmt.Sprintf("Pulled %s", target.Name),
+		AppName:     obj.GetName(),
 		Source:      event.ObjectSource(obj),
 		Observed:    v1.MicroTime(observed),
 	}

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -107,8 +107,9 @@ func TestPullAppImageEvents(t *testing.T) {
 			Type:        AppImagePullSuccessEventType,
 			Severity:    v1.EventSeverityInfo,
 			Description: "Pulled acorn.io/img:1",
+			AppName:     "foo",
 			Source:      v1.EventSource{Kind: "app", Name: "foo", UID: types.UID("foo-uid")},
-			Observed:    v1.MicroTime(now),
+			Observed:    now,
 			Details: mustMapify(t, AppImagePullEventDetails{
 				ResourceVersion: "1",
 				AutoUpgrade:     false,
@@ -129,8 +130,9 @@ func TestPullAppImageEvents(t *testing.T) {
 			Type:        AppImagePullSuccessEventType,
 			Severity:    v1.EventSeverityInfo,
 			Description: "Pulled acorn.io/img:1",
+			AppName:     "foo",
 			Source:      v1.EventSource{Kind: "app", Name: "foo"},
-			Observed:    v1.MicroTime(now),
+			Observed:    now,
 			Details: mustMapify(t, AppImagePullEventDetails{
 				AutoUpgrade: true,
 				Previous:    ImageSummary{Name: "acorn.io/img:1"},
@@ -149,8 +151,9 @@ func TestPullAppImageEvents(t *testing.T) {
 			Type:        AppImagePullSuccessEventType,
 			Severity:    v1.EventSeverityInfo,
 			Description: "Pulled acorn.io/img:1",
+			AppName:     "foo",
 			Source:      v1.EventSource{Kind: "app", Name: "foo"},
-			Observed:    v1.MicroTime(now),
+			Observed:    now,
 			Details: mustMapify(t, AppImagePullEventDetails{
 				AutoUpgrade: true,
 				Target:      ImageSummary{Name: "acorn.io/img:1"},
@@ -169,6 +172,7 @@ func TestPullAppImageEvents(t *testing.T) {
 			Type:        AppImagePullFailureEventType,
 			Severity:    v1.EventSeverityError,
 			Description: "Failed to pull acorn.io/img:1",
+			AppName:     "foo",
 			Source:      v1.EventSource{Kind: "app", Name: "foo"},
 			Observed:    now,
 			Details: mustMapify(t, AppImagePullEventDetails{

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3202,6 +3202,13 @@ func schema_pkg_apis_apiacornio_v1_Event(ref common.ReferenceCallback) common.Op
 							Format:      "",
 						},
 					},
+					"appName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AppName is the name of the app that the event is related to, if any.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"source": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Source identifies the object the Event is regarding.",
@@ -7905,6 +7912,13 @@ func schema_pkg_apis_internalacornio_v1_EventInstance(ref common.ReferenceCallba
 					"actor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Actor is the ID of the entity that generated the Event. This can be the name of a particular user or controller.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"appName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AppName is the name of the app that the event is related to, if any.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/server/registry/apigroups/acorn/apps/events.go
+++ b/pkg/server/registry/apigroups/acorn/apps/events.go
@@ -82,6 +82,7 @@ func (s *eventRecordingStrategy) Create(ctx context.Context, obj types.Object) (
 		Severity:    v1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s created", obj.GetNamespace(), obj.GetName()),
+		AppName:     obj.GetName(),
 		Source:      event.ObjectSource(obj),
 		Observed:    v1.MicroTime(metav1.NowMicro()),
 	}); err != nil {
@@ -115,6 +116,7 @@ func (s *eventRecordingStrategy) Delete(ctx context.Context, obj types.Object) (
 		Severity:    v1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s deleted", obj.GetNamespace(), obj.GetName()),
+		AppName:     obj.GetName(),
 		Source:      event.ObjectSource(obj),
 		Observed:    v1.MicroTime(metav1.NowMicro()),
 	}); err != nil {
@@ -169,6 +171,7 @@ func (s *eventRecordingStrategy) Update(ctx context.Context, obj types.Object) (
 		Severity:    v1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("Spec field updated for App %s/%s", obj.GetNamespace(), obj.GetName()),
+		AppName:     obj.GetName(),
 		Source:      event.ObjectSource(obj),
 		Observed:    v1.MicroTime(metav1.NowMicro()),
 	}); err != nil {


### PR DESCRIPTION
### Description

Add an optional app field to events to support referencing associated Acorns.
