### PR TITLE
change: make acorn exec -c flag work for jobs and sidecars as well (#1798)

### DIFF
--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -84,7 +84,7 @@ func filterContainers(containerName string, containers []apiv1.ContainerReplica)
 	for _, c := range containers {
 		if containerName == "" {
 			result = append(result, c)
-		} else if c.Spec.ContainerName == containerName {
+		} else if c.Spec.ContainerName == containerName || c.Spec.JobName == containerName || c.Spec.SidecarName == containerName {
 			result = append(result, c)
 			break
 		} else if c.Name == containerName {


### PR DESCRIPTION
Ref #1798

Still ugly though

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

