### PR TITLE
Fix secret binding to support public names (#1472)

### DIFF
--- a/pkg/controller/secrets/secret_test.go
+++ b/pkg/controller/secrets/secret_test.go
@@ -375,3 +375,7 @@ func TestSecretLabelsAnnotations(t *testing.T) {
 	assert.Contains(t, secret.Annotations, "globalfromacornfilea")
 	assert.NotContains(t, secret.Annotations, "sec1fromacornfilea")
 }
+
+func TestSecretBinding(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/binding", CreateSecrets)
+}

--- a/pkg/controller/secrets/testdata/binding/existing.yaml
+++ b/pkg/controller/secrets/testdata/binding/existing.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: existing-secret-abcdef
+  namespace: app-namespace
+  labels:
+    acorn.io/public-name: old-app.secret-name
+type: secrets.acorn.io/opaque
+data:
+  # username: myusername
+  username: bXl1c2VybmFtZQ==

--- a/pkg/controller/secrets/testdata/binding/expected.golden
+++ b/pkg/controller/secrets/testdata/binding/expected.golden
@@ -1,0 +1,18 @@
+`apiVersion: v1
+data:
+  username: bXl1c2VybmFtZQ==
+kind: Secret
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/secret-name: foo
+    acorn.io/secret-source-name: existing-secret-abcdef
+  name: foo
+  namespace: app-created-namespace
+type: secrets.acorn.io/opaque
+`

--- a/pkg/controller/secrets/testdata/binding/input.yaml
+++ b/pkg/controller/secrets/testdata/binding/input.yaml
@@ -1,0 +1,25 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  uid: 1234567890abcdef
+  name: app-name
+  namespace: app-namespace
+spec:
+  image: test
+  secrets:
+    - secret: old-app.secret-name
+      target: foo
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+    imageData:
+      images:
+        foo:
+          image: asdf
+  appSpec:
+    secrets:
+      foo:
+        type: opaque
+        data:
+          username: ""


### PR DESCRIPTION
for #1472 

Secret bindings were only looking for secrets by exact name and not by public name. This fixes that problem.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

