### PR TITLE
Fix RBAC and local image resolution for acorn copy

### DIFF
--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -57,6 +57,8 @@ func (a *ImageCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !a.AllTags {
+		// Check if the source argument matches the name of a local image, and use it if it does.
+		// If there is an error, ignore it and move on, assuming the argument is a remote image name.
 		if _, err := c.ImageGet(cmd.Context(), args[0]); err == nil {
 			return a.copyLocalToRemote(cmd, c, args, creds)
 		}

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -93,7 +93,6 @@ func (a *ImageCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return progressbar.Print(progress)
-
 }
 
 func (a *ImageCopy) copyLocalToRemote(cmd *cobra.Command, c client.Client, args []string, creds *credentials.Store) error {

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -58,7 +58,7 @@ func (a *ImageCopy) Run(cmd *cobra.Command, args []string) error {
 
 	if !a.AllTags {
 		// Check if the source argument matches the name of a local image, and use it if it does.
-		// If there is an error, ignore it and move on, assuming the argument is a remote image name.
+		// If there is an error, ignore it and move on, treating the argument as a remote image name.
 		if _, err := c.ImageGet(cmd.Context(), args[0]); err == nil {
 			return a.copyLocalToRemote(cmd, c, args, creds)
 		}

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -123,6 +123,7 @@ var (
 				Resources: []string{
 					"images/push",
 					"images/pull",
+					"images/copy",
 					"containerreplicas/exec",
 					"secrets/reveal",
 				},


### PR DESCRIPTION
This fixes two issues related to `acorn copy`:

- RBAC was previously not set for it at all
- The CLI would potentially utilize credentials for Docker Hub when the user was actually referring to a local image, which would lead to errors

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

