### PR TITLE
Fix volume class determination when binding an existing volume

### DIFF
--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/existing.yaml
@@ -26,3 +26,9 @@ spec:
     type: DirectoryOrCreate
 status:
   phase: Released
+
+---
+apiVersion: internal.admin.acorn.io/v1
+kind: ClusterVolumeClassInstance
+metadata:
+  name: custom-class

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/existing.yaml
@@ -32,3 +32,4 @@ apiVersion: internal.admin.acorn.io/v1
 kind: ClusterVolumeClassInstance
 metadata:
   name: custom-class
+storageClassName: foo

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
@@ -110,7 +110,7 @@ spec:
   resources:
     requests:
       storage: 5M
-  storageClassName: ""
+  storageClassName: foo
   volumeName: existing-foo
 status: {}
 

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
@@ -110,6 +110,7 @@ spec:
   resources:
     requests:
       storage: 5M
+  storageClassName: ""
   volumeName: existing-foo
 status: {}
 

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/existing.yaml
@@ -26,3 +26,9 @@ spec:
     type: DirectoryOrCreate
 status:
   phase: Released
+
+---
+apiVersion: internal.admin.acorn.io/v1
+kind: ClusterVolumeClassInstance
+metadata:
+  name: custom-class

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/existing.yaml
@@ -32,3 +32,4 @@ apiVersion: internal.admin.acorn.io/v1
 kind: ClusterVolumeClassInstance
 metadata:
   name: custom-class
+storageClassName: foo

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
@@ -112,7 +112,7 @@ spec:
   resources:
     requests:
       storage: 5M
-  storageClassName: ""
+  storageClassName: foo
   volumeName: existing-foo
 status: {}
 

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
@@ -112,6 +112,7 @@ spec:
   resources:
     requests:
       storage: 5M
+  storageClassName: ""
   volumeName: existing-foo
 status: {}
 

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -178,6 +178,7 @@ func toPVCs(req router.Request, appInstance *v1.AppInstance) (result []kclient.O
 				}
 			} else {
 				// User did not specify a class with the binding, so get the class from the existing volume.
+				pvc.Spec.StorageClassName = &pv.Spec.StorageClassName
 				pvc.Labels[labels.AcornVolumeClass] = pv.Labels[labels.AcornVolumeClass]
 			}
 

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -168,18 +168,16 @@ func toPVCs(req router.Request, appInstance *v1.AppInstance) (result []kclient.O
 			pvc.Spec.VolumeName = pv.Name
 			pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *v1.MinSize
 
-			if volumeBinding.Class != "" {
-				// Specifically allowing volume classes that are inactive.
-				if volClass, ok := volumeClasses[volumeBinding.Class]; !ok {
-					return nil, fmt.Errorf("%s has an invalid volume class %s", vol, volumeBinding.Class)
-				} else {
-					pvc.Spec.StorageClassName = &volClass.StorageClassName
-					pvc.Labels[labels.AcornVolumeClass] = volClass.Name
-				}
+			volumeClassName := volumeBinding.Class
+			if volumeClassName == "" {
+				volumeClassName = pv.Labels[labels.AcornVolumeClass]
+			}
+
+			if volClass, ok := volumeClasses[volumeClassName]; !ok {
+				return nil, fmt.Errorf("%s has an invalid volume class %s", vol, volumeBinding.Class)
 			} else {
-				// User did not specify a class with the binding, so get the class from the existing volume.
-				pvc.Spec.StorageClassName = &pv.Spec.StorageClassName
-				pvc.Labels[labels.AcornVolumeClass] = pv.Labels[labels.AcornVolumeClass]
+				pvc.Spec.StorageClassName = &volClass.StorageClassName
+				pvc.Labels[labels.AcornVolumeClass] = volClass.Name
 			}
 
 			if volumeBinding.Size != "" {


### PR DESCRIPTION
I found this bug while troubleshooting one of our failing tests.

Prior to this PR, if the volume class is not determined as part of the `-v` argument in `acorn run`, it would be assumed based on the label on the existing PV, and then that label would be set on the new PVC that binds the PV. However, the code fails to properly set the `storageClassName` spec field on the PVC, and it takes the default storage class, leading to a possible mismatch and the inability to actually bind the volume. This change makes sure that the storage class is set based on the volume class under all circumstances.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

(Our e2e tests cover this.)
