### PR TITLE
Enable notarization for MacOS releases again

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -56,7 +56,6 @@ jobs:
           version: latest
           args: release --clean --snapshot
         env:
-          NOTARIZE: "0"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,6 @@ universal_binaries:
         - cmd: ./tools/notarize "{{ .Path }}" "acorn-v{{ .Version }}-macOS-universal"
           output: true
           env:
-            - NOTARIZE=0 # Always disable Notarization since it is not currently necessary.
             - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
             - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
             - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}

--- a/docs/docs/30-installation/01-installing.md
+++ b/docs/docs/30-installation/01-installing.md
@@ -78,7 +78,7 @@ Uncompress and move the binary to your PATH.
 #### Development Binaries (main build)
 
 The last successful build from the HEAD of the main branch is available for
-[macOS](https://cdn.acrn.io/cli/default_darwin_amd64_v1/acorn),
+[macOS](https://cdn.acrn.io/cli/mac_darwin_all/acorn),
 [Linux](https://cdn.acrn.io/cli/default_linux_amd64_v1/acorn), and
 [Windows](https://cdn.acrn.io/cli/default_windows_amd64_v1/acorn.exe)
 

--- a/tools/notarize
+++ b/tools/notarize
@@ -3,9 +3,6 @@ set -e
 
 cd $(dirname $0)/..
 
-: ${KEYCHAIN="build.keychain"}
-: ${SIGN=""}
-: ${NOTARIZE=""}
 : ${AC_BUNDLE="io.acorn.cli"}
 
 BINARY="$1"
@@ -13,12 +10,7 @@ DIR="releases/mac_darwin_all"
 ZIP="releases/$2.zip"
 CHECKSUMS="releases/checksums.txt"
 
-if [[ -z "${NOTARIZE}" && "${GITHUB_REF}" =~ "refs/tags/v" ]]; then
-  echo "Enabling notarize..."
-  NOTARIZE="1"
-fi
-
-echo "NOTARIZE=${NOTARIZE} BUNDLE=${AC_BUNDLE} BINARY=${BINARY} ZIP=${ZIP}"
+echo "BUNDLE=${AC_BUNDLE} BINARY=${BINARY}"
 
 sudo apt-get update -y  
 
@@ -27,11 +19,17 @@ echo "Signing the binary..."
 
 # Install rcodesign from the release page.
 which wget || sudo apt-get install wget -y
-wget https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
-tar -xvf apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
-mv apple-codesign-0.22.0-x86_64-unknown-linux-musl/rcodesign /usr/local/bin
+if ! command -v rcodesign &> /dev/null; then
+  echo "Installing rcodesign..."
+  wget https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
+  tar -xvf apple-codesign-0.22.0-x86_64-unknown-linux-musl.tar.gz
+  mv apple-codesign-0.22.0-x86_64-unknown-linux-musl/rcodesign /usr/local/bin
+else
+  echo "rcodesign already installed!"
+fi
 
-# Sign the binary using rcodesign.
+# Sign the binary using rcodesign. This gives our binary a valid signature.
+# https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_concepts.html#code-signing
 echo "Signing ${BINARY}..."
 echo "${AC_P12}" | base64 --decode > signing.p12
 rcodesign sign \
@@ -43,51 +41,44 @@ rcodesign sign \
   "${BINARY}"
 echo "Signed ${BINARY}!"
 
-# Currently, NOTARIZE is always set to 0. In effect, this means that the
-# binary is signed, but not zipped up, notarized or stapled. Since all of the 
-# official installation processes are through brew or wget, the notarized DMG we were
-# creating was not necessary. Where this does become a problem is if a user 
-# wants to install from a browser. In this situation, there will need to be 
-# a notarization process otherwise MacOS will mark our binary as unsafe and 
-# the user will need to go through hoops to install it. In this instance,
-# setting NOTARIZE to 1 will create a ZIP file (since it was difficult to create
-# a DMG while not on MacOS) and Notarize it.
+# Zip up the release files.
+which zip || sudo apt-get install zip -y
+echo "Building ${ZIP}..."
+cp LICENSE README.md "${DIR}/"
+zip -j "${ZIP}" "${DIR}"/*
+echo "Built ${ZIP}!"
+
+# Build the app-store-connect-api-key from our private key information.
+echo "Building app-store-connect-api-key..."
+echo "${AC_PRIVATE_KEY}" | base64 --decode > private.p8
+rcodesign encode-app-store-connect-api-key \
+  -o ./key.json \
+  "${AC_ISSUER_ID}" \
+  "${AC_KEY_ID}" \
+  private.p8
+echo "Built app-store-connect-api-key!"
+
+# Notarize the ZIP. This uploads the ZIP to Apple's servers for notarization and waits for
+# Apple to complete the notarization ticket. This should not take more than a minute or two.
+# https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_concepts.html#notarization
+echo "Notarizing ${ZIP}..."
+rcodesign notary-submit --wait --api-key-path ./key.json "${ZIP}"
+echo "Notarized ${ZIP}!"
+
+# Staple the ZIP. This adds the notarization ticket to the ZIP. 
+# https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_concepts.html#stapling
+# 
+# Note: Currently disabled as rcodesign doesn't support stapling of ZIP files. We would need 
+#       to switch to a DMG, App bundle, or XAR file to support stapling. Leaving this here 
+#       for future reference.
 #
-# Note - If you want to staple that ZIP, you will need to staple each individual
-#        item in the zip file.
+#       https://github.com/indygreg/apple-platform-rs/blob/6fc832919eb89f86ac381dfb02196b8cbb3de58c/apple-codesign/src/stapling.rs#L325-L327
 #
-# References: 
-# https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
-# https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_rcodesign.html
-if [[ "${NOTARIZE}" == "1" ]]; then
-  which zip || sudo apt-get install zip -y
+# echo "Stapling ${ZIP}..."
+# rcodesign staple "${ZIP}"
+# echo "Stapled ${ZIP}!"
 
-  # Zip everything up
-  echo "Building ${ZIP}..."
-  cp LICENSE README.md "${DIR}/"
-  zip -r "${ZIP}" "${DIR}"
-  echo "Built ${ZIP}!"
-
-  # Notarize the ZIP
-  echo "Building app-store-connect-api-key..."
-  echo "${AC_PRIVATE_KEY}" | base64 --decode > private.p8
-  rcodesign encode-app-store-connect-api-key \
-    -o ./key.json \
-    "${AC_ISSUER_ID}" \
-    "${AC_KEY_ID}" \
-    private.p8
-  echo "Built app-store-connect-api-key!"
-
-  echo "Notarizing ${ZIP}..."
-  rcodesign notary-submit --api-key-path ./key.json "${ZIP}"
-  echo "Notarized ${ZIP}!"
-
-  # Add the sha256sum of the ZIP to the checksums file
-  echo "Adding ${ZIP}'s checksum to the checksums file..."
-  sha256sum "${ZIP}" >> "${CHECKSUMS}"
-  echo "Added ${ZIP}'s checksums!"
-
-else
-  echo "Skipping zip creation and notarization"
-fi
-
+# Add the sha256sum of the ZIP to the checksums file
+echo "Adding ${ZIP}'s checksum to the checksums file..."
+sha256sum "${ZIP}" >> "${CHECKSUMS}"
+echo "Added ${ZIP}'s checksums!"


### PR DESCRIPTION
This PR enables Notarization of our MacOS releases. Notarization is the process of submitting releases to Apple so that they can validate and be made aware of the release. This creates a notarization ticket. You can attach that ticket to the release through a process known as "stapling" however, the current tool we use, `rcodesign` cannot currently do this for ZIP files. As such this PR only enables notarization and not stapling. 

The `notarization` script itself has a lot of comment explaining this process and why it is the way that it is. 

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

