### PR TITLE
Use AppInstance type instead of App for get/list of Jobs

### DIFF
--- a/pkg/client/jobs.go
+++ b/pkg/client/jobs.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,12 +39,10 @@ func (c *DefaultClient) JobList(ctx context.Context, opts *JobListOptions) ([]ap
 }
 
 func (c *DefaultClient) JobRestart(ctx context.Context, name string) error {
-	rs := &apiv1.JobRestart{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: c.Namespace}}
-
 	return c.RESTClient.Post().
 		Namespace(c.Namespace).
 		Resource("jobs").
 		Name(name).
 		SubResource("restart").
-		Body(rs).Do(ctx).Error()
+		Body(&apiv1.JobRestart{}).Do(ctx).Error()
 }

--- a/pkg/server/registry/apigroups/acorn/jobs/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/jobs/strategy.go
@@ -32,7 +32,7 @@ func (s *Strategy) New() types.Object {
 }
 
 func (s *Strategy) List(ctx context.Context, namespace string, options storage.ListOptions) (types.ObjectList, error) {
-	apps := &apiv1.AppList{}
+	apps := &internalapiv1.AppInstanceList{}
 	if err := s.client.List(ctx, apps, strategy.ToListOpts(namespace, options)); err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s *Strategy) Get(ctx context.Context, namespace, name string) (types.Objec
 	}, name)
 }
 
-func jobStatusToJob(namespace string, app apiv1.App, jobStatus internalapiv1.JobStatus) apiv1.Job {
+func jobStatusToJob(namespace string, app internalapiv1.AppInstance, jobStatus internalapiv1.JobStatus) apiv1.Job {
 	creationTime := jobStatus.CreationTime
 	if creationTime == nil {
 		creationTime = &metav1.Time{}


### PR DESCRIPTION
In order to properly work with Manager, we should be using the `AppInstance` (internal) type for `Apps`. Since the `Jobs` is  essentially a wrapper around the `AppStatus.Jobs` section of an `App`'s status this is essential to properly work in Manager.

This also removes a section of code the client that is not needed and blocks the creation of the JobRestart sub resource in manager.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X]  Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

