### PR TITLE
Fix bad handshake

### DIFF
--- a/pkg/controller/builder/builder.go
+++ b/pkg/controller/builder/builder.go
@@ -7,7 +7,6 @@ import (
 	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/acorn-io/runtime/pkg/system"
-	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +60,7 @@ func DeployBuilder(req router.Request, resp router.Response) error {
 
 	if *cfg.BuilderPerProject {
 		if builder.Status.UUID == "" {
-			builder.Status.UUID = uuid.New().String()
+			builder.Status.UUID = string(builder.UID)
 		}
 	} else {
 		builder.Status.UUID = ""


### PR DESCRIPTION
Prior to this PR, there was an issue where the builder would be referencing the wrong UUID (usually on the first try to build in a project). The error that this would return would look like this:

```
INFO[0004] Waiting for builder to start                 
  ✗  ERROR:  websocket: bad handshake
```


This PR addresses the core issue and adds better visibility into the actual error returned from builders.
```
INFO[0004] Waiting for builder to start                 
  ✗  ERROR:  websocket: bad handshake: status 401, invalid builder UID d180da15-08ab-42f1-8aa8-b6f73dbaf628!=01af0e70-30e6-486a-a88c-66cedd84e59e
```

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

