### PR TITLE
Update auto-upgrade logic to have less assumptions

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -319,10 +319,12 @@ func AutoUpgradePattern(image string) (string, bool) {
 	return tag, strings.ContainsAny(tag, "#*")
 }
 
-// ImpliedAutoUpgrade returns boolean indicating if auto-upgrade is implied either
-// by a pattern in the app.Spec.image or app.Spec.AutoUpgradeInterval being specified.
-func ImpliedAutoUpgrade(interval, image string) bool {
-	if _, isPattern := AutoUpgradePattern(image); isPattern || interval != "" {
+// ImpliedAutoUpgrade returns boolean indicating if auto-upgrade is implied either:
+// 1. A pattern specified in the image
+// 2. A non-empty interval
+// 3. app.Spec.NotifyUpgrade set to true
+func ImpliedAutoUpgrade(image, interval string, notify bool) bool {
+	if _, isPattern := AutoUpgradePattern(image); isPattern || interval != "" || notify {
 		return true
 	}
 	return false
@@ -330,7 +332,7 @@ func ImpliedAutoUpgrade(interval, image string) bool {
 
 func Mode(appSpec v1.AppInstanceSpec) (string, bool) {
 	_, isPat := AutoUpgradePattern(appSpec.Image)
-	on := appSpec.GetAutoUpgrade() || appSpec.GetNotifyUpgrade() || isPat
+	on := appSpec.GetAutoUpgrade() || isPat
 
 	if !on {
 		return "", false

--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -319,11 +319,11 @@ func AutoUpgradePattern(image string) (string, bool) {
 	return tag, strings.ContainsAny(tag, "#*")
 }
 
-// ImpliedAutoUpgrade returns boolean indicating if auto-upgrade is implied either:
+// Implied returns a boolean indicating if auto-upgrade is implied by either:
 // 1. A pattern specified in the image
 // 2. A non-empty interval
 // 3. app.Spec.NotifyUpgrade set to true
-func ImpliedAutoUpgrade(image, interval string, notify bool) bool {
+func Implied(image, interval string, notify bool) bool {
 	if _, isPattern := AutoUpgradePattern(image); isPattern || interval != "" || notify {
 		return true
 	}

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"io"
 
+	"github.com/acorn-io/runtime/pkg/autoupgrade"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/dev"
 	"github.com/acorn-io/runtime/pkg/imagesource"
+	"github.com/acorn-io/z"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +64,11 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
+	}
+
+	// If auto-upgrade is not set, set it to the implied value.
+	if !z.Dereference(opts.AutoUpgrade) {
+		opts.AutoUpgrade = z.Pointer(autoupgrade.ImpliedAutoUpgrade(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
 	}
 
 	return dev.Dev(cmd.Context(), c, &dev.Options{

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -68,7 +68,7 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 
 	// If auto-upgrade is not set, set it to the implied value.
 	if !z.Dereference(opts.AutoUpgrade) {
-		opts.AutoUpgrade = z.Pointer(autoupgrade.ImpliedAutoUpgrade(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
+		opts.AutoUpgrade = z.Pointer(autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
 	}
 
 	return dev.Dev(cmd.Context(), c, &dev.Options{

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -245,7 +245,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	// If auto-upgrade is not set, set it to the implied value.
 	if !z.Dereference(opts.AutoUpgrade) {
-		opts.AutoUpgrade = z.Pointer(autoupgrade.ImpliedAutoUpgrade(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
+		opts.AutoUpgrade = z.Pointer(autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
 	}
 
 	// Force install prompt if needed

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/imagesource"
 	"github.com/acorn-io/runtime/pkg/rulerequest"
 	"github.com/acorn-io/runtime/pkg/wait"
+	"github.com/acorn-io/z"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -240,6 +241,11 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
+	}
+
+	// If auto-upgrade is not set, set it to the implied value.
+	if !z.Dereference(opts.AutoUpgrade) {
+		opts.AutoUpgrade = z.Pointer(autoupgrade.ImpliedAutoUpgrade(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
 	}
 
 	// Force install prompt if needed

--- a/pkg/controller/appdefinition/generation.go
+++ b/pkg/controller/appdefinition/generation.go
@@ -4,6 +4,7 @@ import (
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/autoupgrade"
+	"github.com/acorn-io/z"
 )
 
 func UpdateObservedFields(req router.Request, resp router.Response) error {
@@ -16,7 +17,11 @@ func UpdateObservedFields(req router.Request, resp router.Response) error {
 
 func impliedAutoUpgrade(appSpec v1.AppInstanceSpec) bool {
 	au := appSpec.AutoUpgrade != nil && *appSpec.AutoUpgrade
-	if !au && autoupgrade.ImpliedAutoUpgrade(appSpec.AutoUpgradeInterval, appSpec.Image) {
+	if !au && autoupgrade.ImpliedAutoUpgrade(
+		appSpec.Image,
+		appSpec.AutoUpgradeInterval,
+		z.Dereference(appSpec.NotifyUpgrade),
+	) {
 		au = true
 	}
 	return au

--- a/pkg/controller/appdefinition/generation.go
+++ b/pkg/controller/appdefinition/generation.go
@@ -4,25 +4,17 @@ import (
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/autoupgrade"
-	"github.com/acorn-io/z"
 )
 
 func UpdateObservedFields(req router.Request, resp router.Response) error {
 	app := req.Object.(*v1.AppInstance)
 	app.Status.ObservedImageDigest = app.Status.AppImage.Digest
 	app.Status.ObservedGeneration = app.Generation
-	app.Status.ObservedAutoUpgrade = impliedAutoUpgrade(app.Spec)
+	app.Status.ObservedAutoUpgrade = autoUpgradeEnabled(app.Spec)
 	return nil
 }
 
-func impliedAutoUpgrade(appSpec v1.AppInstanceSpec) bool {
-	au := appSpec.AutoUpgrade != nil && *appSpec.AutoUpgrade
-	if !au && autoupgrade.ImpliedAutoUpgrade(
-		appSpec.Image,
-		appSpec.AutoUpgradeInterval,
-		z.Dereference(appSpec.NotifyUpgrade),
-	) {
-		au = true
-	}
-	return au
+func autoUpgradeEnabled(appSpec v1.AppInstanceSpec) bool {
+	_, enabled := autoupgrade.Mode(appSpec)
+	return enabled
 }


### PR DESCRIPTION
for #2000 

The original auto-upgrade assumed that setting an app to auto-upgrade could be done by:
1. Setting AutoUpgrade to true
2. Having a tag is an auto-upgrade pattern
3. Setting an interval
4. Setting NotifyUpgrade to true

Now the only two ways to set an app to auto-upgrade are (from an API level):
1. Setting AutoUpgrade to true
2. Having a tag is an auto-upgrade pattern

To patch up the UX such that it is the same as before from the CLI's perspective there is new code that sets `AutoUpgrade` to true if it is implied. This effectually mantains the same UX as before with the backend behaving in a more explicit manner.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

