### PR TITLE
Fix parsing for event time bounds (#1805)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/events/strategy_test.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy_test.go
@@ -1,0 +1,68 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/z"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTimeBound(t *testing.T) {
+	ts := internalv1.NowMicro()
+	type args struct {
+		raw string
+		now internalv1.MicroTime
+	}
+	type want struct {
+		parsed *internalv1.MicroTime
+		err    assert.ErrorAssertionFunc
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Go duration",
+			args: args{
+				raw: "1m",
+				now: ts,
+			},
+			want: want{
+				parsed: z.Pointer(internalv1.NewMicroTime(ts.Add(-1 * time.Minute))),
+				err:    assert.NoError,
+			},
+		},
+		{
+			name: "Without Z",
+			args: args{
+				raw: "2023-01-09T12:32:00",
+			},
+			want: want{
+				parsed: z.Pointer(internalv1.NewMicroTime(z.MustBe(time.Parse(time.RFC3339, "2023-01-09T12:32:00Z")))),
+				err:    assert.NoError,
+			},
+		},
+		{
+			name: "With Z",
+			args: args{
+				raw: "2023-01-09T12:32:00Z",
+			},
+			want: want{
+				parsed: z.Pointer(internalv1.NewMicroTime(z.MustBe(time.Parse(time.RFC3339, "2023-01-09T12:32:00Z")))),
+				err:    assert.NoError,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parseTimeBound(tt.args.raw, tt.args.now)
+			if !tt.want.err(t, err) {
+				return
+			}
+			assert.Equal(t, tt.want.parsed, parsed)
+		})
+	}
+}


### PR DESCRIPTION
- When given a duration for `until`, subtract it from the current time
  to calculate an upper bound for time filtering; e.g. `acorn events
  --until 1hr`, evaluates to "events observed more than 1 hour ago"
- Support omitting the timezone offset "Z"; e.g. parse "2023-01-09T12:32:00"
  as "2023-01-09T12:32:00Z"
  
Addresses https://github.com/acorn-io/runtime/issues/1805#issuecomment-1639080707