### PR TITLE
Adjust validation for new project paradigms

### DIFF
--- a/pkg/apis/api.acorn.io/v1/region.go
+++ b/pkg/apis/api.acorn.io/v1/region.go
@@ -9,6 +9,7 @@ const (
 	RegionConditionClusterReady = "ClusterReady"
 
 	LocalRegion = "local"
+	AllRegions  = "*"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/internal.acorn.io/v1/projectinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/projectinstance.go
@@ -20,8 +20,11 @@ type ProjectInstanceSpec struct {
 }
 
 type ProjectInstanceStatus struct {
-	Namespace        string   `json:"namespace,omitempty"`
-	DefaultRegion    string   `json:"defaultRegion,omitempty"`
+	Namespace     string `json:"namespace,omitempty"`
+	DefaultRegion string `json:"defaultRegion,omitempty"`
+	// SupportedRegions on the status field should be an explicit list of supported regions.
+	// That is, if the user specifies "*" for supported regions, then the status value should be the list of all regions.
+	// This is to avoid having to make another call to explicitly list all regions.
 	SupportedRegions []string `json:"supportedRegions,omitempty"`
 }
 
@@ -44,7 +47,7 @@ func (in *ProjectInstance) GetSupportedRegions() []string {
 func (in *ProjectInstance) SetDefaultRegion(region string) {
 	if in.Spec.DefaultRegion == "" && len(in.Spec.SupportedRegions) == 0 {
 		in.Status.DefaultRegion = region
-		in.Status.SupportedRegions = []string{region}
+		in.Status.SupportedRegions = []string{"*"}
 	} else {
 		// Set the status values to the provided spec values.
 		// The idea here is that internally, we only need to check the status values.

--- a/pkg/client/project.go
+++ b/pkg/client/project.go
@@ -37,7 +37,7 @@ func (c *DefaultClient) ProjectCreate(ctx context.Context, name, defaultRegion s
 	}
 	if defaultRegion != "" {
 		project.Spec.DefaultRegion = defaultRegion
-		if !slices.Contains(supportedRegions, defaultRegion) {
+		if !slices.Contains(supportedRegions, defaultRegion) && !slices.Contains(supportedRegions, apiv1.AllRegions) {
 			supportedRegions = append([]string{defaultRegion}, supportedRegions...)
 		}
 	}
@@ -57,7 +57,7 @@ func (c *DefaultClient) ProjectUpdate(ctx context.Context, project *apiv1.Projec
 			project.Spec.SupportedRegions = supportedRegions
 		}
 	}
-	if project.Spec.DefaultRegion != "" && !slices.Contains(project.Spec.SupportedRegions, project.Spec.DefaultRegion) {
+	if project.Spec.DefaultRegion != "" && !slices.Contains(project.Spec.SupportedRegions, project.Spec.DefaultRegion) && !slices.Contains(project.Spec.SupportedRegions, apiv1.AllRegions) {
 		project.Spec.SupportedRegions = append(project.Spec.SupportedRegions, project.Spec.DefaultRegion)
 	}
 

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -9437,7 +9437,8 @@ func schema_pkg_apis_internalacornio_v1_ProjectInstanceStatus(ref common.Referen
 					},
 					"supportedRegions": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "SupportedRegions on the status field should be an explicit list of supported regions. That is, if the user specifies \"*\" for supported regions, then the status value should be the list of all regions. This is to avoid having to make another call to explicitly list all regions.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{

--- a/pkg/project/handlers_test.go
+++ b/pkg/project/handlers_test.go
@@ -18,6 +18,7 @@ func TestSetProjectSupportedRegions(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/no-default", SetProjectSupportedRegions)
 	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-supported-regions", SetProjectSupportedRegions)
 	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-default-and-supported", SetProjectSupportedRegions)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/all-supported-regions-with-default", SetProjectSupportedRegions)
 }
 
 func TestCreateNamespace(t *testing.T) {

--- a/pkg/project/testdata/setsupportedregions/all-supported-regions-with-default/expected.golden
+++ b/pkg/project/testdata/setsupportedregions/all-supported-regions-with-default/expected.golden
@@ -1,0 +1,15 @@
+`apiVersion: internal.acorn.io/v1
+kind: ProjectInstance
+metadata:
+  creationTimestamp: null
+  name: acorn
+spec:
+  defaultRegion: other-region
+  supportedRegions:
+  - '*'
+status:
+  defaultRegion: other-region
+  supportedRegions:
+  - other-region
+  - local
+`

--- a/pkg/project/testdata/setsupportedregions/all-supported-regions-with-default/input.yaml
+++ b/pkg/project/testdata/setsupportedregions/all-supported-regions-with-default/input.yaml
@@ -1,0 +1,8 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: acorn
+spec:
+  defaultRegion: other-region
+  supportedRegions:
+    - "*"


### PR DESCRIPTION
It was decided that if a user doesn't specify any region information for a project, then the project supports all region by default. Additionally, it is now possible that a user can specify that a project supports all regions by using the '*' value.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

