### PR TITLE
Add the ability to set the log level at startup (#2072)

### DIFF
--- a/pkg/logserver/logserver.go
+++ b/pkg/logserver/logserver.go
@@ -24,9 +24,14 @@ type Server struct {
 	Debug          bool
 }
 
-// StartServerWithDefaults starts the server with default values
+// StartServerWithDefaults starts the server with default values. If the ACORN_LOG_LEVEL environment variable is set,
+// it will be parsed and used to set the log level.
 func StartServerWithDefaults() {
-	logrus.SetLevel(logrus.InfoLevel)
+	if level, err := logrus.ParseLevel(os.Getenv("ACORN_LOG_LEVEL")); err == nil {
+		logrus.SetLevel(level)
+	} else {
+		logrus.SetLevel(logrus.InfoLevel)
+	}
 	s := Server{
 		SocketLocation: DefaultSocketLocation,
 	}


### PR DESCRIPTION
Previously, in order to change the log level, one must exec into each container and run a command. This is nice for existing containers, but can be tedious if trying to run containers from the start with a log level different from "info."

This change adds the ability to set an environment variable and start the container with a desired log level.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/runtime/issues/2072