### PR TITLE
change: Improve Usage of ImageAllowRules (#2067 + #2064 + #2069)

### DIFF
--- a/integration/client/signatures/rules_test.go
+++ b/integration/client/signatures/rules_test.go
@@ -137,7 +137,7 @@ func TestImageAllowRules(t *testing.T) {
 
 	// try to run - expect success
 	app, err := c.AppRun(ctx, tagName, nil)
-	assert.NoError(t, err, "should not error since image is covered by images scope of IAR and there are not other rules")
+	assert.NoError(t, err, "should not error since image `%s` is covered by images scope `%+v` of IAR and there are not other rules", tagName, iar.Images)
 
 	// remove app
 	_, err = c.AppDelete(ctx, app.Name)

--- a/pkg/cli/images_sign.go
+++ b/pkg/cli/images_sign.go
@@ -135,7 +135,7 @@ func (a *ImageSign) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pterm.Success.Printf("Done: Pushed signature %s\n", sig.SignatureDigest)
+	pterm.Success.Printf("Created signature %s\n", sig.SignatureDigest)
 
 	return nil
 }

--- a/pkg/imageallowrules/imageallowrules.go
+++ b/pkg/imageallowrules/imageallowrules.go
@@ -115,7 +115,8 @@ iarLoop:
 		// Any verification error or failed verification issue will skip on to the next IAR
 		for _, rule := range imageAllowRule.Signatures.Rules {
 			if err := cosign.EnsureReferences(ctx, c, image, namespace, &verifyOpts); err != nil {
-				return err
+				logrus.Infof("failed checking image %s against %s/%s.signatures: %v", image, imageAllowRule.Namespace, imageAllowRule.Name, err)
+				continue iarLoop
 			}
 			verifyOpts.AnnotationRules = rule.Annotations
 

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -178,7 +178,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		}
 
 		if !disableCheckImageAllowRules {
-			if err := s.checkImageAllowed(ctx, app.Namespace, checkImage, remote.WithTransport(s.transport)); err != nil {
+			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, imageDetails.ImageName, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
 				result = append(result, field.Forbidden(field.NewPath("spec", "image"), fmt.Sprintf("%s not allowed to run: %s", app.Spec.Image, err.Error())))
 				return
 			}
@@ -832,12 +832,4 @@ func (s *Validator) getImageDetails(ctx context.Context, namespace string, profi
 	}
 
 	return details, nil
-}
-
-func (s *Validator) checkImageAllowed(ctx context.Context, namespace, image string, opts ...remote.Option) error {
-	digest, _, err := s.resolveLocalImage(ctx, namespace, image)
-	if err != nil {
-		return err
-	}
-	return imageallowrules.CheckImageAllowed(ctx, s.client, namespace, image, digest, opts...)
 }

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -178,7 +178,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		}
 
 		if !disableCheckImageAllowRules {
-			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, imageDetails.ImageName, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
+			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, checkImage, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
 				result = append(result, field.Forbidden(field.NewPath("spec", "image"), fmt.Sprintf("%s not allowed to run: %s", app.Spec.Image, err.Error())))
 				return
 			}

--- a/pkg/server/registry/apigroups/acorn/images/sign.go
+++ b/pkg/server/registry/apigroups/acorn/images/sign.go
@@ -117,7 +117,11 @@ func (t *ImageSignStrategy) ImageSign(ctx context.Context, namespace string, sig
 		return "", err
 	}
 
-	logrus.Debugf("Wrote signature %s to %s", sigOCIDigest, targetRepo.Name())
+	logrus.Infof("Wrote signature %s to %s", sigOCIDigest, targetRepo.Name())
+	dig, err := signatureOCI.Digest()
+	if err == nil {
+		logrus.Infof("Signature OCI digest: %s", dig.String())
+	}
 
 	return sigOCIDigest.String(), nil
 }

--- a/pkg/server/registry/apigroups/acorn/images/sign.go
+++ b/pkg/server/registry/apigroups/acorn/images/sign.go
@@ -92,7 +92,7 @@ func (t *ImageSignStrategy) ImageSign(ctx context.Context, namespace string, sig
 		mutateOpts = append(mutateOpts, mutate.WithDupeDetector(dupeDetector))
 	}
 
-	ociEntity, err := ociremote.SignedEntity(ref, ociremote.WithRemoteOptions(remoteOpts...))
+	targetEntity, err := ociremote.SignedEntity(ref, ociremote.WithRemoteOptions(remoteOpts...))
 	if err != nil {
 		return "", fmt.Errorf("accessing entity: %w", err)
 	}
@@ -102,26 +102,27 @@ func (t *ImageSignStrategy) ImageSign(ctx context.Context, namespace string, sig
 		return "", err
 	}
 
-	sigOCIDigest, err := signatureOCI.Digest()
-	if err != nil {
-		return "", err
-	}
-
-	mutatedOCIEntity, err := mutate.AttachSignatureToEntity(ociEntity, signatureOCI, mutateOpts...)
+	signedEntity, err := mutate.AttachSignatureToEntity(targetEntity, signatureOCI, mutateOpts...)
 	if err != nil {
 		return "", err
 	}
 
 	targetRepo := ref.Context()
-	if err := ociremote.WriteSignatures(targetRepo, mutatedOCIEntity, ociremote.WithRemoteOptions(remoteOpts...)); err != nil {
+
+	if err := ociremote.WriteSignatures(targetRepo, signedEntity, ociremote.WithRemoteOptions(remoteOpts...)); err != nil {
 		return "", err
 	}
 
-	logrus.Infof("Wrote signature %s to %s", sigOCIDigest, targetRepo.Name())
-	dig, err := signatureOCI.Digest()
-	if err == nil {
-		logrus.Infof("Signature OCI digest: %s", dig.String())
+	// Get the digest of the signature artifact we just wrote
+	se, err := signedEntity.Signatures()
+	if err != nil {
+		return "", err
 	}
+	sigDigest, err := se.Digest()
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Wrote signatures artifact %s to %s", sigDigest, targetRepo.Name())
 
-	return sigOCIDigest.String(), nil
+	return sigDigest.String(), nil
 }


### PR DESCRIPTION
This addresses a bunch of issues around the UX of image signatures and IARs

Ref [#2067](https://github.com/acorn-io/runtime/issues/2067)
Ref [#2064](https://github.com/acorn-io/runtime/issues/2064)
Ref [#2069](https://github.com/acorn-io/runtime/issues/2069)

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

