### PR TITLE
Print local credential usage after builds (#2068)

### DIFF
--- a/pkg/buildclient/client.go
+++ b/pkg/buildclient/client.go
@@ -79,7 +79,7 @@ func Stream(ctx context.Context, cwd string, streams *streams.Output, dialer Web
 		if len(credHits) < 1 || streams.Out == nil {
 			return
 		}
-		if _, err := fmt.Fprintln(streams.Out, "Used local build credentials for:", strings.Join(sets.List(credHits), ", ")); err != nil {
+		if _, err := fmt.Fprintln(streams.Out, "Used local credentials for:", strings.Join(sets.List(credHits), ", ")); err != nil {
 			logrus.WithError(err).Error("failed to print credential hits")
 		}
 	}()


### PR DESCRIPTION
Print a message to stdout when local docker credentials are used during `acorn build`.
This should make it more obvious when builds fail due to invalid local
credentials.

The message is printed at the end of both successful and failed builds.

e.g. output of a failed build w/ local cred usage message

```
[+] Building 5.3s (11/11) FINISHED                                                                                                                                   
   // ... ELIDED BUILD OUTPUT                                                                                                              0.0s
 => ERROR exporting to image                                                                                                                                    3.9s
 => => exporting layers                                                                                                                                         0.0s
 => => exporting manifest sha256:db534d916562a0663ee07bd52e8549431d6b13cc8c32c26e1a9ca55fdde61e28                                                               0.0s
 => => exporting config sha256:e4081843971dd0852fa32d8e83a21d5842887e826a1c252d0b1fd1892302c385                                                                 0.0s
 => => pushing layers                                                                                                                                           3.9s
------
 > exporting to image:
------
Used local credentials for: ghcr.io, index.docker.io
  ✗  ERROR:  failed to solve: failed to push ghcr.io/njhale/local-private-acornacorn: failed to authorize: failed to fetch oauth token: unexpected status: 403 Forbidden
```

Addresses #2068