### PR TITLE
Suppress acorn not installed warnings when listing projects

### DIFF
--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/acorn-io/baaah/pkg/typed"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
+	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/project"
 	"github.com/acorn-io/runtime/pkg/tables"
 	"github.com/sirupsen/logrus"
@@ -68,6 +69,9 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 			}
 		}
 		for _, env := range typed.SortedKeys(warnings) {
+			if env == config.LocalServerEnv && a.client.Options().Kubeconfig == "" {
+				continue
+			}
 			logrus.Warnf("Could not list projects from [%s]: %v", env, warnings[env])
 		}
 	}

--- a/pkg/config/cliconfig.go
+++ b/pkg/config/cliconfig.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	LocalServer = "kubeconfig"
+	LocalServer    = "kubeconfig"
+	LocalServerEnv = "local " + LocalServer
 )
 
 type AuthConfig types.AuthConfig


### PR DESCRIPTION
See title. acorn-io/manager#826

```
14:23:19 ~/go/github.com/keyallis/runtime [main] % acorn projects
NAME                                        DEFAULT   REGIONS
main.manager.acornlabs.com/keyallis/acorn   *         aws-2-us-east-2
14:45:44 ~/go/github.com/keyallis/runtime [main] % acorn --kubeconfig ~/.kube/config projects
WARN[0000] Could not list projects from [local kubeconfig]: failed to get API group resources: unable to retrieve the complete list of server APIs: api.acorn.io/v1: the server could not find the requested resource 
NAME      DEFAULT   REGIONS
```

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

