### PR TITLE
Use build jet cache for test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,10 +54,21 @@ jobs:
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
           version: 'v1.27.2-k3s1'
-      - run: make build
-      - run: docker buildx install
-      - run: make setup-ci-image
-      - run: ./bin/acorn install --image acorn:v-ci --skip-checks --acorn-dns=disabled --network-policies=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: acorn:v-ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Load image into k3s
+        run: docker save acorn:v-ci | docker exec -i $(docker ps | grep k3s | awk '{print $1}') ctr --address /run/k3s/containerd/containerd.sock images import -
+      - name: Build CI acorn binary
+        run: make build
+      - name: Install acorn with ci image
+        run: ./bin/acorn install --image acorn:v-ci --skip-checks --acorn-dns=disabled --network-policies=true
       - name: Run integration tests
         id: integration-tests
         run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile integration-test-summary.xml" make integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,17 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
+      - name: Setup Golang caches
+        uses: buildjet/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
       - run: make validate-code
       - run: make build
   unit:
@@ -32,7 +42,17 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
+      - name: Setup Golang caches
+        uses: buildjet/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
       - name: Run unit tests
         id: unit-test
         run: TEST_FLAGS="--junitfile unit-test-summary.xml" make unit
@@ -50,7 +70,17 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
+      - name: Setup Golang caches
+        uses: buildjet/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
           version: 'v1.27.2-k3s1'

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ mocks:
 image:
 	docker build .
 
-setup-ci-image:
-	docker build -t acorn:v-ci .
-	docker save acorn:v-ci | docker exec -i $$(docker ps | grep k3s | awk '{print $$1}') ctr --address /run/k3s/containerd/containerd.sock images import -
-
 GOLANGCI_LINT_VERSION ?= v1.51.1
 setup-env: 
 	if ! command -v golangci-lint &> /dev/null; then \


### PR DESCRIPTION
This PR uses Buildjet's cache for docker images and Golang dependencies. This should provide significant speed-up to our workflows when we have cache hits.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

