### PR TITLE
Stop using init package for logserver

### DIFF
--- a/pkg/cli/apiserver.go
+++ b/pkg/cli/apiserver.go
@@ -3,7 +3,7 @@ package cli
 import (
 	minkserver "github.com/acorn-io/mink/pkg/server"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
-	_ "github.com/acorn-io/runtime/pkg/logserver/init"
+	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/server"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +40,8 @@ func (a *APIServer) Run(cmd *cobra.Command, args []string) error {
 	if err := cfg.Run(cmd.Context()); err != nil {
 		return err
 	}
+
+	logserver.StartServerWithDefaults()
 
 	<-cmd.Context().Done()
 	return cmd.Context().Err()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,7 +17,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/event"
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/acorn-io/runtime/pkg/k8sclient"
-	_ "github.com/acorn-io/runtime/pkg/logserver/init"
+	"github.com/acorn-io/runtime/pkg/logserver"
 	"github.com/acorn-io/runtime/pkg/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -105,6 +105,8 @@ func (c *Controller) Start(ctx context.Context) error {
 
 		autoupgrade.StartSync(ctx, c.Router.Backend())
 	}()
+
+	logserver.StartServerWithDefaults()
 
 	return c.Router.Start(ctx)
 }


### PR DESCRIPTION
The logserver was getting launched on every single CLI command due to the init function, so we are switching back to explicitly launching it where we need it. The init package will still be useful in other repos.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

