### PR TITLE
Add info -A

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_info.md
+++ b/docs/docs/100-reference/01-command-line/acorn_info.md
@@ -12,6 +12,7 @@ acorn info [flags]
 ### Options
 
 ```
+  -A, --all-projects    Include all projects to all currently logged in servers
   -h, --help            help for info
   -o, --output string   Output format (json, yaml, {{gotemplate}}) (default "yaml")
 ```

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -19,6 +19,7 @@ type CommandContext struct {
 type ClientFactory interface {
 	CreateDefault() (client.Client, error)
 	CreateWithAllProjects() (client.Client, error)
+	CreateWithAllProjectsAllServers() (client.Client, error)
 	Options() project.Options
 	AcornConfigFile() string
 }
@@ -44,6 +45,13 @@ func (c *CommandClientFactory) CreateDefault() (client.Client, error) {
 func (c *CommandClientFactory) CreateWithAllProjects() (client.Client, error) {
 	opts := c.Options()
 	opts.AllProjects = true
+	return project.Client(c.cmd.Context(), opts)
+}
+
+func (c *CommandClientFactory) CreateWithAllProjectsAllServers() (client.Client, error) {
+	opts := c.Options()
+	opts.AllProjects = true
+	opts.AllServers = true
 	return project.Client(c.cmd.Context(), opts)
 }
 

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/cli/builder/table"
+	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/tables"
 	"github.com/acorn-io/runtime/pkg/version"
@@ -27,8 +28,9 @@ func NewInfo(c CommandContext) *cobra.Command {
 }
 
 type Info struct {
-	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o" default:"yaml"`
-	client ClientFactory
+	Output      string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o" default:"yaml"`
+	AllProjects bool   `usage:"Include all projects to all currently logged in servers" short:"A"`
+	client      ClientFactory
 }
 
 type InfoCLIResponse struct {
@@ -40,9 +42,21 @@ type InfoCLIResponse struct {
 }
 
 func (s *Info) Run(cmd *cobra.Command, _ []string) error {
-	c, err := s.client.CreateDefault()
-	if err != nil {
-		return err
+	var (
+		c   client.Client
+		err error
+	)
+
+	if s.AllProjects {
+		c, err = s.client.CreateWithAllProjectsAllServers()
+		if err != nil {
+			return err
+		}
+	} else {
+		c, err = s.client.CreateDefault()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := c.Info(cmd.Context())

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -37,6 +37,10 @@ func (dc *MockClientFactoryManual) CreateWithAllProjects() (client.Client, error
 	return dc.Client, nil
 }
 
+func (dc *MockClientFactoryManual) CreateWithAllProjectsAllServers() (client.Client, error) {
+	return dc.Client, nil
+}
+
 func (dc *MockClientFactoryManual) AcornConfigFile() string {
 	return dc.MockAcornConfigFile
 }
@@ -105,6 +109,10 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 }
 
 func (dc *MockClientFactory) CreateWithAllProjects() (client.Client, error) {
+	return dc.CreateDefault()
+}
+
+func (dc *MockClientFactory) CreateWithAllProjectsAllServers() (client.Client, error) {
 	return dc.CreateDefault()
 }
 

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -27,6 +27,7 @@ type Options struct {
 	Kubeconfig      string
 	ContextEnv      string
 	AllProjects     bool
+	AllServers      bool
 }
 
 func (o Options) CLIConfig() (*config.CLIConfig, error) {
@@ -166,7 +167,7 @@ func ParseProject(project string, defaultContext string) (server, account, names
 
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
 	if opts.AllProjects {
-		projects, _, err := List(ctx, true, opts)
+		projects, _, err := List(ctx, !opts.AllServers, opts)
 		return projects, err
 	}
 


### PR DESCRIPTION
This add --all-projects to info. --all-projects differs in this context
in that -A will projects in all servers, not just the current server.

Signed-off-by: Darren Shepherd <darren@acorn.io>
