### PR TITLE
Add a global acorn config option

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn.md
+++ b/docs/docs/100-reference/01-command-line/acorn.md
@@ -16,11 +16,12 @@ acorn [flags]
 ### Options
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-  -h, --help                help for acorn
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+  -h, --help                 help for acorn
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_all.md
+++ b/docs/docs/100-reference/01-command-line/acorn_all.md
@@ -29,10 +29,11 @@ acorn all
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_build.md
+++ b/docs/docs/100-reference/01-command-line/acorn_build.md
@@ -35,10 +35,11 @@ acorn build .
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_check.md
+++ b/docs/docs/100-reference/01-command-line/acorn_check.md
@@ -30,10 +30,11 @@ acorn check
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_container.md
+++ b/docs/docs/100-reference/01-command-line/acorn_container.md
@@ -28,10 +28,11 @@ acorn containers
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_container_kill.md
+++ b/docs/docs/100-reference/01-command-line/acorn_container_kill.md
@@ -25,13 +25,14 @@ acorn container kill app-name.containername-generated-hash
 ### Options inherited from parent commands
 
 ```
-  -a, --all                 Include stopped containers
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+  -a, --all                  Include stopped containers
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_copy.md
@@ -38,10 +38,11 @@ acorn copy [flags] SOURCE DESTINATION
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_credential.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential.md
@@ -27,10 +27,11 @@ acorn credential
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_credential_login.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential_login.md
@@ -31,12 +31,13 @@ acorn login ghcr.io
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_credential_logout.md
+++ b/docs/docs/100-reference/01-command-line/acorn_credential_logout.md
@@ -26,12 +26,13 @@ acorn logout ghcr.io
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_dev.md
+++ b/docs/docs/100-reference/01-command-line/acorn_dev.md
@@ -38,10 +38,11 @@ acorn dev --name wandering-sound <IMAGE>
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -68,10 +68,11 @@ acorn events [flags] [PREFIX]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_exec.md
+++ b/docs/docs/100-reference/01-command-line/acorn_exec.md
@@ -26,10 +26,11 @@ acorn exec [flags] ACORN_NAME|CONTAINER_NAME CMD
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_fmt.md
+++ b/docs/docs/100-reference/01-command-line/acorn_fmt.md
@@ -18,10 +18,11 @@ acorn fmt [flags] [ACORNFILE]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image.md
@@ -30,10 +30,11 @@ acorn images
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_copy.md
@@ -38,10 +38,11 @@ acorn image copy [flags] SOURCE DESTINATION
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image_details.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_details.md
@@ -25,10 +25,11 @@ acorn image details my-image
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_rm.md
@@ -25,10 +25,11 @@ acorn image rm my-image
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image_sign.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_sign.md
@@ -26,10 +26,11 @@ acorn image sign my-image --key ./my-key
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_image_verify.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_verify.md
@@ -34,10 +34,11 @@ acorn image verify my-image --key ac://ibuildthecloud
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_info.md
+++ b/docs/docs/100-reference/01-command-line/acorn_info.md
@@ -19,10 +19,11 @@ acorn info [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -76,10 +76,11 @@ acorn install
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_job.md
+++ b/docs/docs/100-reference/01-command-line/acorn_job.md
@@ -27,10 +27,11 @@ acorn jobs
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_job_restart.md
+++ b/docs/docs/100-reference/01-command-line/acorn_job_restart.md
@@ -25,12 +25,13 @@ acorn job restart app-name.job-name
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_login.md
+++ b/docs/docs/100-reference/01-command-line/acorn_login.md
@@ -31,10 +31,11 @@ acorn login ghcr.io
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_logout.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logout.md
@@ -26,10 +26,11 @@ acorn logout ghcr.io
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -22,10 +22,11 @@ acorn logs [flags] [ACORN_NAME|CONTAINER_REPLICA_NAME]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_offerings.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings.md
@@ -27,10 +27,11 @@ acorn offerings
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_computeclasses.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_computeclasses.md
@@ -27,10 +27,11 @@ acorn computeclasses
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_regions.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_regions.md
@@ -27,10 +27,11 @@ acorn offering regions
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_offerings_volumeclasses.md
+++ b/docs/docs/100-reference/01-command-line/acorn_offerings_volumeclasses.md
@@ -27,10 +27,11 @@ acorn offering volumeclasses
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_port-forward.md
+++ b/docs/docs/100-reference/01-command-line/acorn_port-forward.md
@@ -24,10 +24,11 @@ acorn port-forward [flags] ACORN_NAME|CONTAINER_NAME PORT
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_project.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project.md
@@ -27,10 +27,11 @@ acorn project
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_project_create.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_create.md
@@ -32,12 +32,13 @@ acorn project create acorn.io/username/new-project
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_project_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_rm.md
@@ -26,12 +26,13 @@ acorn project rm my-project
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_project_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_update.md
@@ -28,12 +28,13 @@ acorn project update my-project
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_project_use.md
+++ b/docs/docs/100-reference/01-command-line/acorn_project_use.md
@@ -25,12 +25,13 @@ acorn project use acorn.io/my-user/acorn
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_ps.md
+++ b/docs/docs/100-reference/01-command-line/acorn_ps.md
@@ -29,10 +29,11 @@ acorn ps
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_pull.md
+++ b/docs/docs/100-reference/01-command-line/acorn_pull.md
@@ -21,10 +21,11 @@ acorn pull [flags] IMAGE
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_push.md
+++ b/docs/docs/100-reference/01-command-line/acorn_push.md
@@ -21,10 +21,11 @@ acorn push [flags] IMAGE
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_render.md
+++ b/docs/docs/100-reference/01-command-line/acorn_render.md
@@ -21,10 +21,11 @@ acorn render [flags] DIRECTORY [acorn args]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_rm.md
@@ -31,10 +31,11 @@ acorn rm --volumes --secrets ACORN_NAME
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -72,10 +72,11 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_secret.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret.md
@@ -27,10 +27,11 @@ acorn secret
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_secret_create.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_create.md
@@ -35,12 +35,13 @@ acorn secret create --data @key-name=secret.yaml my-secret
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_secret_encrypt.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_encrypt.md
@@ -20,12 +20,13 @@ acorn secret encrypt [flags] STRING
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
@@ -27,10 +27,11 @@ acorn secret
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_secret_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_rm.md
@@ -25,12 +25,13 @@ acorn secret rm my-secret
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_start.md
+++ b/docs/docs/100-reference/01-command-line/acorn_start.md
@@ -27,10 +27,11 @@ acorn start my-app1 my-app2
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_stop.md
+++ b/docs/docs/100-reference/01-command-line/acorn_stop.md
@@ -27,10 +27,11 @@ acorn stop my-app1 my-app2
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_tag.md
+++ b/docs/docs/100-reference/01-command-line/acorn_tag.md
@@ -18,10 +18,11 @@ acorn tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_uninstall.md
+++ b/docs/docs/100-reference/01-command-line/acorn_uninstall.md
@@ -31,10 +31,11 @@ acorn uninstall -f
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -43,10 +43,11 @@ acorn update [flags] ACORN_NAME [deploy flags]
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_version.md
+++ b/docs/docs/100-reference/01-command-line/acorn_version.md
@@ -24,10 +24,11 @@ acorn version
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_volume.md
+++ b/docs/docs/100-reference/01-command-line/acorn_volume.md
@@ -27,10 +27,11 @@ acorn volume
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
@@ -24,12 +24,13 @@ acorn volume rm my-volume
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -o, --output string       Output format (json, yaml, {{gotemplate}})
-  -j, --project string      Project to work in
-  -q, --quiet               Output only names
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -o, --output string        Output format (json, yaml, {{gotemplate}})
+  -j, --project string       Project to work in
+  -q, --quiet                Output only names
 ```
 
 ### SEE ALSO

