### PR TITLE
Fix regression causing event tail option to be ignored

### DIFF
--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -184,12 +184,7 @@ func (q query) filter(events ...apiv1.Event) []apiv1.Event {
 		return events[i].Observed.Before(events[j].Observed.Time)
 	})
 
-	tail := len(events)
-	if q.tail > 0 && q.tail < int64(tail) {
-		tail = int(q.tail)
-	}
-
-	results := make([]apiv1.Event, 0, tail)
+	results := make([]apiv1.Event, 0, len(events))
 	for _, event := range events {
 		observed := event.Observed
 		if q.afterWindow(observed) {
@@ -212,7 +207,12 @@ func (q query) filter(events ...apiv1.Event) []apiv1.Event {
 		return nil
 	}
 
-	return results
+	tail := len(results)
+	if q.tail > 0 && q.tail < int64(tail) {
+		tail = int(q.tail)
+	}
+
+	return results[len(results)-tail:]
 }
 
 // stripQuery extracts the query from the given options, returning the query and new options sans the query.

--- a/pkg/server/registry/apigroups/acorn/events/strategy_test.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/z"
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,98 @@ func TestParseTimeBound(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.want.parsed, parsed)
+		})
+	}
+}
+
+func TestQueryFilter(t *testing.T) {
+	ts := internalv1.NowMicro()
+	tests := []struct {
+		name  string
+		query query
+		args  []apiv1.Event
+		want  []apiv1.Event
+	}{
+		{
+			name: "Tail less than length",
+			query: query{
+				tail: 1,
+			},
+			args: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+			want: []apiv1.Event{
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+		},
+		{
+			name: "Tail more than length",
+			query: query{
+				tail: 3,
+			},
+			args: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+			want: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+		},
+		{
+			name: "Tail since",
+			query: query{
+				tail:  2,
+				since: z.Pointer(internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))),
+			},
+			args: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+			want: []apiv1.Event{
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+		},
+		{
+			name: "Tail until",
+			query: query{
+				tail:  2,
+				until: z.Pointer(internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))),
+			},
+			args: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+				{Observed: internalv1.NewMicroTime(ts.Add(2 * time.Microsecond))},
+			},
+			want: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+			},
+		},
+		{
+			name: "Tail window",
+			query: query{
+				tail:  2,
+				since: z.Pointer(internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))),
+				until: z.Pointer(internalv1.NewMicroTime(ts.Add(3 * time.Microsecond))),
+			},
+			args: []apiv1.Event{
+				{Observed: ts},
+				{Observed: internalv1.NewMicroTime(ts.Add(1 * time.Microsecond))},
+				{Observed: internalv1.NewMicroTime(ts.Add(2 * time.Microsecond))},
+				{Observed: internalv1.NewMicroTime(ts.Add(3 * time.Microsecond))},
+				{Observed: internalv1.NewMicroTime(ts.Add(4 * time.Microsecond))},
+			},
+			want: []apiv1.Event{
+				{Observed: internalv1.NewMicroTime(ts.Add(2 * time.Microsecond))},
+				{Observed: internalv1.NewMicroTime(ts.Add(3 * time.Microsecond))},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, tt.query.filter(tt.args...))
 		})
 	}
 }


### PR DESCRIPTION
Ensure the result set is pruned to the desired length, indicated by the `--tail` option of the `acorn events` subcommand, when listing events.

This fixes a regression which caused the option to be ignored.