### PR TITLE
Fix a possible panic from occuring in buildclient.Stream

### DIFF
--- a/pkg/buildclient/client.go
+++ b/pkg/buildclient/client.go
@@ -35,11 +35,11 @@ func Stream(ctx context.Context, cwd string, streams *streams.Output, dialer Web
 	conn, response, err := dialer(ctx, wsURL(build.Status.BuildURL), map[string][]string{
 		"X-Acorn-Build-Token": {build.Status.Token},
 	})
-	if response.Body != nil {
+	if response != nil {
 		defer response.Body.Close()
 	}
 	if err != nil {
-		if response.Body == nil {
+		if response == nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Just got a panic from the check of `response.Body` being nil as the `response` was nil when using the latest main release.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

