### PR TITLE
Export function for object existence in a project region

### DIFF
--- a/integration/client/apps/update_test.go
+++ b/integration/client/apps/update_test.go
@@ -36,7 +36,7 @@ func TestUpdatePull(t *testing.T) {
 	}
 
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.AppImage.ID == imageID
+		return obj.Status.AppImage.ID == imageID && obj.Status.Ready
 	})
 	assert.NotEmpty(t, app.Status.Namespace)
 	assert.Equal(t, app.Status.AppImage.ID, imageID)

--- a/pkg/server/registry/apigroups/acorn/projects/validator_test.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator_test.go
@@ -544,6 +544,46 @@ func TestProjectUpdateValidation(t *testing.T) {
 				},
 			).Build(),
 		},
+		{
+			name:      "Update project to remove supported region that was defaulted, but app exists in removed region",
+			wantError: true,
+			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
+				Status: v1.ProjectInstanceStatus{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
+				Spec: v1.ProjectInstanceSpec{
+					SupportedRegions: []string{"my-region"},
+				},
+				Status: v1.ProjectInstanceStatus{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.AppList{
+					Items: []apiv1.App{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "my-app",
+								Namespace: "my-project",
+							},
+							Spec: v1.AppInstanceSpec{
+								Region: "my-other-region",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The function is being exported so that it can be used in other packages that need similar functionality. A test is also added for an untested edge case.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

