### PR TITLE
Add external aliasas for internal runtime event helper types

### DIFF
--- a/pkg/apis/api.acorn.io/v1/event.go
+++ b/pkg/apis/api.acorn.io/v1/event.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"time"
+
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+type Event internalv1.EventInstance
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+type EventList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Event `json:"items"`
+}
+
+// Alias helper types so that clients don't need to import the internal package when creating events.
+
+// +k8s:deepcopy-gen=false
+
+type EventResource = internalv1.EventResource
+
+// +k8s:deepcopy-gen=false
+
+type MicroTime = internalv1.MicroTime
+
+func NowMicro() MicroTime {
+	return internalv1.NowMicro()
+}
+
+func NewMicroTime(t time.Time) MicroTime {
+	return internalv1.NewMicroTime(t)
+}
+
+const (
+	EventSeverityInfo  = internalv1.EventSeverityInfo
+	EventSeverityError = internalv1.EventSeverityError
+)
+
+func Mapify(v any) (internalv1.GenericMap, error) {
+	return internalv1.Mapify(v)
+}

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -560,18 +560,6 @@ type ImageAllowRuleList struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-type Event v1.EventInstance
-
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-type EventList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Event `json:"items"`
-}
-
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type DevSession v1.DevSessionInstance
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -208,11 +208,11 @@ func recordPullEvent(ctx context.Context, recorder event.Recorder, observed meta
 	previous, target := newImageSummary(previousImage), newImageSummary(targetImage)
 	e := apiv1.Event{
 		Type:        AppImagePullSuccessEventType,
-		Severity:    v1.EventSeverityInfo,
+		Severity:    apiv1.EventSeverityInfo,
 		Description: fmt.Sprintf("Pulled %s", target.Name),
 		AppName:     obj.GetName(),
 		Resource:    event.Resource(obj),
-		Observed:    v1.MicroTime(observed),
+		Observed:    apiv1.MicroTime(observed),
 	}
 	e.SetNamespace(obj.GetNamespace())
 
@@ -231,7 +231,7 @@ func recordPullEvent(ctx context.Context, recorder event.Recorder, observed meta
 		details.Err = err.Error()
 	}
 
-	if e.Details, err = v1.Mapify(details); err != nil {
+	if e.Details, err = apiv1.Mapify(details); err != nil {
 		logrus.Warnf("Failed to mapify event details: %s", err.Error())
 	}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -65,8 +65,8 @@ func publicKind(obj runtime.Object) string {
 }
 
 // Resource returns a non-nil pointer to a v1.EventResource for the given object.
-func Resource(obj kclient.Object) *internalv1.EventResource {
-	return &internalv1.EventResource{
+func Resource(obj kclient.Object) *apiv1.EventResource {
+	return &apiv1.EventResource{
 		Kind: publicKind(obj),
 		Name: obj.GetName(),
 		UID:  obj.GetUID(),

--- a/pkg/server/registry/apigroups/acorn/apps/events.go
+++ b/pkg/server/registry/apigroups/acorn/apps/events.go
@@ -66,7 +66,7 @@ func (s *eventRecordingStrategy) Create(ctx context.Context, obj types.Object) (
 		return created, err
 	}
 
-	details, err := v1.Mapify(AppSpecCreateEventDetails{
+	details, err := apiv1.Mapify(AppSpecCreateEventDetails{
 		ResourceVersion: created.GetResourceVersion(),
 	})
 	if err != nil {
@@ -79,12 +79,12 @@ func (s *eventRecordingStrategy) Create(ctx context.Context, obj types.Object) (
 			Namespace: obj.GetNamespace(),
 		},
 		Type:        AppCreateEventType,
-		Severity:    v1.EventSeverityInfo,
+		Severity:    apiv1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s created", obj.GetNamespace(), obj.GetName()),
 		AppName:     obj.GetName(),
 		Resource:    event.Resource(obj),
-		Observed:    v1.NowMicro(),
+		Observed:    apiv1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err.Error())
 	}
@@ -100,7 +100,7 @@ func (s *eventRecordingStrategy) Delete(ctx context.Context, obj types.Object) (
 		return deleted, err
 	}
 
-	details, err := v1.Mapify(AppSpecDeleteEventDetails{
+	details, err := apiv1.Mapify(AppSpecDeleteEventDetails{
 		ResourceVersion: deleted.GetResourceVersion(),
 	})
 	if err != nil {
@@ -113,12 +113,12 @@ func (s *eventRecordingStrategy) Delete(ctx context.Context, obj types.Object) (
 			Namespace: obj.GetNamespace(),
 		},
 		Type:        AppDeleteEventType,
-		Severity:    v1.EventSeverityInfo,
+		Severity:    apiv1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s deleted", obj.GetNamespace(), obj.GetName()),
 		AppName:     obj.GetName(),
 		Resource:    event.Resource(obj),
-		Observed:    v1.NowMicro(),
+		Observed:    apiv1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err.Error())
 	}
@@ -153,7 +153,7 @@ func (s *eventRecordingStrategy) Update(ctx context.Context, obj types.Object) (
 		return updated, nil
 	}
 
-	details, err := v1.Mapify(AppSpecUpdateEventDetails{
+	details, err := apiv1.Mapify(AppSpecUpdateEventDetails{
 		ResourceVersion: updated.GetResourceVersion(),
 		OldSpec:         oldSpec,
 		Patch:           patch,
@@ -168,12 +168,12 @@ func (s *eventRecordingStrategy) Update(ctx context.Context, obj types.Object) (
 			Namespace: obj.GetNamespace(),
 		},
 		Type:        AppSpecUpdateEventType,
-		Severity:    v1.EventSeverityInfo,
+		Severity:    apiv1.EventSeverityInfo,
 		Details:     details,
 		Description: fmt.Sprintf("Spec field updated for App %s/%s", obj.GetNamespace(), obj.GetName()),
 		AppName:     obj.GetName(),
 		Resource:    event.Resource(obj),
-		Observed:    v1.NowMicro(),
+		Observed:    apiv1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err)
 	}

--- a/pkg/server/registry/apigroups/acorn/events/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/events/strategy.go
@@ -103,10 +103,10 @@ type query struct {
 	prefix prefix
 
 	// since excludes events observed before it when not nil.
-	since *internalv1.MicroTime
+	since *apiv1.MicroTime
 
 	// until excludes events observed after it when not nil.
-	until *internalv1.MicroTime
+	until *apiv1.MicroTime
 }
 
 // filterChannel applies the query to every event received from unfiltered and forwards the result to filtered, if any.
@@ -154,7 +154,7 @@ func (q query) filterEvent(e watch.Event) *watch.Event {
 	return &e
 }
 
-func (q query) afterWindow(observation internalv1.MicroTime) bool {
+func (q query) afterWindow(observation apiv1.MicroTime) bool {
 	if q.until == nil {
 		// Window includes all future events
 		return false
@@ -163,7 +163,7 @@ func (q query) afterWindow(observation internalv1.MicroTime) bool {
 	return observation.After(q.until.Time)
 }
 
-func (q query) beforeWindow(observation internalv1.MicroTime) bool {
+func (q query) beforeWindow(observation apiv1.MicroTime) bool {
 	if q.since == nil {
 		// Window includes all existing events
 		return false
@@ -255,12 +255,12 @@ func stripQuery(opts storage.ListOptions) (q query, stripped storage.ListOptions
 // 2. RFC3339; e.g. "2006-01-02T15:04:05Z07:00"
 // 3. RFC3339Micro; e.g. "2006-01-02T15:04:05.999999Z07:00"
 // 4. Unix timestamp; e.g. "1136239445"
-func parseTimeBound(raw string, now internalv1.MicroTime) (*internalv1.MicroTime, error) {
+func parseTimeBound(raw string, now apiv1.MicroTime) (*apiv1.MicroTime, error) {
 	// Try to parse raw as a duration string
 	var errs []error
 	duration, err := time.ParseDuration(raw)
 	if err == nil {
-		return z.Pointer(internalv1.NewMicroTime(now.Add(-1 * duration))), nil
+		return z.Pointer(apiv1.NewMicroTime(now.Add(-1 * duration))), nil
 	}
 	errs = append(errs, fmt.Errorf("%s is not a valid duration: %w", raw, err))
 
@@ -287,12 +287,12 @@ var supportedLayouts = []string{
 	"2006-01-02T15:04:05",
 }
 
-func parseTime(raw string) (*internalv1.MicroTime, error) {
+func parseTime(raw string) (*apiv1.MicroTime, error) {
 	var errs []error
 	for _, layout := range supportedLayouts {
 		t, err := time.Parse(layout, raw)
 		if err == nil {
-			return z.Pointer(internalv1.NewMicroTime(t)), nil
+			return z.Pointer(apiv1.NewMicroTime(t)), nil
 		}
 
 		errs = append(errs, err)
@@ -307,7 +307,7 @@ func parseUnix(raw string) (*internalv1.MicroTime, error) {
 		return nil, err
 	}
 
-	return z.Pointer(internalv1.NewMicroTime(time.Unix(sec, 0))), nil
+	return z.Pointer(apiv1.NewMicroTime(time.Unix(sec, 0))), nil
 }
 
 type prefix string


### PR DESCRIPTION
Make it easier for third party services to record events without importing internal packages by adding type aliases and wrapper in our external API package.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

