### PR TITLE
Stop printing stack traces when buildkitd pod is deleted (#2081)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY /scripts/acorn-job-helper-init /usr/local/bin
 COPY /scripts/acorn-job-helper-shutdown /usr/local/bin
 COPY /scripts/acorn-job-get-output /usr/local/bin
 CMD []
+STOPSIGNAL SIGTERM
 ENTRYPOINT ["/usr/local/bin/acorn"]
 
 FROM base AS goreleaser


### PR DESCRIPTION
There are two fixes here related to the deletion of the buildkitd pod:
1. A SIGQUIT was being sent to the pod, which was causing both containers to print their stack traces. This is fixed in the Dockerfile
2. The service container was not exiting gracefully because it wasn't paying attention to the context. Now it will watch the context and exit when it closes.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/runtime/issues/2081