### PR TITLE
Take the default context into account when printing project information

### DIFF
--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -119,9 +119,10 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 				}
 			}
 
+			projectName := project.RenderProjectName(projectItem.FullName, cfg.DefaultContext)
 			out.WriteFormatted(projectEntry{
-				Name:    project.RenderProjectName(projectItem.FullName, cfg.DefaultContext),
-				Default: defaultProject == projectItem.FullName,
+				Name:    projectName,
+				Default: defaultProject == projectName,
 				Regions: supportedRegions,
 			}, projectItem.Project)
 		}


### PR DESCRIPTION
The default context was being taken into account when displaying a project name, but not when determining the default project output. This change will take the default context into account for the default display.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

