### PR TITLE
Don't send index.docker.io auth for local image references

### DIFF
--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"context"
+
+	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/imagesource"
+	"github.com/acorn-io/runtime/pkg/tags"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func getAuthForImage(ctx context.Context, clientFactory ClientFactory, image string) (*apiv1.RegistryAuth, error) {
+	if tags.IsLocalReference(image) {
+		return nil, nil
+	}
+
+	c, err := clientFactory.CreateDefault()
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		// not failing on malformed image names
+		return nil, nil
+	}
+
+	creds, err := imagesource.GetCreds(c)
+	if err != nil {
+		return nil, err
+	}
+
+	auth, _, err := creds(ctx, ref.Context().RegistryStr())
+	return auth, err
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -79,15 +79,7 @@ func (s *Build) Run(cmd *cobra.Command, args []string) error {
 
 	if s.Push {
 		for _, tag := range s.Tag {
-			parsedTag, err := name.NewTag(tag)
-			if err != nil {
-				return err
-			}
-			creds, err := imagesource.GetCreds(c)
-			if err != nil {
-				return err
-			}
-			auth, _, err := creds(cmd.Context(), parsedTag.RegistryStr())
+			auth, err := getAuthForImage(cmd.Context(), s.client, tag)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/images_detail.go
+++ b/pkg/cli/images_detail.go
@@ -1,11 +1,10 @@
 package cli
 
 import (
+	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
 	"github.com/acorn-io/runtime/pkg/client"
-	"github.com/acorn-io/runtime/pkg/credentials"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -33,27 +32,16 @@ func (a *ImageDetails) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var nested string
+	var (
+		nested string
+		auth   *apiv1.RegistryAuth
+	)
+
 	if len(args) > 1 {
 		nested = args[1]
 	}
 
-	ref, err := name.ParseReference(args[0])
-	if err != nil {
-		return err
-	}
-
-	cfg, err := a.client.Options().CLIConfig()
-	if err != nil {
-		return err
-	}
-
-	creds, err := credentials.NewStore(cfg, c)
-	if err != nil {
-		return err
-	}
-
-	auth, _, err := creds.Get(cmd.Context(), ref.Context().RegistryStr())
+	auth, err = getAuthForImage(cmd.Context(), a.client, args[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/images_sign.go
+++ b/pkg/cli/images_sign.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"strings"
 
-	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/client"
 	acornsign "github.com/acorn-io/runtime/pkg/cosign"
-	"github.com/acorn-io/runtime/pkg/imagesource"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pterm/pterm"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
@@ -53,19 +51,13 @@ func (a *ImageSign) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var auth *apiv1.RegistryAuth
-	ref, err := name.ParseReference(imageName)
-	if err == nil { // not failing here, since it could be a local image
-		creds, err := imagesource.GetCreds(c)
-		if err != nil {
-			return err
-		}
-
-		auth, _, err = creds(cmd.Context(), ref.Context().RegistryStr())
-		if err != nil {
-			return err
-		}
+	auth, err := getAuthForImage(cmd.Context(), a.client, imageName)
+	if err != nil {
+		return err
 	}
+
+	// not failing here, since it could be a local image
+	ref, _ := name.ParseReference(imageName)
 
 	details, err := c.ImageDetails(cmd.Context(), args[0], &client.ImageDetailsOptions{
 		Auth: auth,

--- a/pkg/cli/pull.go
+++ b/pkg/cli/pull.go
@@ -5,9 +5,7 @@ import (
 
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/client"
-	"github.com/acorn-io/runtime/pkg/credentials"
 	"github.com/acorn-io/runtime/pkg/progressbar"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -33,22 +31,7 @@ func (s *Pull) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ref, err := name.ParseReference(args[0])
-	if err != nil {
-		return err
-	}
-
-	cfg, err := s.client.Options().CLIConfig()
-	if err != nil {
-		return err
-	}
-
-	creds, err := credentials.NewStore(cfg, c)
-	if err != nil {
-		return err
-	}
-
-	auth, _, err := creds.Get(cmd.Context(), ref.Context().RegistryStr())
+	auth, err := getAuthForImage(cmd.Context(), s.client, args[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -3,9 +3,7 @@ package cli
 import (
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/client"
-	"github.com/acorn-io/runtime/pkg/credentials"
 	"github.com/acorn-io/runtime/pkg/progressbar"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -33,22 +31,7 @@ func (s *Push) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cfg, err := s.client.Options().CLIConfig()
-	if err != nil {
-		return err
-	}
-
-	creds, err := credentials.NewStore(cfg, c)
-	if err != nil {
-		return err
-	}
-
-	tag, err := name.NewTag(args[0])
-	if err != nil {
-		return err
-	}
-
-	auth, _, err := creds.Get(cmd.Context(), tag.RegistryStr())
+	auth, err := getAuthForImage(cmd.Context(), s.client, args[0])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A local image digest like abcdef will be interpreted by the credential
lookup logic as index.docker.io/library/abcdef and as such will send
index.docker.io credentials when doing pull, push, etc. This will
cause unexpected auth issues.

Signed-off-by: Darren Shepherd <darren@acorn.io>
