### PR TITLE
Add create perms for events to edit role

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -108,6 +108,7 @@ var (
 					"apps/confirmupgrade",
 					"apps/pullimage",
 					"apps/ignorecleanup",
+					"events",
 				},
 			},
 			{


### PR DESCRIPTION
Allow users with the edit role to create events. This lets users
run service acorns that create events.

Required for https://github.com/acorn-io/manager/issues/668
