### PR TITLE
fix/regression: don't rely on deprecated image.Remote when pruning signatures

### DIFF
--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -177,7 +177,7 @@ func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, 
 	}
 
 	// Prune signatures - from cluster (internal) registry only
-	if !image.Remote && image.Repo == "" {
+	if image.Repo == "" { // image.Remote was deprecated
 		remoteOpts := []remote.Option{remote.WithTransport(s.transport)}
 
 		// make sure we're only searching in the internal registry

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -177,7 +177,7 @@ func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, 
 	}
 
 	// Prune signatures - from cluster (internal) registry only
-	if image.Repo == "" { // image.Remote was deprecated
+	if image.Repo == "" {
 		remoteOpts := []remote.Option{remote.WithTransport(s.transport)}
 
 		// make sure we're only searching in the internal registry


### PR DESCRIPTION
Fix Regression: https://github.com/acorn-io/runtime/actions/runs/5927962316

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

