### PR TITLE
Break validate, unit and integration tests into seperate jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
-          cache: false
           go-version: "1.20"
-      - uses: debianmaster/actions-k3s@v1.0.5
-        with:
-          version: 'v1.27.2-k3s1'
       - run: make validate-code
       - run: make build
   unit:
@@ -36,11 +32,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
-          cache: false
           go-version: "1.20"
-      - uses: debianmaster/actions-k3s@v1.0.5
-        with:
-          version: 'v1.27.2-k3s1'
       - name: Run unit tests
         id: unit-test
         run: TEST_FLAGS="--junitfile unit-test-summary.xml" make unit
@@ -58,7 +50,6 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
-          cache: false
           go-version: "1.20"
       - uses: debianmaster/actions-k3s@v1.0.5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ on:
       - main
 
 jobs:
-  test:
+  validate:
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
@@ -27,13 +27,51 @@ jobs:
           version: 'v1.27.2-k3s1'
       - run: make validate-code
       - run: make build
+  unit:
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    needs: validate
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: "1.20"
+      - uses: debianmaster/actions-k3s@v1.0.5
+        with:
+          version: 'v1.27.2-k3s1'
+      - name: Run unit tests
+        id: unit-test
+        run: TEST_FLAGS="--junitfile unit-test-summary.xml" make unit
+      - name: Build test summary
+        uses: test-summary/action@v1
+        if: "!cancelled() && steps.unit-test.conclusion != 'skipped'"
+        with:
+          paths: unit-test-summary.xml
+  integration:
+    runs-on: buildjet-4vcpu-ubuntu-2004
+    needs: validate
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: "1.20"
+      - uses: debianmaster/actions-k3s@v1.0.5
+        with:
+          version: 'v1.27.2-k3s1'
+      - run: make build
       - run: docker buildx install
       - run: make setup-ci-image
       - run: ./bin/acorn install --image acorn:v-ci --skip-checks --acorn-dns=disabled --network-policies=true
-      - run: TEST_FLAGS="--junitfile test-summary.xml" make unit
-      - run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml" make integration
+      - name: Run integration tests
+        id: integration-tests
+        run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile integration-test-summary.xml" make integration
       - name: Build test summary
         uses: test-summary/action@v1
-        if: "!cancelled() && steps.test.conclusion != 'skipped'"
+        if: "!cancelled() && steps.integration-tests.conclusion != 'skipped'"
         with:
-          paths: test-summary.xml
+          paths: integration-test-summary.xml


### PR DESCRIPTION
We can shave some minutes off if we make more jobs, and run them asynchronously using a cache for dependencies.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