--- a/docs/docs/100-reference/01-command-line/acorn_wait.md
+++ b/docs/docs/100-reference/01-command-line/acorn_wait.md
@@ -19,10 +19,11 @@ acorn wait [flags] ACORN_NAME
 ### Options inherited from parent commands
 
 ```
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 ```
 
 ### SEE ALSO

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -252,7 +252,7 @@ func TestBuildNestedAcornWithLocalImage(t *testing.T) {
 	}
 
 	// build the Nginx image
-	source := imagesource.NewImageSource("./testdata/nested/nginx.Acornfile", []string{}, []string{}, []string{}, false)
+	source := imagesource.NewImageSource("", "./testdata/nested/nginx.Acornfile", []string{}, []string{}, []string{}, false)
 	image, _, err := source.GetImageAndDeployArgs(helper.GetCTX(t), c)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/dev/dev_test.go
+++ b/integration/dev/dev_test.go
@@ -60,7 +60,7 @@ func TestDev(t *testing.T) {
 	eg := errgroup.Group{}
 	eg.Go(func() error {
 		return dev.Dev(subCtx, helper.BuilderClient(t, project.Name), &dev.Options{
-			ImageSource: imagesource.NewImageSource(acornCueFile, []string{tmp}, nil, nil, false),
+			ImageSource: imagesource.NewImageSource("", acornCueFile, []string{tmp}, nil, nil, false),
 			Run: client.AppRunOptions{
 				Name: "test-app",
 			},

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1766,7 +1766,7 @@ func TestAutoUpgradeLocalImage(t *testing.T) {
 	}
 
 	// Deploy the app
-	imageSource := imagesource.NewImageSource("", []string{"mylocalimage"}, []string{}, nil, true)
+	imageSource := imagesource.NewImageSource("", "", []string{"mylocalimage"}, []string{}, nil, true)
 	appImage, _, err := imageSource.GetImageAndDeployArgs(ctx, c)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -25,7 +25,7 @@ func getAuthForImage(ctx context.Context, clientFactory ClientFactory, image str
 		return nil, nil
 	}
 
-	creds, err := imagesource.GetCreds(c)
+	creds, err := imagesource.GetCreds(clientFactory.AcornConfigFile(), c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -57,7 +57,7 @@ func (s *Build) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	helper := imagesource.NewImageSource(s.File, args, s.Profile, s.Platform, false)
+	helper := imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, s.Platform, false)
 
 	image, _, err := helper.GetImageAndDeployArgs(cmd.Context(), c)
 	if err != nil {

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -272,20 +272,29 @@ func secretsCompletion(ctx context.Context, c client.Client, toComplete string) 
 	return result, nil
 }
 
-func projectsCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
-	projects, _, err := project.List(ctx, false, project.Options{})
-	if err != nil {
-		return nil, err
-	}
-
-	var result []string
-	for _, project := range projects {
-		if strings.HasPrefix(project, toComplete) {
-			result = append(result, project)
+func projectsCompletion(f ClientFactory) completionFunc {
+	return func(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+		var acornConfigFile string
+		if f != nil {
+			acornConfigFile = f.AcornConfigFile()
 		}
-	}
 
-	return result, nil
+		projects, _, err := project.List(ctx, false, project.Options{
+			AcornConfigFile: acornConfigFile,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		var result []string
+		for _, project := range projects {
+			if strings.HasPrefix(project, toComplete) {
+				result = append(result, project)
+			}
+		}
+
+		return result, nil
+	}
 }
 
 func volumeClassCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -20,6 +20,7 @@ type ClientFactory interface {
 	CreateDefault() (client.Client, error)
 	CreateWithAllProjects() (client.Client, error)
 	Options() project.Options
+	AcornConfigFile() string
 }
 
 type CommandClientFactory struct {
@@ -29,9 +30,10 @@ type CommandClientFactory struct {
 
 func (c *CommandClientFactory) Options() project.Options {
 	return project.Options{
-		Project:    c.acorn.Project,
-		Kubeconfig: c.acorn.Kubeconfig,
-		ContextEnv: os.Getenv("CONTEXT"),
+		AcornConfigFile: c.acorn.AcornConfigFile,
+		Project:         c.acorn.Project,
+		Kubeconfig:      c.acorn.Kubeconfig,
+		ContextEnv:      os.Getenv("CONTEXT"),
 	}
 }
 
@@ -43,4 +45,8 @@ func (c *CommandClientFactory) CreateWithAllProjects() (client.Client, error) {
 	opts := c.Options()
 	opts.AllProjects = true
 	return project.Client(c.cmd.Context(), opts)
+}
+
+func (c *CommandClientFactory) AcornConfigFile() string {
+	return c.acorn.AcornConfigFile
 }

--- a/pkg/cli/credential_test.go
+++ b/pkg/cli/credential_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/acorn-io/runtime/pkg/cli/testdata"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCredential(t *testing.T) {
 	cfgDir, err := os.MkdirTemp("", "acorn-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(cfgDir)
-	os.Setenv("ACORN_CONFIG_FILE", filepath.Join(cfgDir, "acorn.yaml"))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(cfgDir))
+	}()
+	acornConfigFile := filepath.Join(cfgDir, "acorn.yaml")
 
 	type fields struct {
 		Quiet  bool
@@ -47,10 +47,12 @@ func TestCredential(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					MockAcornConfigFile: acornConfigFile,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{"--", "test-server-address"},
@@ -66,10 +68,12 @@ func TestCredential(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					MockAcornConfigFile: acornConfigFile,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{"--", "dne"},
@@ -85,10 +89,12 @@ func TestCredential(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
+				ClientFactory: &testdata.MockClientFactory{
+					MockAcornConfigFile: acornConfigFile,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
 			},
 			args: args{
 				args:   []string{},
@@ -111,7 +117,7 @@ func TestCredential(t *testing.T) {
 			} else if err != nil && tt.wantErr {
 				assert.Equal(t, tt.wantOut, err.Error())
 			} else {
-				w.Close()
+				require.NoError(t, w.Close())
 				out, _ := io.ReadAll(r)
 				assert.Equal(t, tt.wantOut, string(out))
 			}

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -59,7 +59,7 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	imageSource := imagesource.NewImageSource(s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+	imageSource := imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
 
 	opts, err := s.ToOpts()
 	if err != nil {

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -51,7 +51,7 @@ func (s *Info) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Testing/mocking ReadCLIConfig() is difficult. Any better way to test?
-	cfg, err := config.ReadCLIConfig(true)
+	cfg, err := config.ReadCLIConfig(s.client.AcornConfigFile(), true)
 	if err != nil {
 		logrus.Errorf("failed to read CLI config: %v", err)
 		cfg = nil

--- a/pkg/cli/info_test.go
+++ b/pkg/cli/info_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -169,12 +170,12 @@ func TestInfo(t *testing.T) {
 
 			r, w, _ := os.Pipe()
 			os.Stdout = w
-			os.Setenv("ACORN_CONFIG_FILE", "/fake-file")
 
 			// Mock client factory just returns the gomock client.
 			cmd := NewInfo(CommandContext{
 				ClientFactory: &testdata.MockClientFactoryManual{
-					Client: mClient,
+					MockAcornConfigFile: "/fake-file",
+					Client:              mClient,
 				},
 				StdOut: w,
 				StdErr: w,
@@ -188,7 +189,7 @@ func TestInfo(t *testing.T) {
 			} else if err != nil && tt.wantErr {
 				assert.Equal(t, tt.wantOut, err.Error())
 			} else {
-				w.Close()
+				require.NoError(t, w.Close())
 				out, _ := io.ReadAll(r)
 				testOut, _ := os.ReadFile(tt.wantOut)
 				assert.Equal(t, string(testOut), string(out))

--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -24,7 +24,7 @@ acorn project`,
 		SilenceUsage:      true,
 		Short:             "Manage projects",
 		Args:              cobra.MaximumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion(c.ClientFactory)).complete,
 	})
 	cmd.AddCommand(NewProjectCreate(c))
 	cmd.AddCommand(NewProjectRm(c))

--- a/pkg/cli/project_create.go
+++ b/pkg/cli/project_create.go
@@ -21,7 +21,7 @@ acorn project create acorn.io/username/new-project
 		SilenceUsage:      true,
 		Short:             "Create new project",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion(c.ClientFactory)).complete,
 	})
 	// This will produce an error if the region flag doesn't exist or a completion function has already
 	// been registered for this flag. Not returning the error since neither of these is likely occur.

--- a/pkg/cli/project_rm.go
+++ b/pkg/cli/project_rm.go
@@ -17,7 +17,7 @@ acorn project rm my-project
 		SilenceUsage:      true,
 		Short:             "Deletes projects",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion(c.ClientFactory)).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/project_update.go
+++ b/pkg/cli/project_update.go
@@ -17,7 +17,7 @@ acorn project update my-project
 		SilenceUsage:      true,
 		Short:             "Update project",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion(c.ClientFactory)).complete,
 	})
 	// This will produce an error if the region flag doesn't exist or a completion function has already
 	// been registered for this flag. Not returning the error since neither of these is likely occur.

--- a/pkg/cli/project_use.go
+++ b/pkg/cli/project_use.go
@@ -16,7 +16,7 @@ acorn project use acorn.io/my-user/acorn`,
 		SilenceUsage:      true,
 		Short:             "Set current project",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion(c.ClientFactory)).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/render.go
+++ b/pkg/cli/render.go
@@ -30,7 +30,7 @@ type Render struct {
 func (s *Render) Run(cmd *cobra.Command, args []string) error {
 	var c client2.Client
 
-	imageAndArgs := imagesource.NewImageSource(s.File, args, s.Profile, nil, false)
+	imageAndArgs := imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, false)
 
 	_, file, err := imageAndArgs.ResolveImageAndFile()
 	if err != nil {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -233,7 +233,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	var (
-		imageSource = imagesource.NewImageSource(s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+		imageSource = imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
 		app         *apiv1.App
 		updated     bool
 	)

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -19,11 +19,14 @@ import (
 )
 
 type MockClientFactoryManual struct {
-	Client client.Client
+	MockAcornConfigFile string
+	Client              client.Client
 }
 
 func (dc *MockClientFactoryManual) Options() project.Options {
-	return project.Options{}
+	return project.Options{
+		AcornConfigFile: dc.MockAcornConfigFile,
+	}
 }
 
 func (dc *MockClientFactoryManual) CreateDefault() (client.Client, error) {
@@ -34,35 +37,42 @@ func (dc *MockClientFactoryManual) CreateWithAllProjects() (client.Client, error
 	return dc.Client, nil
 }
 
+func (dc *MockClientFactoryManual) AcornConfigFile() string {
+	return dc.MockAcornConfigFile
+}
+
 type MockClientFactory struct {
-	AppList          []apiv1.App
-	AppItem          *apiv1.App
-	ContainerList    []apiv1.ContainerReplica
-	ContainerItem    *apiv1.ContainerReplica
-	JobList          []apiv1.Job
-	JobItem          *apiv1.Job
-	CredentialList   []apiv1.Credential
-	CredentialItem   *apiv1.Credential
-	VolumeList       []apiv1.Volume
-	VolumeItem       *apiv1.Volume
-	SecretList       []apiv1.Secret
-	SecretItem       *apiv1.Secret
-	ImageList        []apiv1.Image
-	ImageItem        *apiv1.Image
-	ProjectList      []apiv1.Project
-	ProjectItem      *apiv1.Project
-	VolumeClassList  []apiv1.VolumeClass
-	VolumeClassItem  *apiv1.VolumeClass
-	ComputeClassList []apiv1.ComputeClass
-	ComputeClassItem *apiv1.ComputeClass
-	RegionList       []apiv1.Region
-	RegionItem       *apiv1.Region
-	EventList        []apiv1.Event
-	EventItem        *apiv1.Event
+	MockAcornConfigFile string
+	AppList             []apiv1.App
+	AppItem             *apiv1.App
+	ContainerList       []apiv1.ContainerReplica
+	ContainerItem       *apiv1.ContainerReplica
+	JobList             []apiv1.Job
+	JobItem             *apiv1.Job
+	CredentialList      []apiv1.Credential
+	CredentialItem      *apiv1.Credential
+	VolumeList          []apiv1.Volume
+	VolumeItem          *apiv1.Volume
+	SecretList          []apiv1.Secret
+	SecretItem          *apiv1.Secret
+	ImageList           []apiv1.Image
+	ImageItem           *apiv1.Image
+	ProjectList         []apiv1.Project
+	ProjectItem         *apiv1.Project
+	VolumeClassList     []apiv1.VolumeClass
+	VolumeClassItem     *apiv1.VolumeClass
+	ComputeClassList    []apiv1.ComputeClass
+	ComputeClassItem    *apiv1.ComputeClass
+	RegionList          []apiv1.Region
+	RegionItem          *apiv1.Region
+	EventList           []apiv1.Event
+	EventItem           *apiv1.Event
 }
 
 func (dc *MockClientFactory) Options() project.Options {
-	return project.Options{}
+	return project.Options{
+		AcornConfigFile: dc.MockAcornConfigFile,
+	}
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
@@ -96,6 +106,10 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 
 func (dc *MockClientFactory) CreateWithAllProjects() (client.Client, error) {
 	return dc.CreateDefault()
+}
+
+func (dc *MockClientFactory) AcornConfigFile() string {
+	return dc.MockAcornConfigFile
 }
 
 type MockClient struct {
@@ -240,14 +254,14 @@ func (m *MockClient) AppRun(ctx context.Context, image string, opts *client.AppR
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{Ready: true},
 		}, nil
 	case "found.container":
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	}
@@ -265,14 +279,14 @@ func (m *MockClient) AppUpdate(ctx context.Context, name string, opts *client.Ap
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	case "found.container":
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	}
@@ -747,7 +761,7 @@ func (m *MockClient) ImageTag(ctx context.Context, image, tag string) error {
 func (m *MockClient) ImageDetails(ctx context.Context, imageName string, opts *client.ImageDetailsOptions) (*client.ImageDetails, error) {
 	return &client.ImageDetails{
 		AppImage: v1.AppImage{ID: imageName, ImageData: v1.ImagesData{
-			Containers: map[string]v1.ContainerData{"test-image-running-container": v1.ContainerData{
+			Containers: map[string]v1.ContainerData{"test-image-running-container": {
 				Image:    "test-image-running-container",
 				Sidecars: nil,
 			}},

--- a/pkg/cli/testdata/acorn/acorn_test_info.txt
+++ b/pkg/cli/testdata/acorn/acorn_test_info.txt
@@ -43,10 +43,11 @@ Available Commands:
   wait         Wait an app to be ready then exit with status code 0
 
 Flags:
-      --debug               Enable debug logging
-      --debug-level int     Debug log level (valid 0-9) (default 7)
-  -h, --help                help for acorn
-      --kubeconfig string   Explicitly use kubeconfig file, overriding the default context
-  -j, --project string      Project to work in
+      --config-file string   Path of the acorn config file to use
+      --debug                Enable debug logging
+      --debug-level int      Debug log level (valid 0-9) (default 7)
+  -h, --help                 help for acorn
+      --kubeconfig string    Explicitly use kubeconfig file, overriding the default context
+  -j, --project string       Project to work in
 
 Use "acorn [command] --help" for more information about a command.

--- a/pkg/imagesource/helper.go
+++ b/pkg/imagesource/helper.go
@@ -25,9 +25,13 @@ type ImageSource struct {
 	// NoDefaultRegistry - if true, indicates that no container registry should be assumed for the Image.
 	// This is used if the ImageSource is for an app with auto-upgrade enabled.
 	NoDefaultRegistry bool
+
+	// acornConfig is the path to the acorn config file.
+	acornConfig string
 }
 
-func NewImageSource(file string, args, profiles, platforms []string, noDefaultReg bool) (result ImageSource) {
+func NewImageSource(acornConfig string, file string, args, profiles, platforms []string, noDefaultReg bool) (result ImageSource) {
+	result.acornConfig = acornConfig
 	result.File = file
 	result.Image, result.Args = splitImageAndArgs(args)
 	result.Profiles = profiles
@@ -172,7 +176,7 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 	// if file is set, then we must build to get the image, if it's not set, then
 	// it must be an external image
 	if i.File != "" {
-		creds, err := GetCreds(c)
+		creds, err := GetCreds(i.acornConfig, c)
 		if err != nil {
 			return "", nil, err
 		}
@@ -204,8 +208,8 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 	return i.Image, deployArgs, err
 }
 
-func GetCreds(c client.Client) (client.CredentialLookup, error) {
-	cfg, err := config.ReadCLIConfig(false)
+func GetCreds(acornConfig string, c client.Client) (client.CredentialLookup, error) {
+	cfg, err := config.ReadCLIConfig(acornConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagesource/platforms_test.go
+++ b/pkg/imagesource/platforms_test.go
@@ -14,7 +14,7 @@ func TestParamsHelp(t *testing.T) {
 		file = "testdata/params/Acornfile"
 		cwd  = "testdata/params"
 	)
-	_, _, err := NewImageSource(file, []string{
+	_, _, err := NewImageSource("", file, []string{
 		cwd,
 		"image-name",
 		"--str=s",
@@ -30,10 +30,11 @@ func TestParamsHelp(t *testing.T) {
 
 func TestParams(t *testing.T) {
 	var (
-		file = "testdata/params/Acornfile"
-		cwd  = "testdata/params"
+		acornConfig string
+		file        = "testdata/params/Acornfile"
+		cwd         = "testdata/params"
 	)
-	_, params, err := NewImageSource(file, []string{
+	_, params, err := NewImageSource(acornConfig, file, []string{
 		cwd,
 		"image-name",
 		"--str=s",

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -142,7 +142,7 @@ func Login(ctx context.Context, cfg *config.CLIConfig, password, address string)
 	}
 
 	// reload config, could have changed
-	if newCfg, err := config.ReadCLIConfig(false); err != nil {
+	if newCfg, err := config.ReadCLIConfig(cfg.AcornConfigFile, false); err != nil {
 		return user, pass, err
 	} else {
 		*cfg = *newCfg

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -22,14 +22,15 @@ var (
 )
 
 type Options struct {
-	Project     string
-	Kubeconfig  string
-	ContextEnv  string
-	AllProjects bool
+	AcornConfigFile string
+	Project         string
+	Kubeconfig      string
+	ContextEnv      string
+	AllProjects     bool
 }
 
 func (o Options) CLIConfig() (*config.CLIConfig, error) {
-	return config.ReadCLIConfig(o.Kubeconfig != "")
+	return config.ReadCLIConfig(o.AcornConfigFile, o.Kubeconfig != "")
 }
 
 func Client(ctx context.Context, opts Options) (client.Client, error) {


### PR DESCRIPTION
Add a global `--config-file` option to the acorn cli that allows users to
set the acorn config file to use during command execution.

e.g. Set the current project to `foo` in `./special-config.yaml`

```sh
$ acorn --config-file special-config.yaml project use foo
```

If both `--config-file` and `ACORN_CONFIG_FILE` are provided, `--config-file`
takes precedence.

