### PR TITLE
Retry building up to 5 times if it fails

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Build Acornfile",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}",
+            "args": ["build", "${input:acornfile}"], 
+        },
+        {
             "name": "Launch API",
             "type": "go",
             "request": "launch",


### PR DESCRIPTION
This helps to mask an issue where the first attempt to build would result in a "✗  ERROR:  websocket: bad handshake" message printed. Typically, subsequent attempts would succeed and this just codifies that so a user doesn't have to manually retry.

I am also adding in a VS Code launch configuration for building an Acornfile.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

