### PR TITLE
Change logserver to only print an error log if it fails

### DIFF
--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -44,11 +44,11 @@ func (s *Server) Start() {
 // ListenAndServe is used to setup handlers and
 // start listening on the specified location
 func (s *Server) ListenAndServe() error {
-	logrus.Infof("Listening on %s", s.SocketLocation)
 	server := http.Server{}
 	http.HandleFunc("/v1/loglevel", s.loglevel)
 	socketListener, err := net.Listen("unix", s.SocketLocation)
 	if err != nil {
+		logrus.Errorf("Failed to start logserver: %v", err)
 		return err
 	}
 	return server.Serve(socketListener)


### PR DESCRIPTION
The info log that was getting printed at the start of this caused several of our e2e tests to fail last night because they were not expecting that to be present in the output. There's very little that can go wrong while starting this thing anyway, so I think it makes more sense to just log and error if there is one, and otherwise be silent.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

