### PR TITLE
Add TCP protocol to published UDP ports for healthchecks to pass

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -252,6 +252,15 @@ func ForService(req router.Request, resp router.Response) error {
 			Protocol: &proto,
 			Port:     &targetPort,
 		})
+
+		// Healthchecks in AWS that are performed on LoadBalancer Services use TCP even if the port is UDP,
+		// so we need to add TCP also in that case.
+		if proto == corev1.ProtocolUDP {
+			netPolPorts = append(netPolPorts, networkingv1.NetworkPolicyPort{
+				Protocol: z.Pointer(corev1.ProtocolTCP),
+				Port:     &targetPort,
+			})
+		}
 	}
 
 	// build the NetPol

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/service/expected.golden
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/service/expected.golden
@@ -16,6 +16,8 @@ spec:
       protocol: TCP
     - port: 9090
       protocol: UDP
+    - port: 9090
+      protocol: TCP
   podSelector:
     matchLabels:
       acorn.io/app-name: my-app


### PR DESCRIPTION
This should fix the issue we were seeing with published UDP ports. AWS LoadBalancer healthchecks were using TCP even though the port they are forwarding traffic to is UDP, so the NetworkPolicies were blocking it.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

