### PR TITLE
Fix openapi schema generation for event fields

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -79,6 +79,16 @@ func NowMicro() MicroTime {
 	return NewMicroTime(time.Now())
 }
 
+// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+//
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ MicroTime) OpenAPISchemaType() []string { return []string{"string"} }
+
+// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+func (_ MicroTime) OpenAPISchemaFormat() string { return "date-time" }
+
 // DeepCopyInto returns a deep-copy of the MicroTime value.  The underlying time.Time
 // type is effectively immutable in the time API, so it is safe to
 // copy-by-assign, despite the presence of (unexported) Pointer fields.
@@ -108,6 +118,16 @@ func (t *MicroTime) UnmarshalJSON(b []byte) error {
 
 	t.Time = pt.Local()
 	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t MicroTime) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		// Encode unset/nil objects as JSON's "null".
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(t.UTC().Format(metav1.RFC3339Micro))
 }
 
 const (

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -8,8 +8,9 @@
 package generated
 
 import (
+	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	common "k8s.io/kube-openapi/pkg/common"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -8744,17 +8745,8 @@ func schema_pkg_apis_internalacornio_v1_MicroTime(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "MicroTime represents a time with microsecond level precision.\n\nIt extends metav1.MicroTime to allow unmarshaling from RFC3339.",
-				Type:        []string{"object"},
-				Properties: map[string]spec.Schema{
-					"Time": {
-						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Type:    []string{"string"},
-							Format:  "date-time",
-						},
-					},
-				},
-				Required: []string{"Time"},
+				Type:        v1.MicroTime{}.OpenAPISchemaType(),
+				Format:      v1.MicroTime{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -25813,8 +25805,8 @@ func schema_pkg_apis_meta_v1_Duration(ref common.ReferenceCallback) common.OpenA
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-				Type:        v1.Duration{}.OpenAPISchemaType(),
-				Format:      v1.Duration{}.OpenAPISchemaFormat(),
+				Type:        metav1.Duration{}.OpenAPISchemaType(),
+				Format:      metav1.Duration{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -26435,8 +26427,8 @@ func schema_pkg_apis_meta_v1_MicroTime(ref common.ReferenceCallback) common.Open
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "MicroTime is version of Time with microsecond level precision.",
-				Type:        v1.MicroTime{}.OpenAPISchemaType(),
-				Format:      v1.MicroTime{}.OpenAPISchemaFormat(),
+				Type:        metav1.MicroTime{}.OpenAPISchemaType(),
+				Format:      metav1.MicroTime{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -27345,8 +27337,8 @@ func schema_pkg_apis_meta_v1_Time(ref common.ReferenceCallback) common.OpenAPIDe
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-				Type:        v1.Time{}.OpenAPISchemaType(),
-				Format:      v1.Time{}.OpenAPISchemaFormat(),
+				Type:        metav1.Time{}.OpenAPISchemaType(),
+				Format:      metav1.Time{}.OpenAPISchemaFormat(),
 			},
 		},
 	}

--- a/pkg/openapi/map.go
+++ b/pkg/openapi/map.go
@@ -10,7 +10,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 	result := generated.GetOpenAPIDefinitions(ref)
 	for _, v := range result {
 		for name := range v.Schema.SchemaProps.Properties {
-			if name == "deployArgs" || name == "buildArgs" || name == "params" {
+			if name == "deployArgs" || name == "buildArgs" || name == "params" || name == "details" {
 				v.Schema.SchemaProps.Properties[name] = spec.Schema{
 					VendorExtensible: spec.VendorExtensible{
 						Extensions: spec.Extensions{


### PR DESCRIPTION
Set formatting and extensions for the observed and details fields
respectively. This prevents field manager from complaining when events
are created.

Addresses #1672 