### PR TITLE
Add the ability to specify unlimited for individual resources

### DIFF
--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -20,8 +20,6 @@ func UnlimitedQuantity() resource.Quantity {
 // external controllers to programmatically set the resources easier. Calls to
 // its functions are mutating.
 type Resources struct {
-	Unlimited bool `json:"unlimited,omitempty"`
-
 	Apps       int `json:"apps,omitempty"`
 	Containers int `json:"containers,omitempty"`
 	Jobs       int `json:"jobs,omitempty"`
@@ -127,10 +125,6 @@ func (current *Resources) Remove(incoming Resources, all bool) {
 // an aggregated error will be returned with all exceeded resources.
 // If the current resources defines unlimited, then it will always fit.
 func (current *Resources) Fits(incoming Resources) error {
-	if current.Unlimited {
-		return nil
-	}
-
 	exceededResources := []string{}
 
 	// Define function for checking int resources to keep code DRY
@@ -204,8 +198,7 @@ func (current *Resources) NonEmptyString() string {
 // Equals will check if the current Resources struct is equal to another. This is useful
 // to avoid needing to do a deep equal on the entire struct.
 func (current *Resources) Equals(incoming Resources) bool {
-	return current.Unlimited == incoming.Unlimited &&
-		current.Apps == incoming.Apps &&
+	return current.Apps == incoming.Apps &&
 		current.Containers == incoming.Containers &&
 		current.Jobs == incoming.Jobs &&
 		current.Volumes == incoming.Volumes &&

--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -9,6 +9,13 @@ import (
 
 var ErrExceededResources = fmt.Errorf("quota would be exceeded for resources")
 
+const Unlimited = -1
+
+// NewUnlimitedQuantity creates a Quantity with an Unlimited value
+func UnlimitedQuantity() resource.Quantity {
+	return *resource.NewQuantity(Unlimited, resource.DecimalSI)
+}
+
 // Resources is a struct separate from the QuotaRequestInstanceSpec to allow for
 // external controllers to programmatically set the resources easier. Calls to
 // its functions are mutating.
@@ -30,44 +37,88 @@ type Resources struct {
 
 // Add will add the resources of another Resources struct into the current one.
 func (current *Resources) Add(incoming Resources) {
-	current.Apps += incoming.Apps
-	current.Containers += incoming.Containers
-	current.Jobs += incoming.Jobs
-	current.Volumes += incoming.Volumes
-	current.Secrets += incoming.Secrets
-	current.Images += incoming.Images
-	current.Projects += incoming.Projects
+	add := func(c, i int) int {
+		if c == Unlimited || i == Unlimited {
+			return Unlimited
+		}
+		return c + i
+	}
 
-	current.VolumeStorage.Add(incoming.VolumeStorage)
-	current.Memory.Add(incoming.Memory)
-	current.CPU.Add(incoming.CPU)
+	unlimitedQuantity := UnlimitedQuantity()
+	addQuantity := func(c, i resource.Quantity) resource.Quantity {
+		if c.Equal(unlimitedQuantity) || i.Equal(unlimitedQuantity) {
+			return unlimitedQuantity
+		}
+		c.Add(i)
+		return c
+	}
+
+	current.Apps = add(current.Apps, incoming.Apps)
+	current.Containers = add(current.Containers, incoming.Containers)
+	current.Jobs = add(current.Jobs, incoming.Jobs)
+	current.Volumes = add(current.Volumes, incoming.Volumes)
+	current.Secrets = add(current.Secrets, incoming.Secrets)
+	current.Images = add(current.Images, incoming.Images)
+	current.Projects = add(current.Projects, incoming.Projects)
+
+	current.VolumeStorage = addQuantity(current.VolumeStorage, incoming.VolumeStorage)
+	current.Memory = addQuantity(current.Memory, incoming.Memory)
+	current.CPU = addQuantity(current.CPU, incoming.CPU)
 }
 
-// Remove will remove the resources of another Resources struct from the current one.
+// Remove will remove the resources of another Resources struct from the current one. Calling remove
+// will be a no-op for any resource values that are set to unlimited.
 func (current *Resources) Remove(incoming Resources, all bool) {
-	// Do not allow resources to go below 0
-	nonNegativeSubtract := func(currentVal, incomingVal int) int {
-		difference := currentVal - incomingVal
+	sub := func(c, i int) int {
+		// We don't expect this situation to happen. This is because there should not be a situation
+		// where we are removing from or with unlimited resources. However if it does, we want to
+		// be careful and handle it. With that in mind the logic here is as follows:
+		//
+		// 1. If the current value is unlimited, then removing a non-unlimited value should not change
+		//    the current value.
+		// 2. If the current value is not unlimited, then removing an unlimited value should not
+		//    change the current value.
+		// 3. Finally if both values are unlimited, then the current value should remain unlimited.
+		if c == Unlimited || i == Unlimited {
+			return c
+		}
+
+		difference := c - i
 		if difference < 0 {
 			difference = 0
 		}
 		return difference
 	}
 
-	current.Apps = nonNegativeSubtract(current.Apps, incoming.Apps)
-	current.Containers = nonNegativeSubtract(current.Containers, incoming.Containers)
-	current.Jobs = nonNegativeSubtract(current.Jobs, incoming.Jobs)
-	current.Volumes = nonNegativeSubtract(current.Volumes, incoming.Volumes)
-	current.Images = nonNegativeSubtract(current.Images, incoming.Images)
-	current.Projects = nonNegativeSubtract(current.Projects, incoming.Projects)
+	unlimitedQuantity := UnlimitedQuantity()
+	subQuantity := func(c, i resource.Quantity) resource.Quantity {
+		// This is the same situation as describe in the sub function above
+		// but for the resource.Quantity type.
+		if c.Equal(unlimitedQuantity) || i.Equal(unlimitedQuantity) {
+			return c
+		}
 
-	current.Memory.Sub(incoming.Memory)
-	current.CPU.Sub(incoming.CPU)
+		c.Sub(i)
+		if c.CmpInt64(0) < 0 {
+			c.Set(0)
+		}
+		return c
+	}
+
+	current.Apps = sub(current.Apps, incoming.Apps)
+	current.Containers = sub(current.Containers, incoming.Containers)
+	current.Jobs = sub(current.Jobs, incoming.Jobs)
+	current.Volumes = sub(current.Volumes, incoming.Volumes)
+	current.Images = sub(current.Images, incoming.Images)
+	current.Projects = sub(current.Projects, incoming.Projects)
+
+	current.Memory = subQuantity(current.Memory, incoming.Memory)
+	current.CPU = subQuantity(current.CPU, incoming.CPU)
 
 	// Only remove persistent resources if all is true.
 	if all {
-		current.Secrets = nonNegativeSubtract(current.Secrets, incoming.Secrets)
-		current.VolumeStorage.Sub(incoming.VolumeStorage)
+		current.Secrets = sub(current.Secrets, incoming.Secrets)
+		current.VolumeStorage = subQuantity(current.VolumeStorage, incoming.VolumeStorage)
 	}
 }
 
@@ -84,14 +135,14 @@ func (current *Resources) Fits(incoming Resources) error {
 
 	// Define function for checking int resources to keep code DRY
 	checkResource := func(resource string, currentVal, incomingVal int) {
-		if currentVal < incomingVal {
+		if currentVal != Unlimited && currentVal < incomingVal {
 			exceededResources = append(exceededResources, resource)
 		}
 	}
 
 	// Define function for checking quantity resources to keep code DRY
 	checkQuantityResource := func(resource string, currentVal, incomingVal resource.Quantity) {
-		if currentVal.Cmp(incomingVal) < 0 {
+		if !currentVal.Equal(UnlimitedQuantity()) && currentVal.Cmp(incomingVal) < 0 {
 			exceededResources = append(exceededResources, resource)
 		}
 	}

--- a/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -59,13 +60,58 @@ func TestAdd(t *testing.T) {
 				VolumeStorage: resource.MustParse("1Mi"),
 			},
 		},
+		{
+			name: "add where current has a resource specified with unlimited",
+			current: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			expected: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+		},
+		{
+			name: "add where incoming has a resource specified with unlimited",
+			current: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			expected: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+		},
+		{
+			name: "add where current and incoming have a resource specified with unlimited",
+			current: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			expected: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+		},
 	}
 
 	// Run the test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.current.Add(tc.incoming)
-			tc.current.Equals(tc.expected)
+			assert.True(t, tc.current.Equals(tc.expected))
 		})
 	}
 }
@@ -83,30 +129,49 @@ func TestRemove(t *testing.T) {
 			name:    "remove from empty resources",
 			current: Resources{},
 			incoming: Resources{
-				Apps:          1,
-				VolumeStorage: resource.MustParse("1Mi"),
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
 			},
 			expected: Resources{},
 		},
 		{
 			name: "remove from existing resources",
 			current: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			expected: Resources{},
+		},
+		{
+			name: "should never get negative values",
+			all:  true,
+			current: Resources{
 				Apps:          1,
+				Memory:        resource.MustParse("1Mi"),
+				Secrets:       1,
 				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			incoming: Resources{
-				Apps:          1,
-				VolumeStorage: resource.MustParse("1Mi"),
+				Apps:          2,
+				Memory:        resource.MustParse("2Mi"),
+				Secrets:       2,
+				VolumeStorage: resource.MustParse("2Mi"),
 			},
 			expected: Resources{},
 		},
 		{
 			name: "remove persistent counts with all",
 			current: Resources{
-				Secrets: 1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			incoming: Resources{
-				Secrets: 1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			all:      true,
 			expected: Resources{},
@@ -114,13 +179,61 @@ func TestRemove(t *testing.T) {
 		{
 			name: "does not remove persistent counts without all",
 			current: Resources{
-				Secrets: 1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			incoming: Resources{
-				Secrets: 1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			expected: Resources{
-				Secrets: 1,
+				Secrets:       1,
+				VolumeStorage: resource.MustParse("1Mi"),
+			},
+		},
+		{
+			name: "remove where current has a resource specified with unlimited",
+			current: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			expected: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+		},
+		{
+			name: "remove where incoming has a resource specified with unlimited",
+			current: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+			incoming: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			expected: Resources{
+				Apps:   1,
+				Memory: resource.MustParse("1Mi"),
+			},
+		},
+		{
+			name: "remove where current and incoming have a resource specified with unlimited",
+			current: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
+			},
+			expected: Resources{
+				Apps:   Unlimited,
+				Memory: UnlimitedQuantity(),
 			},
 		},
 	}
@@ -129,7 +242,7 @@ func TestRemove(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.current.Remove(tc.incoming, tc.all)
-			tc.current.Equals(tc.expected)
+			assert.True(t, tc.current.Equals(tc.expected))
 		})
 	}
 }
@@ -176,14 +289,26 @@ func TestEquals(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "equal resources with unlimited values",
+			current: Resources{
+				Apps:          Unlimited,
+				Secrets:       Unlimited,
+				VolumeStorage: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:          Unlimited,
+				Secrets:       Unlimited,
+				VolumeStorage: UnlimitedQuantity(),
+			},
+			expected: true,
+		},
 	}
 
 	// Run the test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.current.Equals(tc.incoming) != tc.expected {
-				t.Errorf("expected %v, got %v", tc.expected, !tc.expected)
-			}
+			assert.Equal(t, tc.expected, tc.current.Equals(tc.incoming))
 		})
 	}
 }
@@ -242,6 +367,45 @@ func TestFits(t *testing.T) {
 				Secrets:       2,
 				VolumeStorage: resource.MustParse("2Mi"),
 			},
+		},
+		{
+			name: "fits resources with specified unlimited values",
+			current: Resources{
+				Apps:          Unlimited,
+				Secrets:       Unlimited,
+				VolumeStorage: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				Apps:          2,
+				Secrets:       2,
+				VolumeStorage: resource.MustParse("2Mi"),
+			},
+		},
+		{
+			name: "fits count resources with specified unlimited values but not others",
+			current: Resources{
+				Jobs:    0,
+				Apps:    Unlimited,
+				Secrets: Unlimited,
+			},
+			incoming: Resources{
+				Jobs:    2,
+				Apps:    2,
+				Secrets: 2,
+			},
+			expectedErr: ErrExceededResources,
+		},
+
+		{
+			name: "fits quantity resources with specified unlimited values but not others",
+			current: Resources{
+				VolumeStorage: UnlimitedQuantity(),
+			},
+			incoming: Resources{
+				CPU:           resource.MustParse("100m"),
+				VolumeStorage: resource.MustParse("2Mi"),
+			},
+			expectedErr: ErrExceededResources,
 		},
 	}
 

