### PR TITLE
Respect -j when -A is also specified (acorn ps) (#1897)

### DIFF
--- a/pkg/project/operations.go
+++ b/pkg/project/operations.go
@@ -173,7 +173,12 @@ func List(ctx context.Context, onlyUseCurrentServer bool, opts Options) (project
 		}
 	}
 
-	managerHost, _, managerHostExists := strings.Cut(cfg.CurrentProject, "/")
+	currentProject := cfg.CurrentProject
+	if opts.Project != "" {
+		currentProject = opts.Project
+	}
+
+	managerHost, _, managerHostExists := strings.Cut(currentProject, "/")
 
 	creds, err := credentials.NewLocalOnlyStore(cfg)
 	if err != nil {


### PR DESCRIPTION
Prior to this PR, when doing `acorn ps -Aj <some project>`, the apps from the CLI config's current project's server would still be printed, instead of treating the project specified by `-j` as the one by which the server would be determined. This fixes that.

for #1897

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

