### PR TITLE
fix: properly handle image-not-allowed errors for normal tags and autoupgrade patterns (#1698 + #1970 + #1409)

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -284,9 +284,10 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	image, deployArgs, err := imageSource.GetImageAndDeployArgs(cmd.Context(), c)
 	if err != nil {
-		if naErr := client.TranslateNotAllowed(err); naErr != nil {
+		err = client.TranslateNotAllowed(err)
+		if naErr := (*imageallowrules.ErrImageNotAllowed)(nil); errors.As(err, &naErr) {
 			if _, isPattern := autoupgrade.AutoUpgradePattern(image); isPattern {
-				naErr.(*imageallowrules.ErrImageNotAllowed).Image = image
+				err.(*imageallowrules.ErrImageNotAllowed).Image = image
 				logrus.Debugf("Valid tags for pattern %s were not allowed to run: %v", image, naErr)
 				if choice, promptErr := rulerequest.HandleNotAllowed(s.Dangerous, image); promptErr != nil {
 					return promptErr

--- a/pkg/imageallowrules/imageallowrules.go
+++ b/pkg/imageallowrules/imageallowrules.go
@@ -117,7 +117,7 @@ iarLoop:
 		// Any verification error or failed verification issue will skip on to the next IAR
 		for _, rule := range imageAllowRule.Signatures.Rules {
 			if err := cosign.EnsureReferences(ctx, c, image, &verifyOpts); err != nil {
-				return fmt.Errorf("error ensuring references for image %s: %w", image, err)
+				return err
 			}
 			verifyOpts.AnnotationRules = rule.Annotations
 

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -159,7 +159,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 
 		if !disableCheckImageAllowRules {
 			if err := s.checkImageAllowed(ctx, app.Namespace, checkImage); err != nil {
-				result = append(result, field.Invalid(field.NewPath("spec", "image"), app.Spec.Image, err.Error()))
+				result = append(result, field.Forbidden(field.NewPath("spec", "image"), fmt.Sprintf("%s not allowed to run: %s", app.Spec.Image, err.Error())))
 				return
 			}
 		}


### PR DESCRIPTION
Ref #1968 + #1970 + #1409

Fixes 2 ways for the CLI to panic when running an app against an IAR enabled setup.


### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

