### PR TITLE
Let job fail three times before breaking the watch in acorn run

### DIFF
--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -52,7 +52,7 @@ func waitForApp(ctx context.Context, c client.Client, app *apiv1.App) (*apiv1.Ap
 			return true, nil
 		}
 		for name, job := range app.Status.AppStatus.Jobs {
-			if !job.Ready && job.RunningCount == 0 && job.ErrorCount > 0 && len(job.ErrorMessages) > 0 {
+			if !job.Ready && job.RunningCount == 0 && job.ErrorCount > 2 && len(job.ErrorMessages) > 0 {
 				return false, fmt.Errorf("job %s failed: %s", name, job.ErrorMessages)
 			}
 		}


### PR DESCRIPTION
We decided earlier today to change this so that the job has to fail three times before we quit watching/waiting on the new app after running `acorn run`.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

