### PR TITLE
expand testing on acorn run input edge cases (#1942)

### DIFF
--- a/pkg/buildclient/client.go
+++ b/pkg/buildclient/client.go
@@ -35,7 +35,7 @@ func Stream(ctx context.Context, cwd string, streams *streams.Output, dialer Web
 	conn, response, err := dialer(ctx, wsURL(build.Status.BuildURL), map[string][]string{
 		"X-Acorn-Build-Token": {build.Status.Token},
 	})
-	if response != nil {
+	if response != nil && response.Body != nil {
 		defer response.Body.Close()
 	}
 	if err != nil {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -186,6 +186,28 @@ func TestRun(t *testing.T) {
 			wantOut: "open Acornfile: no such file or directory",
 		},
 		{
+			name: "acorn_run_pointed_at_nothing", fields: fields{
+				All:   false,
+				Force: true,
+			},
+
+			args: args{
+				args: []string{},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+						},
+					}, nil)
+			},
+			wantErr: true,
+			wantOut: "open Acornfile: no such file or directory",
+		},
+		{
 			name: "acorn_run_points_at_file", fields: fields{
 				All:   false,
 				Force: true,


### PR DESCRIPTION
Based on behavior observed in #1942 I've added an additional check to the functional code to prevent any future panics in this code location. A new unit test was added to verify the behavior of the `acorn run` command when no file or directory is supplied.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

