### PR TITLE
Add Cilium proxy visibility annotations to pods

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"path"
 	"strconv"
@@ -486,6 +487,7 @@ func podAnnotations(appInstance *v1.AppInstance, container v1.Container) map[str
 		labels.AcornContainerSpec: containerAnnotation(container),
 	}
 	addPrometheusAnnotations(annotations, container)
+	addCiliumAnnotations(annotations, container)
 
 	images := map[string]string{}
 	addImageAnnotations(images, appInstance, container)
@@ -519,6 +521,18 @@ func addPrometheusAnnotations(annotations map[string]string, container v1.Contai
 		annotations[labels.PrometheusScrape] = "true"
 		annotations[labels.PrometheusPath] = container.Metrics.Path
 		annotations[labels.PrometheusPort] = strconv.Itoa(int(container.Metrics.Port))
+	}
+}
+
+func addCiliumAnnotations(annotations map[string]string, container v1.Container) {
+	var visibilityConfigs []string
+	for _, port := range container.Ports {
+		if port.Protocol == v1.ProtocolHTTP {
+			visibilityConfigs = append(visibilityConfigs, fmt.Sprintf("<Ingress/%d/TCP/HTTP>", port.TargetPort))
+		}
+	}
+	if len(visibilityConfigs) > 0 {
+		annotations[labels.CiliumProxyVisibility] = strings.Join(visibilityConfigs, ",")
 	}
 }
 

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -142,6 +143,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"class":"sample-compute-class-01","image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -142,6 +143,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"class":"sample-compute-class","image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
@@ -122,6 +122,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -194,6 +194,7 @@ spec:
         admit.io: test-admit-app-spec-ann
         allowed-global.io: test-global
         allowed.io: test-allowed-app-spec-ann
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -189,6 +189,7 @@ spec:
         appSpecAnn: test-app-spec-ann
         global-scoped-ann: test-global
         jobAnn: test-job-ann
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"foo","metrics":{"path":"/","port":80},"ports":[{"protocol":"http","targetPort":80}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/80/TCP/HTTP>
         prometheus.io/path: /
         prometheus.io/port: "80"
         prometheus.io/scrape: "true"

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -131,6 +131,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -130,6 +131,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
@@ -63,6 +63,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -128,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
@@ -63,6 +63,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
@@ -63,6 +63,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.golden
@@ -61,6 +61,7 @@ spec:
         globala: value
         job1a: value
         job3a: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","memory":2097152,"metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -132,6 +133,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","memory":1048576,"metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -122,6 +122,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -316,6 +317,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -137,6 +138,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
@@ -122,6 +122,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
@@ -208,6 +208,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
@@ -122,6 +122,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -309,6 +310,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
@@ -129,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
@@ -122,6 +122,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -309,6 +310,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
@@ -129,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -325,6 +326,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/probes/expected.golden
+++ b/pkg/controller/appdefinition/testdata/probes/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":[]}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -125,6 +126,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"probes":[{"http":{"headers":{"foo":"bar"},"url":"http://localhost/foo/bar"},"type":"readiness"},{"tcp":{"url":"garbage://1.1.1.1:1234/foo/bar"},"type":"startup"},{"exec":{"command":["/bin/true"]},"type":"liveness"}]}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.golden
@@ -48,6 +48,7 @@ spec:
         acorn.io/container-spec: '{"annotations":{"both":"con1val","con1":"value"},"image":"foo","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":80,"protocol":"http","targetPort":81},{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}'
         both: con1val
         con1: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>,<Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -161,6 +162,7 @@ spec:
         acorn.io/container-spec: '{"annotations":{"both":"con2val","con2":"value"},"image":"foo","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":80,"protocol":"tcp","targetPort":81},{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}'
         both: con2val
         con2: value
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.golden
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -130,6 +131,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
+        policy.cilium.io/proxy-visibility: <Ingress/81/TCP/HTTP>
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -71,6 +71,8 @@ const (
 	PrometheusScrape = "prometheus.io/scrape"
 	PrometheusPath   = "prometheus.io/path"
 	PrometheusPort   = "prometheus.io/port"
+
+	CiliumProxyVisibility = "policy.cilium.io/proxy-visibility"
 )
 
 func Merge(base, overlay map[string]string) map[string]string {


### PR DESCRIPTION
These are needed in order to get HTTP metrics from Cilium.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

