### PR TITLE
Change: verification key reference should default to acorn:// if it's not a file

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image_verify.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_verify.md
@@ -19,7 +19,7 @@ acorn image verify my-image --key ./my-key.pub
 acorn image verify my-image --key gh://ibuildthecloud
 
 # Verify using a public key belonging to an Acorn Manager Identity
-acorn image verify my-image --key ac://ibuildthecloud
+acorn image verify my-image --key acorn://ibuildthecloud
 
 ```
 

--- a/pkg/cli/images_verify.go
+++ b/pkg/cli/images_verify.go
@@ -22,7 +22,7 @@ acorn image verify my-image --key ./my-key.pub
 acorn image verify my-image --key gh://ibuildthecloud
 
 # Verify using a public key belonging to an Acorn Manager Identity
-acorn image verify my-image --key ac://ibuildthecloud
+acorn image verify my-image --key acorn://ibuildthecloud
 `,
 		SilenceUsage:      true,
 		Short:             "Verify Image Signatures",

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -390,10 +390,10 @@ func LoadVerifiers(ctx context.Context, keyRef string, algorithm string) (verifi
 			return nil, fmt.Errorf("failed to load public key from SSH - %s: %w", keyRef, err)
 		}
 		verifiers = append(verifiers, v)
-	} else if strings.HasPrefix(keyRef, "ac://") {
+	} else if strings.HasPrefix(keyRef, "acorn://") {
 		// Acorn Manager
 		logrus.Debugf("Loading public key from Acorn Manager: %s", keyRef)
-		acKeys, err := getAcornPublicKeys(strings.TrimPrefix(keyRef, "ac://"))
+		acKeys, err := getAcornPublicKeys(strings.TrimPrefix(keyRef, "acorn://"))
 		if err != nil {
 			return nil, fmt.Errorf("failed to load public key from Acorn Manager - %s: %w", keyRef, err)
 		}


### PR DESCRIPTION
Some changes that were requested by @ibuildthecloud a while ago - found the branch lingering around locally

change: ac:// -> acorn:// for verification key reference
change: --key foobar default to acorn://foobar if it's not a local file

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

