### PR TITLE
Add a global acorn config option

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -252,7 +252,7 @@ func TestBuildNestedAcornWithLocalImage(t *testing.T) {
 	}
 
 	// build the Nginx image
-	source := imagesource.NewImageSource("./testdata/nested/nginx.Acornfile", []string{}, []string{}, []string{}, false)
+	source := imagesource.NewImageSource("", "./testdata/nested/nginx.Acornfile", []string{}, []string{}, []string{}, false)
 	image, _, err := source.GetImageAndDeployArgs(helper.GetCTX(t), c)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/dev/dev_test.go
+++ b/integration/dev/dev_test.go
@@ -60,7 +60,7 @@ func TestDev(t *testing.T) {
 	eg := errgroup.Group{}
 	eg.Go(func() error {
 		return dev.Dev(subCtx, helper.BuilderClient(t, project.Name), &dev.Options{
-			ImageSource: imagesource.NewImageSource(acornCueFile, []string{tmp}, nil, nil, false),
+			ImageSource: imagesource.NewImageSource("", acornCueFile, []string{tmp}, nil, nil, false),
 			Run: client.AppRunOptions{
 				Name: "test-app",
 			},

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1766,7 +1766,7 @@ func TestAutoUpgradeLocalImage(t *testing.T) {
 	}
 
 	// Deploy the app
-	imageSource := imagesource.NewImageSource("", []string{"mylocalimage"}, []string{}, nil, true)
+	imageSource := imagesource.NewImageSource("", "", []string{"mylocalimage"}, []string{}, nil, true)
 	appImage, _, err := imageSource.GetImageAndDeployArgs(ctx, c)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -84,10 +84,11 @@ func New() *cobra.Command {
 }
 
 type Acorn struct {
-	Kubeconfig string `usage:"Explicitly use kubeconfig file, overriding the default context" env:"ACORN_KUBECONFIG"`
-	Project    string `usage:"Project to work in" short:"j" env:"ACORN_PROJECT"`
-	Debug      bool   `usage:"Enable debug logging" env:"ACORN_DEBUG"`
-	DebugLevel int    `usage:"Debug log level (valid 0-9) (default 7)" env:"ACORN_DEBUG_LEVEL"`
+	AcornConfig string `usage:"Path of the acorn config file to use" name:"config" env:"ACORN_CONFIG_FILE"`
+	Kubeconfig  string `usage:"Explicitly use kubeconfig file, overriding the default context" env:"ACORN_KUBECONFIG"`
+	Project     string `usage:"Project to work in" short:"j" env:"ACORN_PROJECT"`
+	Debug       bool   `usage:"Enable debug logging" env:"ACORN_DEBUG"`
+	DebugLevel  int    `usage:"Debug log level (valid 0-9) (default 7)" env:"ACORN_DEBUG_LEVEL"`
 }
 
 func setEnv(key, value string) error {

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -25,7 +25,7 @@ func getAuthForImage(ctx context.Context, clientFactory ClientFactory, image str
 		return nil, nil
 	}
 
-	creds, err := imagesource.GetCreds(c)
+	creds, err := imagesource.GetCreds(clientFactory.Options().AcornConfig, c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -57,7 +57,7 @@ func (s *Build) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	helper := imagesource.NewImageSource(s.File, args, s.Profile, s.Platform, false)
+	helper := imagesource.NewImageSource(s.client.Options().AcornConfig, s.File, args, s.Profile, s.Platform, false)
 
 	image, _, err := helper.GetImageAndDeployArgs(cmd.Context(), c)
 	if err != nil {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -29,9 +29,10 @@ type CommandClientFactory struct {
 
 func (c *CommandClientFactory) Options() project.Options {
 	return project.Options{
-		Project:    c.acorn.Project,
-		Kubeconfig: c.acorn.Kubeconfig,
-		ContextEnv: os.Getenv("CONTEXT"),
+		AcornConfig: c.acorn.AcornConfig,
+		Project:     c.acorn.Project,
+		Kubeconfig:  c.acorn.Kubeconfig,
+		ContextEnv:  os.Getenv("CONTEXT"),
 	}
 }
 

--- a/pkg/cli/credential_test.go
+++ b/pkg/cli/credential_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/acorn-io/runtime/pkg/cli/testdata"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCredential(t *testing.T) {
 	cfgDir, err := os.MkdirTemp("", "acorn-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(cfgDir)
-	os.Setenv("ACORN_CONFIG_FILE", filepath.Join(cfgDir, "acorn.yaml"))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(cfgDir))
+	}()
+	acornConfig := filepath.Join(cfgDir, "acorn.yaml")
 
 	type fields struct {
 		Quiet  bool
@@ -42,15 +42,17 @@ func TestCredential(t *testing.T) {
 	}{
 		{
 			name: "acorn credential found", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					AcornConfig: acornConfig,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{"--", "test-server-address"},
@@ -61,15 +63,17 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			name: "acorn credential dne", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					AcornConfig: acornConfig,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{"--", "dne"},
@@ -80,15 +84,17 @@ func TestCredential(t *testing.T) {
 		},
 		{
 			name: "acorn credential", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					AcornConfig: acornConfig,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{},
@@ -111,7 +117,7 @@ func TestCredential(t *testing.T) {
 			} else if err != nil && tt.wantErr {
 				assert.Equal(t, tt.wantOut, err.Error())
 			} else {
-				w.Close()
+				require.NoError(t, w.Close())
 				out, _ := io.ReadAll(r)
 				assert.Equal(t, tt.wantOut, string(out))
 			}

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -59,7 +59,7 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	imageSource := imagesource.NewImageSource(s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+	imageSource := imagesource.NewImageSource(s.client.Options().AcornConfig, s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
 
 	opts, err := s.ToOpts()
 	if err != nil {

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -51,7 +51,7 @@ func (s *Info) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Testing/mocking ReadCLIConfig() is difficult. Any better way to test?
-	cfg, err := config.ReadCLIConfig(true)
+	cfg, err := config.ReadCLIConfig(s.client.Options().AcornConfig, true)
 	if err != nil {
 		logrus.Errorf("failed to read CLI config: %v", err)
 		cfg = nil

--- a/pkg/cli/info_test.go
+++ b/pkg/cli/info_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,10 +31,10 @@ func TestInfo(t *testing.T) {
 	}{
 		{
 			name: "acorn info", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			prepare: func(f *mocks.MockClient) {
 				f.EXPECT().Info(gomock.Any()).Return(
 					[]apiv1.Info{
@@ -56,10 +57,10 @@ func TestInfo(t *testing.T) {
 		},
 		{
 			name: "acorn info empty response", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			prepare: func(f *mocks.MockClient) {
 				f.EXPECT().Info(gomock.Any()).Return(
 					nil, nil)
@@ -70,10 +71,10 @@ func TestInfo(t *testing.T) {
 		},
 		{
 			name: "acorn info -A", fields: fields{
-				All:    true,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    true,
+			Quiet:  false,
+			Output: "",
+		},
 			// Want to return two entries
 			prepare: func(f *mocks.MockClient) {
 				f.EXPECT().Info(gomock.Any()).Return(
@@ -108,10 +109,10 @@ func TestInfo(t *testing.T) {
 		},
 		{
 			name: "acorn info -o yaml", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			prepare: func(f *mocks.MockClient) {
 				f.EXPECT().Info(gomock.Any()).Return([]apiv1.Info{
 					{
@@ -133,10 +134,10 @@ func TestInfo(t *testing.T) {
 		},
 		{
 			name: "acorn info -o json", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
+			All:    false,
+			Quiet:  false,
+			Output: "",
+		},
 			prepare: func(f *mocks.MockClient) {
 				f.EXPECT().Info(gomock.Any()).Return(
 					[]apiv1.Info{
@@ -169,12 +170,12 @@ func TestInfo(t *testing.T) {
 
 			r, w, _ := os.Pipe()
 			os.Stdout = w
-			os.Setenv("ACORN_CONFIG_FILE", "/fake-file")
 
 			// Mock client factory just returns the gomock client.
 			cmd := NewInfo(CommandContext{
 				ClientFactory: &testdata.MockClientFactoryManual{
-					Client: mClient,
+					AcornConfig: "/fake-file",
+					Client:      mClient,
 				},
 				StdOut: w,
 				StdErr: w,
@@ -188,7 +189,7 @@ func TestInfo(t *testing.T) {
 			} else if err != nil && tt.wantErr {
 				assert.Equal(t, tt.wantOut, err.Error())
 			} else {
-				w.Close()
+				require.NoError(t, w.Close())
 				out, _ := io.ReadAll(r)
 				testOut, _ := os.ReadFile(tt.wantOut)
 				assert.Equal(t, string(testOut), string(out))

--- a/pkg/cli/render.go
+++ b/pkg/cli/render.go
@@ -30,7 +30,7 @@ type Render struct {
 func (s *Render) Run(cmd *cobra.Command, args []string) error {
 	var c client2.Client
 
-	imageAndArgs := imagesource.NewImageSource(s.File, args, s.Profile, nil, false)
+	imageAndArgs := imagesource.NewImageSource(s.client.Options().AcornConfig, s.File, args, s.Profile, nil, false)
 
 	_, file, err := imageAndArgs.ResolveImageAndFile()
 	if err != nil {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -233,7 +233,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	var (
-		imageSource = imagesource.NewImageSource(s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+		imageSource = imagesource.NewImageSource(s.client.Options().AcornConfig, s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
 		app         *apiv1.App
 		updated     bool
 	)

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -19,11 +19,14 @@ import (
 )
 
 type MockClientFactoryManual struct {
-	Client client.Client
+	AcornConfig string
+	Client      client.Client
 }
 
 func (dc *MockClientFactoryManual) Options() project.Options {
-	return project.Options{}
+	return project.Options{
+		AcornConfig: dc.AcornConfig,
+	}
 }
 
 func (dc *MockClientFactoryManual) CreateDefault() (client.Client, error) {
@@ -35,6 +38,7 @@ func (dc *MockClientFactoryManual) CreateWithAllProjects() (client.Client, error
 }
 
 type MockClientFactory struct {
+	AcornConfig      string
 	AppList          []apiv1.App
 	AppItem          *apiv1.App
 	ContainerList    []apiv1.ContainerReplica
@@ -62,7 +66,9 @@ type MockClientFactory struct {
 }
 
 func (dc *MockClientFactory) Options() project.Options {
-	return project.Options{}
+	return project.Options{
+		AcornConfig: dc.AcornConfig,
+	}
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {

--- a/pkg/cli/testdata/acorn/acorn_test_info.txt
+++ b/pkg/cli/testdata/acorn/acorn_test_info.txt
@@ -43,6 +43,7 @@ Available Commands:
   wait         Wait an app to be ready then exit with status code 0
 
 Flags:
+      --config string       Path of the acorn config file to use
       --debug               Enable debug logging
       --debug-level int     Debug log level (valid 0-9) (default 7)
   -h, --help                help for acorn

--- a/pkg/imagesource/helper.go
+++ b/pkg/imagesource/helper.go
@@ -25,9 +25,13 @@ type ImageSource struct {
 	// NoDefaultRegistry - if true, indicates that no container registry should be assumed for the Image.
 	// This is used if the ImageSource is for an app with auto-upgrade enabled.
 	NoDefaultRegistry bool
+
+	// acornConfig is the path to the acorn config file.
+	acornConfig string
 }
 
-func NewImageSource(file string, args, profiles, platforms []string, noDefaultReg bool) (result ImageSource) {
+func NewImageSource(acornConfig string, file string, args, profiles, platforms []string, noDefaultReg bool) (result ImageSource) {
+	result.acornConfig = acornConfig
 	result.File = file
 	result.Image, result.Args = splitImageAndArgs(args)
 	result.Profiles = profiles
@@ -172,7 +176,7 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 	// if file is set, then we must build to get the image, if it's not set, then
 	// it must be an external image
 	if i.File != "" {
-		creds, err := GetCreds(c)
+		creds, err := GetCreds(i.acornConfig, c)
 		if err != nil {
 			return "", nil, err
 		}
@@ -204,8 +208,8 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 	return i.Image, deployArgs, err
 }
 
-func GetCreds(c client.Client) (client.CredentialLookup, error) {
-	cfg, err := config.ReadCLIConfig(false)
+func GetCreds(acornConfig string, c client.Client) (client.CredentialLookup, error) {
+	cfg, err := config.ReadCLIConfig(acornConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagesource/platforms_test.go
+++ b/pkg/imagesource/platforms_test.go
@@ -14,7 +14,7 @@ func TestParamsHelp(t *testing.T) {
 		file = "testdata/params/Acornfile"
 		cwd  = "testdata/params"
 	)
-	_, _, err := NewImageSource(file, []string{
+	_, _, err := NewImageSource("", file, []string{
 		cwd,
 		"image-name",
 		"--str=s",
@@ -30,10 +30,11 @@ func TestParamsHelp(t *testing.T) {
 
 func TestParams(t *testing.T) {
 	var (
-		file = "testdata/params/Acornfile"
-		cwd  = "testdata/params"
+		acornConfig string
+		file        = "testdata/params/Acornfile"
+		cwd         = "testdata/params"
 	)
-	_, params, err := NewImageSource(file, []string{
+	_, params, err := NewImageSource(acornConfig, file, []string{
 		cwd,
 		"image-name",
 		"--str=s",

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -142,7 +142,7 @@ func Login(ctx context.Context, cfg *config.CLIConfig, password, address string)
 	}
 
 	// reload config, could have changed
-	if newCfg, err := config.ReadCLIConfig(false); err != nil {
+	if newCfg, err := config.ReadCLIConfig(cfg.AcornConfig, false); err != nil {
 		return user, pass, err
 	} else {
 		*cfg = *newCfg

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -22,6 +22,7 @@ var (
 )
 
 type Options struct {
+	AcornConfig string
 	Project     string
 	Kubeconfig  string
 	ContextEnv  string
@@ -29,7 +30,7 @@ type Options struct {
 }
 
 func (o Options) CLIConfig() (*config.CLIConfig, error) {
-	return config.ReadCLIConfig(o.Kubeconfig != "")
+	return config.ReadCLIConfig(o.AcornConfig, o.Kubeconfig != "")
 }
 
 func Client(ctx context.Context, opts Options) (client.Client, error) {


### PR DESCRIPTION
Add a global `--config` option to the acorn cli that allows users to
set the acorn config file to use during command execution.

e.g. Set the current project to `foo` in `./special-config.yaml`

```sh
$ acorn --config special-config.yaml project use foo
```

If both `--config` and `ACORN_CONFIG_FILE` are provided, `--config`
takes precedence.

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
