### PR TITLE
Add imageName to ImageDetail command to support wildcards

### DIFF
--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -230,6 +230,7 @@ type ImageDetails struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Input Params
+	ImageName    string        `json:"imageName,omitempty"`
 	NestedDigest string        `json:"nestedDigest,omitempty"`
 	DeployArgs   v1.GenericMap `json:"deployArgs,omitempty"`
 	Profiles     []string      `json:"profiles,omitempty"`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -189,6 +189,7 @@ type ImageDetails struct {
 	AppImage        v1.AppImage   `json:"appImage,omitempty"`
 	AppSpec         *v1.AppSpec   `json:"appSpec,omitempty"`
 	Params          *v1.ParamSpec `json:"params,omitempty"`
+	ImageName       string        `json:"imageName,omitempty"`
 	SignatureDigest string        `json:"signatureDigest,omitempty"`
 	Readme          string        `json:"readme,omitempty"`
 	ParseError      string        `json:"parseError,omitempty"`

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -35,9 +35,9 @@ func (c *DefaultClient) ImageTag(ctx context.Context, imageName, tag string) err
 }
 
 func (c *DefaultClient) ImageDetails(ctx context.Context, imageName string, opts *ImageDetailsOptions) (*ImageDetails, error) {
-	imageName = strings.ReplaceAll(imageName, "/", "+")
-
-	detailsResult := &apiv1.ImageDetails{}
+	detailsResult := &apiv1.ImageDetails{
+		ImageName: imageName,
+	}
 
 	if opts != nil {
 		detailsResult.DeployArgs = opts.DeployArgs
@@ -50,7 +50,7 @@ func (c *DefaultClient) ImageDetails(ctx context.Context, imageName string, opts
 	err := c.RESTClient.Post().
 		Namespace(c.Namespace).
 		Resource("images").
-		Name(imageName).
+		Name("_").
 		SubResource("details").
 		Body(detailsResult).
 		Do(ctx).Into(detailsResult)
@@ -59,6 +59,7 @@ func (c *DefaultClient) ImageDetails(ctx context.Context, imageName string, opts
 	}
 
 	return &ImageDetails{
+		ImageName:       detailsResult.ImageName,
 		AppImage:        detailsResult.AppImage,
 		AppSpec:         detailsResult.AppSpec,
 		Readme:          detailsResult.Readme,

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -109,6 +109,7 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 			Name:      imageName,
 			Namespace: namespace,
 		},
+		ImageName:       imageName,
 		DeployArgs:      details.DeployArgs,
 		Profiles:        profiles,
 		Params:          details.Params,

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3717,11 +3717,17 @@ func schema_pkg_apis_apiacornio_v1_ImageDetails(ref common.ReferenceCallback) co
 							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
-					"nestedDigest": {
+					"imageName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Input Params",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"nestedDigest": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"deployArgs": {

--- a/pkg/server/registry/apigroups/acorn/images/detail.go
+++ b/pkg/server/registry/apigroups/acorn/images/detail.go
@@ -41,22 +41,25 @@ func (s *ImageDetailStrategy) Get(ctx context.Context, namespace, name string) (
 
 func (s *ImageDetailStrategy) Create(ctx context.Context, obj types.Object) (types.Object, error) {
 	details := obj.(*apiv1.ImageDetails)
-	if details.Name == "" {
+	if details.ImageName == "" {
+		details.ImageName = details.Name
+	}
+	if details.ImageName == "" {
 		ri, ok := request.RequestInfoFrom(ctx)
 		if ok {
-			details.Name = ri.Name
+			details.ImageName = ri.Name
 		}
 	}
 	ns, _ := request.NamespaceFrom(ctx)
 	opts := []remote.Option{s.remoteOpt}
 	if details.Auth != nil {
-		imageName := strings.ReplaceAll(details.Name, "+", "/")
+		imageName := strings.ReplaceAll(details.ImageName, "+", "/")
 		ref, err := name.ParseReference(imageName)
 		if err == nil {
 			opts = append(opts, remote.WithAuthFromKeychain(images.NewSimpleKeychain(ref.Context(), *details.Auth, nil)))
 		}
 	}
-	return imagedetails.GetImageDetails(ctx, s.client, ns, details.Name, details.Profiles, details.DeployArgs, details.NestedDigest, details.NoDefaultRegistry, opts...)
+	return imagedetails.GetImageDetails(ctx, s.client, ns, details.ImageName, details.Profiles, details.DeployArgs, details.NestedDigest, details.NoDefaultRegistry, opts...)
 }
 
 func (s *ImageDetailStrategy) New() types.Object {


### PR DESCRIPTION
acorn image detail now support passing patterns supported by autoupgrade.

Signed-off-by: Darren Shepherd <darren@acorn.io>
