### PR TITLE
Add -w to acorn kube to write kubeconfig to a file

### DIFF
--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -119,6 +119,11 @@ type MockClient struct {
 	EventItem        *apiv1.Event
 }
 
+func (m *MockClient) KubeConfig(ctx context.Context, opts *client.KubeProxyAddressOptions) ([]byte, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *MockClient) KubeProxyAddress(ctx context.Context, opts *client.KubeProxyAddressOptions) (string, error) {
 	//TODO implement me
 	panic("implement me")

--- a/pkg/client/deferred.go
+++ b/pkg/client/deferred.go
@@ -459,6 +459,13 @@ func (d *DeferredClient) GetClient() (client.WithWatch, error) {
 	return d.Client.GetClient()
 }
 
+func (d *DeferredClient) KubeConfig(ctx context.Context, opts *KubeProxyAddressOptions) ([]byte, error) {
+	if err := d.create(); err != nil {
+		return nil, err
+	}
+	return d.Client.KubeConfig(ctx, opts)
+}
+
 func (d *DeferredClient) KubeProxyAddress(ctx context.Context, opts *KubeProxyAddressOptions) (string, error) {
 	if err := d.create(); err != nil {
 		return "", err

--- a/pkg/client/multi.go
+++ b/pkg/client/multi.go
@@ -656,6 +656,14 @@ func (m *MultiClient) GetClient() (kclient.WithWatch, error) {
 	return c.GetClient()
 }
 
+func (m *MultiClient) KubeConfig(ctx context.Context, opts *KubeProxyAddressOptions) ([]byte, error) {
+	c, err := m.Factory.ForProject(context.Background(), m.Factory.DefaultProject())
+	if err != nil {
+		panic(err)
+	}
+	return c.KubeConfig(ctx, opts)
+}
+
 func (m *MultiClient) KubeProxyAddress(ctx context.Context, opts *KubeProxyAddressOptions) (string, error) {
 	c, err := m.Factory.ForProject(context.Background(), m.Factory.DefaultProject())
 	if err != nil {

--- a/pkg/mocks/mock_client.go
+++ b/pkg/mocks/mock_client.go
@@ -690,6 +690,21 @@ func (mr *MockClientMockRecorder) Info(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), arg0)
 }
 
+// KubeConfig mocks base method.
+func (m *MockClient) KubeConfig(arg0 context.Context, arg1 *client.KubeProxyAddressOptions) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KubeConfig", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KubeConfig indicates an expected call of KubeConfig.
+func (mr *MockClientMockRecorder) KubeConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubeConfig", reflect.TypeOf((*MockClient)(nil).KubeConfig), arg0, arg1)
+}
+
 // KubeProxyAddress mocks base method.
 func (m *MockClient) KubeProxyAddress(arg0 context.Context, arg1 *client.KubeProxyAddressOptions) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

