### PR TITLE
Record lifecycle events for managed containers

### DIFF
--- a/pkg/controller/pod/pod.go
+++ b/pkg/controller/pod/pod.go
@@ -1,0 +1,97 @@
+package pod
+
+import (
+	"strconv"
+
+	"github.com/acorn-io/baaah/pkg/name"
+	"github.com/acorn-io/baaah/pkg/router"
+	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/event"
+	"github.com/acorn-io/runtime/pkg/server/registry/apigroups/acorn/containers"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	deletedEventType   = "ContainerReplicaDeleted"
+	createdEventType   = "ContainerReplicaCreated"
+	restartedEventType = "ContainerReplicaRestarted"
+)
+
+func NewEventHandler(recorder event.Recorder) *EventHandler {
+	return &EventHandler{
+		recorder: recorder,
+	}
+}
+
+type EventHandler struct {
+	recorder event.Recorder
+}
+
+func (h *EventHandler) Handle(req router.Request, _ router.Response) error {
+	p := req.Object.(*corev1.Pod)
+	var events []*apiv1.Event
+	for _, cr := range containers.PodToContainerReplicas(p) {
+
+		var e apiv1.Event
+		switch {
+		case isDelete(&cr):
+			e.Name = name.SafeHashConcatName(
+				"d",
+				cr.Name,
+			)
+			e.Type = deletedEventType
+			e.Observed = apiv1.NewMicroTime(e.DeletionTimestamp.Time)
+		case isCreate(&cr):
+			e.Name = name.SafeHashConcatName(
+				"c",
+				cr.Name,
+			)
+			e.Type = createdEventType
+			e.Observed = apiv1.NewMicroTime(e.CreationTimestamp.Time)
+		case isRestart(&cr):
+			e.Name = name.SafeHashConcatName(
+				"r",
+				strconv.FormatInt(int64(cr.Status.RestartCount), 10),
+				cr.Name,
+			)
+			e.Type = restartedEventType
+			e.Observed = apiv1.NewMicroTime(e.CreationTimestamp.Time)
+		default:
+			// Not an event we care to generate, skip it
+			continue
+		}
+
+		// Set common fields
+		e.Namespace = cr.Namespace
+		e.Severity = apiv1.EventSeverityInfo
+		e.AppName = cr.Spec.AppName
+		e.ServiceName = cr.Spec.ContainerName
+		e.Resource = event.Resource(&cr)
+
+		events = append(events, &e)
+	}
+
+	for _, e := range events {
+		// If the event is already recorded, ignore it.
+		if err := h.recorder.Record(req.Ctx, e); err != nil && !apierror.IsAlreadyExists(err) {
+			// Log recording errors instead of retrying
+			logrus.WithError(err).Warn("failed to record containerreplica event")
+		}
+	}
+
+	return nil
+}
+
+func isDelete(cr *apiv1.ContainerReplica) bool {
+	return cr.DeletionTimestamp != nil && !cr.DeletionTimestamp.IsZero() && len(cr.Finalizers) == 0
+}
+
+func isCreate(cr *apiv1.ContainerReplica) bool {
+	return cr.Status.RestartCount == 0 && cr.Status.State == corev1.ContainerState{}
+}
+
+func isRestart(cr *apiv1.ContainerReplica) bool {
+	return cr.Status.RestartCount > 0
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/controller/jobs"
 	"github.com/acorn-io/runtime/pkg/controller/namespace"
 	"github.com/acorn-io/runtime/pkg/controller/networkpolicy"
+	"github.com/acorn-io/runtime/pkg/controller/pod"
 	"github.com/acorn-io/runtime/pkg/controller/pvc"
 	"github.com/acorn-io/runtime/pkg/controller/quota"
 	"github.com/acorn-io/runtime/pkg/controller/scheduling"
@@ -129,6 +130,9 @@ func routes(router *router.Router, cfg *rest.Config, registryTransport http.Roun
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.ForIngress)
 	router.Type(&appsv1.Deployment{}).Namespace(system.ImagesNamespace).HandlerFunc(networkpolicy.ForBuilder)
 	router.Type(&netv1.NetworkPolicy{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
+
+	// Record container lifecycle events for managed pods
+	router.Type(&corev1.Pod{}).Selector(managedSelector).Handler(pod.NewEventHandler(recorder))
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)
 	configRouter.Handler(config.NewDNSConfigHandler())

--- a/pkg/server/registry/apigroups/acorn/containers/translator.go
+++ b/pkg/server/registry/apigroups/acorn/containers/translator.go
@@ -65,7 +65,7 @@ func (t *Translator) ListOpts(ctx context.Context, namespace string, opts storag
 
 func (t *Translator) ToPublic(ctx context.Context, objs ...runtime.Object) (result []mtypes.Object, _ error) {
 	for _, obj := range objs {
-		for _, con := range podToContainers(obj.(*corev1.Pod)) {
+		for _, con := range PodToContainerReplicas(obj.(*corev1.Pod)) {
 			con := con
 			result = append(result, &con)
 		}
@@ -91,7 +91,7 @@ func (t *Translator) NewPublic() mtypes.Object {
 	return &apiv1.ContainerReplica{}
 }
 
-func podToContainers(pod *corev1.Pod) (result []apiv1.ContainerReplica) {
+func PodToContainerReplicas(pod *corev1.Pod) (result []apiv1.ContainerReplica) {
 	containerSpecData := []byte(pod.Annotations[labels.AcornContainerSpec])
 	if len(containerSpecData) == 0 {
 		return nil
@@ -174,6 +174,7 @@ func containerSpecToContainerReplica(pod *corev1.Pod, imageMapping map[string]st
 	result.Namespace = namespace
 	result.OwnerReferences = nil
 	result.UID = uid
+	result.DeletionTimestamp = pod.DeletionTimestamp
 	result.Spec.AppName = pod.Labels[labels.AcornAppPublicName]
 	result.Spec.JobName = jobName
 	result.Spec.ContainerName = containerName
@@ -243,3 +244,5 @@ func containerSpecToContainerReplica(pod *corev1.Pod, imageMapping map[string]st
 
 	return result, nil
 }
+
+


### PR DESCRIPTION
Record created, restarted, and deleted acorn events for containers
managed as part of an Acorn.

Addresses https://github.com/acorn-io/manager/issues/701