### PR TITLE
change: always use internal image ref for IAR validation, if possible (#2067)

### DIFF
--- a/pkg/autoupgrade/client.go
+++ b/pkg/autoupgrade/client.go
@@ -60,5 +60,5 @@ func (c *client) resolveLocalTag(ctx context.Context, namespace, name string) (s
 }
 
 func (c *client) checkImageAllowed(ctx context.Context, namespace, name string) error {
-	return imageallowrules.CheckImageAllowed(ctx, c.client, namespace, name, "")
+	return imageallowrules.CheckImageAllowed(ctx, c.client, namespace, name, "", "")
 }

--- a/pkg/controller/appdefinition/checkimageallowed.go
+++ b/pkg/controller/appdefinition/checkimageallowed.go
@@ -38,7 +38,7 @@ func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 		targetImage := strings.TrimSuffix(ref.Name(), ":")
 		targetImageDigest := appInstance.Status.AppImage.Digest
 
-		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, targetImageDigest, remote.WithTransport(transport)); err != nil {
+		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, appInstance.Status.AppImage.ID, targetImageDigest, remote.WithTransport(transport)); err != nil {
 			if _, ok := err.(*imageallowrules.ErrImageNotAllowed); ok {
 				cond.Error(err)
 				return nil

--- a/pkg/controller/appdefinition/checkimageallowed.go
+++ b/pkg/controller/appdefinition/checkimageallowed.go
@@ -3,6 +3,7 @@ package appdefinition
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
@@ -26,7 +27,7 @@ func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 			return nil
 		}
 
-		ref, err := name.ParseReference(appInstance.Status.AppImage.Name, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+		ref, err := name.ParseReference(appInstance.Status.AppImage.ID, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
 		if err != nil {
 			e := fmt.Errorf("failed to parse image name: %w", err)
 			logrus.Error(e)
@@ -34,7 +35,7 @@ func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 			return nil
 		}
 
-		targetImage := ref.Name()
+		targetImage := strings.TrimSuffix(ref.Name(), ":")
 		targetImageDigest := appInstance.Status.AppImage.Digest
 
 		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, targetImageDigest, remote.WithTransport(transport)); err != nil {

--- a/pkg/imageallowrules/imageallowrules.go
+++ b/pkg/imageallowrules/imageallowrules.go
@@ -36,27 +36,7 @@ func (e *ErrImageNotAllowed) Is(target error) bool {
 }
 
 // CheckImageAllowed checks if the image is allowed by the ImageAllowRules on cluster and project level
-func CheckImageAllowed(ctx context.Context, c client.Reader, namespace, image, digest string, opts ...remote.Option) error {
-	// Get ImageAllowRules in the same namespace as the AppInstance
-	rulesList := &v1.ImageAllowRuleInstanceList{}
-	if err := c.List(ctx, rulesList, &client.ListOptions{Namespace: namespace}); err != nil {
-		return fmt.Errorf("failed to list ImageAllowRules: %w", err)
-	}
-
-	opts, err := images.GetAuthenticationRemoteOptions(ctx, c, namespace, opts...)
-	if err != nil {
-		return err
-	}
-
-	return CheckImageAgainstRules(ctx, c, namespace, image, digest, rulesList.Items, opts...)
-}
-
-// CheckImageAgainstRules checks if the image is allowed by the given ImageAllowRules
-// If no rules are given, the image is
-// - DENIED if strict mode (deny-by-default) is enabled
-// - ALLOWED if strict mode is disabled (the default)
-// ! Only one single rule has to allow the image for this to pass !
-func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace string, image string, digest string, imageAllowRules []v1.ImageAllowRuleInstance, opts ...remote.Option) error {
+func CheckImageAllowed(ctx context.Context, c client.Reader, namespace, imageName, resolvedName, digest string, opts ...remote.Option) error {
 	cfg, err := config.Get(ctx, c)
 	if err != nil {
 		return err
@@ -67,12 +47,39 @@ func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace stri
 		return nil
 	}
 
-	// No rules? Deny all images.
-	if len(imageAllowRules) == 0 {
-		return &ErrImageNotAllowed{Image: image}
+	// Get ImageAllowRules in the same namespace as the AppInstance
+	rulesList := &v1.ImageAllowRuleInstanceList{}
+	if err := c.List(ctx, rulesList, &client.ListOptions{Namespace: namespace}); err != nil {
+		return fmt.Errorf("failed to list ImageAllowRules: %w", err)
 	}
 
-	logrus.Debugf("Checking image %s (%s) against %d rules", image, digest, len(imageAllowRules))
+	opts, err = images.GetAuthenticationRemoteOptions(ctx, c, namespace, opts...)
+	if err != nil {
+		return err
+	}
+
+	return CheckImageAgainstRules(ctx, c, namespace, imageName, resolvedName, digest, rulesList.Items, opts...)
+}
+
+// CheckImageAgainstRules checks if the image is allowed by the given ImageAllowRules
+// If no rules are given, the image is
+// - DENIED if strict mode (deny-by-default) is enabled
+// - ALLOWED if strict mode is disabled (the default)
+// ! Only one single rule has to allow the image for this to pass !
+//
+// About image references:
+// @param imageName: the image how it was called (e.g. how it was specified by the user in `acorn run`)
+// @param resolvedName: the image name after resolution (e.g. resolved to an internal image ID)
+// @param digest: the digest of the image
+// We will use all of those to check if an image is covered by an IAR.
+// We will prefer resolvedName to find signature artifacts (potentially in the internal registry)
+func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace, imageName, resolvedName, digest string, imageAllowRules []v1.ImageAllowRuleInstance, opts ...remote.Option) error {
+	// No rules? Deny all images.
+	if len(imageAllowRules) == 0 {
+		return &ErrImageNotAllowed{Image: imageName}
+	}
+
+	logrus.Debugf("Checking image %s (%s) against %d rules", imageName, digest, len(imageAllowRules))
 
 	// Check if the image is allowed
 	verifyOpts := cosign.VerifyOpts{
@@ -83,40 +90,56 @@ func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace stri
 		RemoteOpts:         opts,
 	}
 
-	ref, err := images.GetImageReference(ctx, c, namespace, image)
+	imageNameRef, err := images.GetImageReference(ctx, c, namespace, imageName)
 	if err != nil {
-		return fmt.Errorf("error parsing image reference %s: %w", image, err)
+		return fmt.Errorf("error parsing image reference %s: %w", imageName, err)
 	}
 
-	if ref.Identifier() == "" && tags.SHAPattern.MatchString(image) {
+	if imageNameRef.Identifier() == "" && tags.SHAPattern.MatchString(imageName) {
 		// image is a digest and was parsed as repository-only reference
-		if digest == "" {
-			digest = image
+		digest = imageName
+	} else if imageNameRef.Context().String() != "" {
+		digest = imageNameRef.Context().Digest(digest).Name()
+	}
+
+	signatureSourceRef := imageNameRef
+
+	var resolvedNameRef name.Reference
+	if resolvedName != "" {
+		// use resolved name for signature verification -> potentially get signature from internal registry
+		resolvedNameRefUsed, err := images.GetImageReference(ctx, c, namespace, resolvedName)
+		if err != nil {
+			return fmt.Errorf("error parsing image reference %s: %w", resolvedName, err)
 		}
-	} else if ref.Context().String() != "" {
-		digest = ref.Context().Digest(digest).Name()
+		signatureSourceRef = resolvedNameRefUsed
+
+		// for pattern matching we use the reference without any defaults
+		resolvedNameRef, err = name.ParseReference(resolvedName, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+		if err != nil {
+			return fmt.Errorf("error parsing image reference %s: %w", resolvedName, err)
+		}
 	}
 
 iarLoop:
 	for _, imageAllowRule := range imageAllowRules {
 		// Check if the image is in scope of the ImageAllowRule
-		if !ImageCovered(ref, digest, imageAllowRule.Images) {
-			logrus.Infof("Image %s (%s) is not covered by ImageAllowRule %s/%s: %#v", image, digest, imageAllowRule.Namespace, imageAllowRule.Name, imageAllowRule.Images)
+		if !ImageCovered(imageNameRef, digest, imageAllowRule.Images) && (resolvedNameRef != nil && !ImageCovered(resolvedNameRef, digest, imageAllowRule.Images)) { // could be the same check twice here or the latter could be the resolvedNameRef
+			logrus.Debugf("Image imageNameRef=[%s],digest=[%s],resolvedNameRef=[%s] is not covered by ImageAllowRule %s/%s: %#v", imageNameRef.String(), digest, resolvedNameRef.String(), imageAllowRule.Namespace, imageAllowRule.Name, imageAllowRule.Images)
 			continue
 		}
 
 		// > Signatures
 		// Any verification error or failed verification issue will skip on to the next IAR
 		for _, rule := range imageAllowRule.Signatures.Rules {
-			if err := VerifySignatureRule(ctx, c, namespace, image, rule, verifyOpts); err != nil {
-				logrus.Errorf("Verification failed for %s against %s/%s: %v", image, imageAllowRule.Namespace, imageAllowRule.Name, err)
+			if err := VerifySignatureRule(ctx, c, namespace, signatureSourceRef.String(), rule, verifyOpts); err != nil {
+				logrus.Errorf("Verification failed for %s against %s/%s: %v", imageName, imageAllowRule.Namespace, imageAllowRule.Name, err)
 				continue iarLoop
 			}
 		}
-		logrus.Debugf("Image %s (%s) is allowed by ImageAllowRule %s/%s", image, digest, imageAllowRule.Namespace, imageAllowRule.Name)
+		logrus.Debugf("Image %s (%s) is allowed by ImageAllowRule %s/%s", imageName, digest, imageAllowRule.Namespace, imageAllowRule.Name)
 		return nil
 	}
-	return &ErrImageNotAllowed{Image: image}
+	return &ErrImageNotAllowed{Image: imageName}
 }
 
 func VerifySignatureRule(ctx context.Context, c client.Reader, namespace string, image string, rule v1.SignatureRules, verifyOpts cosign.VerifyOpts) error {

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -227,6 +227,7 @@ func GetImageReference(ctx context.Context, c client.Reader, namespace, image st
 	if tags.SHAPattern.MatchString(image) {
 		return imagesystem.GetInternalRepoForNamespaceAndID(ctx, c, namespace, image)
 	}
+
 	return imagename.ParseReference(image)
 }
 

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -178,7 +178,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		}
 
 		if !disableCheckImageAllowRules {
-			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, image, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
+			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, checkImage, image, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
 				result = append(result, field.Forbidden(field.NewPath("spec", "image"), fmt.Sprintf("%s not allowed to run: %s", app.Spec.Image, err.Error())))
 				return
 			}

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -178,7 +178,7 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 		}
 
 		if !disableCheckImageAllowRules {
-			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, checkImage, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
+			if err := imageallowrules.CheckImageAllowed(ctx, s.client, app.Namespace, image, imageDetails.AppImage.Digest, remote.WithTransport(s.transport)); err != nil {
 				result = append(result, field.Forbidden(field.NewPath("spec", "image"), fmt.Sprintf("%s not allowed to run: %s", app.Spec.Image, err.Error())))
 				return
 			}


### PR DESCRIPTION
Ref: #2067 

We want to make sure, that the "local" image (and thus the local signature) is always preferred for IAR verification.

Also, we had the keychain derived from local auth lingering around there which was unused and is now gone.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

