### PR TITLE
Fix test flake when project doesn't support region

### DIFF
--- a/integration/helper/project.go
+++ b/integration/helper/project.go
@@ -51,6 +51,11 @@ func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {
 		return obj.Name == project.Name
 	})
 
+	// Wait for status default region to be set...
+	WaitForObject(t, client.Watch, &v1.ProjectInstanceList{}, project, func(obj *v1.ProjectInstance) bool {
+		return obj.Status.DefaultRegion == obj.Spec.DefaultRegion
+	})
+
 	t.Cleanup(func() {
 		err = client.Delete(ctx, project)
 		if err != nil {


### PR DESCRIPTION
We have seen a few flakes regarding projects not supporting regions. This seems to be because the app goes through the controller before the project completes. This change will ensure the project default region is set before returning the project.
