### PR TITLE
fix: properly translate acorn run/update errors (#1698 + #1712)

### DIFF
--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -242,13 +242,8 @@ func translateErr(err error) error {
 		return err
 	}
 
-	if e := translatePermissions(err); e != nil {
-		return e
-	}
-
-	if e := TranslateNotAllowed(err); e != nil {
-		return e
-	}
+	err = translatePermissions(err)
+	err = TranslateNotAllowed(err)
 
 	return err
 }
@@ -261,7 +256,7 @@ func TranslateNotAllowed(err error) error {
 		return &imageallowrules.ErrImageNotAllowed{} // we could actually extract the full error (including) image here, but that's probably not required
 	}
 
-	return nil
+	return err
 }
 
 func translatePermissions(err error) error {


### PR DESCRIPTION
Ref #1698 + #1712

Fixes a regression introduced by a fixed regression that I introduced like 2 months ago :grimacing: 

Should now properly handle permission and not-allowed errors on acorn run/update.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

