### PR TITLE
Add soft cap for events (#1709)

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -108,5 +108,10 @@ func (c *Controller) Start(ctx context.Context) error {
 
 	logserver.StartServerWithDefaults()
 
+	// Every 5 minutes, delete EventInstances until only the most recent 1000 remain.
+	// Use c.Router.Backend() to ensure we hit the cache when possible.
+	// Note: the cache will only be populated for EventInstances if a handler for EventInstances has been registered.
+	go event.Truncate(ctx, c.Router.Backend(), 5*time.Minute, 1000)
+
 	return c.Router.Start(ctx)
 }

--- a/pkg/event/truncate.go
+++ b/pkg/event/truncate.go
@@ -1,0 +1,53 @@
+package event
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/sirupsen/logrus"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Truncate truncates the set of stored account events to a maximum of limit once every period.
+func Truncate(ctx context.Context, client kclient.Client, period time.Duration, limit int) {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			logrus.Debug("truncating eventinstances")
+			var events internalv1.EventInstanceList
+			if err := client.List(ctx, &events); err != nil {
+				logrus.WithError(err).Warn("failed to truncate events, error listing events")
+				continue
+			}
+
+			if len(events.Items) <= limit {
+				// Nothing to do
+				continue
+			}
+
+			// Sort events by observed so that the newest events are first
+			sort.Slice(events.Items, func(i, j int) bool {
+				return events.Items[i].Observed.After(events.Items[j].Observed.Time)
+			})
+
+			var errs []error
+			for _, event := range events.Items[limit:] {
+				if err := client.Delete(ctx, &event); err != nil {
+					errs = append(errs, err)
+				}
+			}
+
+			if err := errors.Join(errs...); err != nil {
+				logrus.WithError(err).Warn("failed to truncate events, error deleting events")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add a daemon that periodically deletes EventInstances to keep the number of events near a fixed limit. The daemon uses the observed field to determine which events to delete first, so that only the most recently observed remain after each period.

The daemon is hardcoded to delete everything but the latest 1000 events every 5 minutes.

Addresses #1709 