--- a/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources_test.go
@@ -48,19 +48,6 @@ func TestAdd(t *testing.T) {
 			},
 		},
 		{
-			name:    "does not change flags",
-			current: Resources{},
-			incoming: Resources{
-				Unlimited:     true,
-				Apps:          1,
-				VolumeStorage: resource.MustParse("1Mi"),
-			},
-			expected: Resources{
-				Apps:          1,
-				VolumeStorage: resource.MustParse("1Mi"),
-			},
-		},
-		{
 			name: "add where current has a resource specified with unlimited",
 			current: Resources{
 				Apps:   Unlimited,
@@ -353,20 +340,6 @@ func TestFits(t *testing.T) {
 				VolumeStorage: resource.MustParse("1Mi"),
 			},
 			expectedErr: ErrExceededResources,
-		},
-		{
-			name: "fits resources with unlimited flag set",
-			current: Resources{
-				Unlimited:     true,
-				Apps:          1,
-				Secrets:       1,
-				VolumeStorage: resource.MustParse("1Mi"),
-			},
-			incoming: Resources{
-				Apps:          2,
-				Secrets:       2,
-				VolumeStorage: resource.MustParse("2Mi"),
-			},
 		},
 		{
 			name: "fits resources with specified unlimited values",

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -13412,12 +13412,6 @@ func schema_pkg_apis_internaladminacornio_v1_Resources(ref common.ReferenceCallb
 				Description: "Resources is a struct separate from the QuotaRequestInstanceSpec to allow for external controllers to programmatically set the resources easier. Calls to its functions are mutating.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"unlimited": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 					"apps": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},


### PR DESCRIPTION
This adds the ability for `Unlimited` to be more granularly set per resource.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

