### PR TITLE
Remove non-HTTP ports from ExternalName Services

### DIFF
--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -67,3 +67,13 @@ func ToServicePort(port v1.PortDef) corev1.ServicePort {
 	}
 	return servicePort
 }
+
+func RemoveNonHTTPPorts(ports []corev1.ServicePort) []corev1.ServicePort {
+	var result []corev1.ServicePort
+	for _, port := range ports {
+		if port.Protocol == corev1.ProtocolTCP && port.AppProtocol != nil && strings.ToUpper(*port.AppProtocol) == "HTTP" {
+			result = append(result, port)
+		}
+	}
+	return result
+}

--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -68,6 +68,11 @@ func ToServicePort(port v1.PortDef) corev1.ServicePort {
 	return servicePort
 }
 
+// RemoveNonHTTPPorts removes all ports from the slice that do not have AppProtocol set to HTTP.
+// This is useful for ExternalName Services, which cause problems for Istio if they have non-HTTP ports.
+// See https://github.com/istio/istio/issues/20703.
+// Kubernetes does not care about ports on ExternalName Services, so it is safe to remove them.
+// Traefik does care about ports on ExternalName Services, but only on HTTP ones.
 func RemoveNonHTTPPorts(ports []corev1.ServicePort) []corev1.ServicePort {
 	var result []corev1.ServicePort
 	for _, port := range ports {


### PR DESCRIPTION
This should satisfy both Istio and Traefik. Traefik requires ports to be specified on HTTP ExternalName Services in order for ingress to function properly. Istio does a lot of damage if any ports are specified on TCP/UDP (but not HTTP) ExternalName Services, as documented in this issue: https://github.com/istio/istio/issues/20703

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

