### PR TITLE
Update Fits logic with Unlimited and fix bug with comparison logic of resources

### DIFF
--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -72,19 +72,24 @@ func (current *Resources) Remove(incoming Resources, all bool) {
 // Fits will check if a group of resources will be able to contain
 // another group of resources. If the resources are not able to fit,
 // an aggregated error will be returned with all exceeded resources.
+// If the current resources defines unlimited, then it will always fit.
 func (current *Resources) Fits(incoming Resources) error {
+	if current.Unlimited {
+		return nil
+	}
+
 	exceededResources := []string{}
 
 	// Define function for checking int resources to keep code DRY
 	checkResource := func(resource string, currentVal, incomingVal int) {
-		if currentVal <= incomingVal {
+		if currentVal < incomingVal {
 			exceededResources = append(exceededResources, resource)
 		}
 	}
 
 	// Define function for checking quantity resources to keep code DRY
 	checkQuantityResource := func(resource string, currentVal, incomingVal resource.Quantity) {
-		if currentVal.Cmp(incomingVal) <= 0 {
+		if currentVal.Cmp(incomingVal) < 0 {
 			exceededResources = append(exceededResources, resource)
 		}
 	}

--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+var ErrExceededResources = fmt.Errorf("quota would be exceeded for resources")
+
 // Resources is a struct separate from the QuotaRequestInstanceSpec to allow for
 // external controllers to programmatically set the resources easier. Calls to
 // its functions are mutating.
@@ -108,7 +110,7 @@ func (current *Resources) Fits(incoming Resources) error {
 
 	// Build an aggregated error message for the exceeded resources
 	if len(exceededResources) > 0 {
-		return fmt.Errorf("quota would be exceeded for resources: %s", strings.Join(exceededResources, ", "))
+		return fmt.Errorf("%w: %s", ErrExceededResources, strings.Join(exceededResources, ", "))
 	}
 
 	return nil

--- a/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
@@ -1,0 +1,257 @@
+package v1
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestAdd(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name     string
+		current  Resources
+		incoming Resources
+		expected Resources
+	}{
+		{
+			name:    "add to empty resources",
+			current: Resources{},
+			incoming: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+		},
+		{
+			name: "add to existing resources",
+			current: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          1,
+				Images:        1,
+				VolumeStorage: resource.MustParse("1Mi"),
+				CPU:           resource.MustParse("20m"),
+			},
+			expected: Resources{
+				Apps:          2,
+				Images:        1,
+				VolumeStorage: resource.MustParse("2Mi"),
+				CPU:           resource.MustParse("20m"),
+			},
+		},
+		{
+			name:    "does not change flags",
+			current: Resources{},
+			incoming: Resources{
+				Unlimited:     true,
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+		},
+	}
+
+	// Run the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.current.Add(tc.incoming)
+			tc.current.Equals(tc.expected)
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name     string
+		current  Resources
+		incoming Resources
+		all      bool
+		expected Resources
+	}{
+		{
+			name:    "remove from empty resources",
+			current: Resources{},
+			incoming: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: Resources{},
+		},
+		{
+			name: "remove from existing resources",
+			current: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: Resources{},
+		},
+		{
+			name: "remove persistent counts with all",
+			current: Resources{
+				Secrets: 1,
+			},
+			incoming: Resources{
+				Secrets: 1,
+			},
+			all:      true,
+			expected: Resources{},
+		},
+		{
+			name: "does not remove persistent counts without all",
+			current: Resources{
+				Secrets: 1,
+			},
+			incoming: Resources{
+				Secrets: 1,
+			},
+			expected: Resources{
+				Secrets: 1,
+			},
+		},
+	}
+
+	// Run the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.current.Remove(tc.incoming, tc.all)
+			tc.current.Equals(tc.expected)
+		})
+	}
+}
+
+func TestEquals(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name     string
+		current  Resources
+		incoming Resources
+		expected bool
+	}{
+		{
+			name:     "empty resources",
+			current:  Resources{},
+			incoming: Resources{},
+			expected: true,
+		},
+		{
+			name: "equal resources",
+			current: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: true,
+		},
+		{
+			name: "unequal resources",
+			current: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          2,
+				Secrets:       2,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expected: false,
+		},
+	}
+
+	// Run the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.current.Equals(tc.incoming) != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, !tc.expected)
+			}
+		})
+	}
+}
+
+func TestFits(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name        string
+		current     Resources
+		incoming    Resources
+		expectedErr error
+	}{
+		{
+			name:     "empty resources",
+			current:  Resources{},
+			incoming: Resources{},
+		},
+		{
+			name: "fits resources",
+			current: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+		},
+
+		{
+			name: "does not fit resources",
+			current: Resources{
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          2,
+				Secrets:       2,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			expectedErr: ErrExceededResources,
+		},
+		{
+			name: "fits resources with unlimited flag set",
+			current: Resources{
+				Unlimited:     true,
+				Apps:          1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:          2,
+				Secrets:       2,
+				VolumeStorage: resource.MustParse("2Mi"),
+			},
+		},
+	}
+
+	// Run the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.current.Fits(tc.incoming)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR does three things:
1. If `Unlimited` is set, return nil for the `resources.Fits` function.
2. Fixes a bug in the `resources.Fits` logic where if an incoming resource perfectly fit it would be considered too large.
3. Adds unit tests to the Resources struct to prevent this happening again.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

