### PR TITLE
Decrease log noise for event watch

### DIFF
--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -51,8 +51,8 @@ func (s *eventStrategy) Watch(ctx context.Context, namespace string, opts storag
 	go func() {
 		defer close(result)
 
-		if err := q.filterChannel(ctx, events, result); !channels.NilOrCanceled(err) {
-			logrus.Warnf("error forwarding events: [%v]", err)
+		if err := q.filterChannel(ctx, events, result); !channels.NilOrCanceled(err) && !errors.Is(err, context.DeadlineExceeded) {
+			logrus.WithError(err).Warn("error forwarding events")
 		}
 	}()
 


### PR DESCRIPTION
Omit error logs for event watch requests that exceed their context
deadline. This reduces log noise when clients don't close watch requests properly.

Addresses #1956 