### PR TITLE
Check for production acorn dns serves

### DIFF
--- a/pkg/controller/tls/letsencrypt.go
+++ b/pkg/controller/tls/letsencrypt.go
@@ -360,10 +360,6 @@ func (u *LEUser) mustRenew(sec *corev1.Secret) bool {
 }
 
 func (u *LEUser) dnsChallenge(ctx context.Context, domain string) (*certificate.Resource, error) {
-	if !strings.HasSuffix(domain, "oss-acorn.io") {
-		return nil, fmt.Errorf("ACME DNS challenge is only supported for oss-acorn.io subdomains, not for %s", domain)
-	}
-
 	client, err := u.leClient()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
from @cjellick 

>we only try to get a wild card cert when we are getting a domain that was provisioned by acorn-dns (because we found it in the acorn-dns secret)

So we should get rid of the check since at this point we are sure that this domain is provisioned through acorn-dns.