### PR TITLE
change: properly use local auth when signing/verifying images and getting signatures in imagedetails

### DIFF
--- a/pkg/cli/images_sign.go
+++ b/pkg/cli/images_sign.go
@@ -112,7 +112,9 @@ func (a *ImageSign) Run(cmd *cobra.Command, args []string) error {
 
 	signatureB64 := base64.StdEncoding.EncodeToString(signature)
 
-	imageSignOpts := &client.ImageSignOptions{}
+	imageSignOpts := &client.ImageSignOptions{
+		Auth: auth,
+	}
 
 	pubkey, err := sigSigner.PublicKey()
 	if err != nil {

--- a/pkg/cli/images_verify.go
+++ b/pkg/cli/images_verify.go
@@ -73,6 +73,7 @@ func (a *ImageVerify) Run(cmd *cobra.Command, args []string) error {
 	vOpts := &client.ImageVerifyOptions{
 		Annotations: a.Annotations,
 		PublicKey:   a.Key,
+		Auth:        auth,
 	}
 
 	// load public key from file (if it is a file, not a remote reference)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -352,12 +352,14 @@ type EventStreamOptions struct {
 }
 
 type ImageSignOptions struct {
-	PublicKey string `json:"publicKeys,omitempty"`
+	PublicKey string              `json:"publicKeys,omitempty"`
+	Auth      *apiv1.RegistryAuth `json:"auth,omitempty"`
 }
 
 type ImageVerifyOptions struct {
-	PublicKey   string            `json:"publicKeys,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	PublicKey   string              `json:"publicKeys,omitempty"`
+	Annotations map[string]string   `json:"annotations,omitempty"`
+	Auth        *apiv1.RegistryAuth `json:"auth,omitempty"`
 }
 
 func (o EventStreamOptions) ListOptions() *kclient.ListOptions {

--- a/pkg/client/sign.go
+++ b/pkg/client/sign.go
@@ -12,9 +12,10 @@ func (c *DefaultClient) ImageSign(ctx context.Context, image string, payload []b
 		Payload:      payload,
 		SignatureB64: signatureB64,
 		PublicKey:    opts.PublicKey,
+		Auth:         opts.Auth,
 	}
 
-	imageDetails, err := c.ImageDetails(ctx, image, &ImageDetailsOptions{})
+	imageDetails, err := c.ImageDetails(ctx, image, &ImageDetailsOptions{Auth: opts.Auth})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/verify.go
+++ b/pkg/client/verify.go
@@ -12,6 +12,7 @@ import (
 func (c *DefaultClient) ImageVerify(ctx context.Context, image string, opts *ImageVerifyOptions) (*apiv1.ImageSignature, error) {
 	sigInput := &apiv1.ImageSignature{
 		PublicKey: opts.PublicKey,
+		Auth:      opts.Auth,
 	}
 
 	if opts.PublicKey == "" {
@@ -22,7 +23,7 @@ func (c *DefaultClient) ImageVerify(ctx context.Context, image string, opts *Ima
 		Match: opts.Annotations,
 	}
 
-	imageDetails, err := c.ImageDetails(ctx, image, &ImageDetailsOptions{})
+	imageDetails, err := c.ImageDetails(ctx, image, &ImageDetailsOptions{Auth: opts.Auth})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -82,6 +82,12 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 	if err != nil {
 		return nil, err
 	}
+
+	opts, err = images.GetAuthenticationRemoteOptions(ctx, c, namespace, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	_, sigHash, err := acornsign.FindSignature(imgRef.Context().Digest(appImageWithData.AppImage.Digest), opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Ref #2026 (I couldn't really reproduce this issue, but the code was problematic anyway)


### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

