### PR TITLE
Propagate ports from main container service to additional services for the same container

### DIFF
--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -124,3 +124,7 @@ func TestCustomCertsShouldNotSetCertManager(t *testing.T) {
 func TestCustomCertsWithAnnonationsShouldNotSetCertManagerDefaultIssuer(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/ingress/customdomainwithannotations", RenderServices)
 }
+
+func TestContainerService(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/service/container", RenderServices)
+}

--- a/pkg/controller/service/testdata/service/container/existing.yaml
+++ b/pkg/controller/service/testdata/service/container/existing.yaml
@@ -1,0 +1,42 @@
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  name: my-container
+  namespace: app-created-namespace
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/container-name: my-container
+    acorn.io/managed: "true"
+spec:
+  appName: my-app
+  appNamespace: my-app-namespace
+  container: my-container
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/container-name: my-container
+    acorn.io/managed: "true"
+  ports:
+    - port: 80
+      protocol: http
+      targetPort: 80
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  name: my-app
+  namespace: my-app-namespace
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+spec:
+  image: test
+  ports:
+    - publish: true
+      port: 80
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test

--- a/pkg/controller/service/testdata/service/container/expected.golden
+++ b/pkg/controller/service/testdata/service/container/expected.golden
@@ -1,0 +1,66 @@
+`apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-extra-container-service
+  name: my-extra-container-service
+  namespace: app-created-namespace
+spec:
+  ports:
+  - appProtocol: HTTP
+    name: "80"
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - appProtocol: HTTP
+    name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/container-name: my-container
+    acorn.io/managed: "true"
+  type: ClusterIP
+status:
+  loadBalancer: {}
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-extra-container-service
+  name: my-extra-container-service
+  namespace: app-created-namespace
+spec:
+  appName: my-app
+  appNamespace: my-app-namespace
+  container: my-container
+  default: false
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-extra-container-service
+  ports:
+  - port: 8080
+    protocol: http
+    targetPort: 80
+status:
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  hasService: true
+`

--- a/pkg/controller/service/testdata/service/container/input.yaml
+++ b/pkg/controller/service/testdata/service/container/input.yaml
@@ -1,0 +1,23 @@
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  name: my-extra-container-service
+  namespace: app-created-namespace
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-extra-container-service
+spec:
+  appName: my-app
+  appNamespace: my-app-namespace
+  container: my-container
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: my-app-namespace
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-extra-container-service
+  ports:
+    - port: 8080
+      protocol: http
+      targetPort: 80

--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -1,12 +1,12 @@
 package ports
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/acorn-io/baaah/pkg/typed"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
-	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -85,8 +85,8 @@ func RemoveNonHTTPPorts(ports []corev1.ServicePort) []corev1.ServicePort {
 }
 
 func SortPorts(ports []corev1.ServicePort) []corev1.ServicePort {
-	slices.SortFunc[corev1.ServicePort](ports, func(i, j corev1.ServicePort) bool {
-		return i.Port < j.Port
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Port < ports[j].Port
 	})
 	return ports
 }

--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/acorn-io/baaah/pkg/typed"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -81,4 +82,11 @@ func RemoveNonHTTPPorts(ports []corev1.ServicePort) []corev1.ServicePort {
 		}
 	}
 	return result
+}
+
+func SortPorts(ports []corev1.ServicePort) []corev1.ServicePort {
+	slices.SortFunc[corev1.ServicePort](ports, func(i, j corev1.ServicePort) bool {
+		return i.Port < j.Port
+	})
+	return ports
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -41,7 +41,29 @@ func toContainerLabelsService(service *v1.ServiceInstance) (result []kclient.Obj
 	return
 }
 
-func toContainerService(service *v1.ServiceInstance) (result []kclient.Object) {
+func toContainerService(ctx context.Context, c kclient.Client, service *v1.ServiceInstance) (result []kclient.Object, err error) {
+	svcPorts := ports.ToServicePorts(service.Spec.Ports)
+
+	// Check whether this is the main ServiceInstance for this container.
+	if service.Spec.Container != service.Name {
+		// Return an error if there are any non-HTTP ports defined. This could maybe cause problems with Istio.
+		for _, port := range service.Spec.Ports {
+			if port.Protocol != v1.ProtocolHTTP {
+				return nil, fmt.Errorf("container service %s has non-HTTP port %d\nservices defined for existing containers must contain only HTTP ports", service.Name, port.Port)
+			}
+		}
+
+		// Get the main ServiceInstance for this container.
+		mainService := &v1.ServiceInstance{}
+		if err = c.Get(ctx, kclient.ObjectKey{Name: service.Spec.Container, Namespace: service.Namespace}, mainService); err != nil {
+			return
+		}
+
+		// Take the HTTP ports from the main ServiceInstance and put them on this one too.
+		// If we don't do this, Istio might incorrectly route traffic.
+		svcPorts = ports.SortPorts(ports.DedupPorts(append(svcPorts, ports.RemoveNonHTTPPorts(ports.ToServicePorts(mainService.Spec.Ports))...)))
+	}
+
 	newService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        service.Name,
@@ -50,14 +72,14 @@ func toContainerService(service *v1.ServiceInstance) (result []kclient.Object) {
 			Annotations: service.Spec.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: ports.ToServicePorts(service.Spec.Ports),
+			Ports: svcPorts,
 			Type:  corev1.ServiceTypeClusterIP,
 			Selector: labels.ManagedByApp(service.Spec.AppNamespace,
 				service.Spec.AppName, labels.AcornContainerName, service.Spec.Container),
 		},
 	}
 	result = append(result, newService)
-	return
+	return result, nil
 }
 
 func toAddressService(service *v1.ServiceInstance) (result []kclient.Object) {
@@ -241,7 +263,8 @@ func ToK8sService(req router.Request, service *v1.ServiceInstance) (result []kcl
 	} else if service.Spec.Address != "" {
 		return toAddressService(service), nil, nil
 	} else if service.Spec.Container != "" {
-		return toContainerService(service), nil, nil
+		portList, err := toContainerService(req.Ctx, req.Client, service)
+		return portList, nil, err
 	} else if len(service.Spec.ContainerLabels) > 0 {
 		return toContainerLabelsService(service), nil, nil
 	}


### PR DESCRIPTION
This one is a bit tough to explain. Let's start with this Acornfile:

```cue
containers: "my-container": {
  image: "nginx:latest"
  ports: "80/http"
}

services: "nginx": {
  ports: "8080:80/http"
  container: "my-container"
}
```

Prior to this PR, the controller would render two Kubernetes Services for this. The first is  `my-container`, accessible on port 80 and sending traffic to port 80 on the `my-container` container. The second is `nginx`, accessible on port 8080 and sending traffic to port 80 on the `my-container` container. Fairly straightforward and works great.

...that is, until Istio comes into the picture. Istio [does not like](https://istio.io/latest/docs/reference/config/analysis/ist0137) when multiple services have the same target port on the same pod, but with different public-facing ports. When we were running like this, we had weird traffic routing issues where Envoy would forward traffic to a stale pod IP that no longer belonged to any pods.

The fix? When we create additional `services` for a specific container (i.e., the `container` field is specified, as it is in our example), propagate all of the HTTP ports from the "main" service for the container (the one whose name is the same as the name of the container). Istio will still complain when you run `istioctl analyze -A`, but the routing issues disappear and things work again.

Also in this PR, we block these additional `services` from being allowed to specify any non-HTTP ports.

I also added a new unit test to cover this case.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

