### PR TITLE
send eks nightly failures to both ci-reports and engineering channels

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: sudo install -o root -g root -m 0755 ./bin/acorn /usr/local/bin/acorn
 
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.GHA_SVC_ACC_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.GHA_SVC_ACC_AWS_SECRET_ACCESS_KEY }}
@@ -72,7 +72,7 @@ jobs:
         id: slack-failure
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}'
+          channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }},${{ secrets.SLACK_BOT_SUCCESS_CHANNEL }}'
           slack-message: "❌ Nightly EKS test had ${{ steps.test_summary.outputs.failed }} test case(s) fail: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
         id: unit-test
         run: TEST_FLAGS="--junitfile unit-test-summary.xml" make unit
       - name: Build test summary
-        uses: test-summary/action@v1
+        uses: test-summary/action@v2
         if: "!cancelled() && steps.unit-test.conclusion != 'skipped'"
         with:
           paths: unit-test-summary.xml
@@ -92,7 +92,7 @@ jobs:
         id: integration-tests
         run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile integration-test-summary.xml" make integration
       - name: Build test summary
-        uses: test-summary/action@v1
+        uses: test-summary/action@v2
         if: "!cancelled() && steps.integration-tests.conclusion != 'skipped'"
         with:
           paths: integration-test-summary.xml


### PR DESCRIPTION
Version bump based on a notice on the following ci report: https://github.com/acorn-io/runtime/actions/runs/5818000632

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

