### PR TITLE
change: if default storage class exists use 10Gi PVC for registry (#1974)

### DIFF
--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -39,7 +39,7 @@ func registryService(namespace string) []client.Object {
 	}
 }
 
-func registryDeployment(namespace, registryImage string, requirements corev1.ResourceRequirements) []client.Object {
+func registryDeployment(namespace, registryImage string, requirements corev1.ResourceRequirements, volumeSource corev1.VolumeSource) []client.Object {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      system.RegistryName,
@@ -117,10 +117,8 @@ func registryDeployment(namespace, registryImage string, requirements corev1.Res
 					},
 					Volumes: []corev1.Volume{
 						{
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-							Name: "registry",
+							VolumeSource: volumeSource,
+							Name:         "registry",
 						},
 					},
 					Tolerations: []corev1.Toleration{

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -22,6 +22,7 @@ const (
 
 var (
 	RegistryName                   = "registry"
+	RegistryPVCSize                = "10Gi"
 	RegistryPort                   = 5000
 	BuildKitName                   = "buildkitd"
 	ControllerName                 = "acorn-controller"

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -173,3 +173,18 @@ func CopyVolumeDefaults(volumeRequest v1.VolumeRequest, volumeBinding v1.VolumeB
 
 	return volumeRequest
 }
+
+func FindDefaultStorageClass(ctx context.Context, c client.Reader) (string, error) {
+	storageClasses := &storagev1.StorageClassList{}
+	if err := c.List(ctx, storageClasses); err != nil {
+		return "", err
+	}
+
+	for _, sc := range storageClasses.Items {
+		if sc.Annotations[storage.IsDefaultStorageClassAnnotation] == "true" {
+			return sc.Name, nil
+		}
+	}
+
+	return "", nil
+}


### PR DESCRIPTION
Ref #1974 

So far, the registry was backed by an EmptyDir, so restarts/redeployments, e.g. as part of an upgrade cleared the registry and we would end up with image resources backed by nothing in the registry.
With this PR we get a basic 10Gi PVC backing the registry if there's a default storage class defined upon installation.
As discussed, there are not configuration options available.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

