### PR TITLE
Add install opt to set annotations on acorn-api pods

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -27,6 +27,7 @@ acorn install
       --allow-user-metadata-namespace strings           Allow these namespaces to propagate labels and annotations to dependent objects, no effect if --ignore-user-labels-and-annotations not true
       --api-server-cpu string                           The CPU to allocate to the runtime-api-server in the format of <req>:<limit> (example 200m:1000m)
       --api-server-memory string                        The memory to allocate to the runtime-api-server in the format of <req>:<limit> (example 256Mi:1Gi)
+      --api-server-pod-annotations stringArray          annotations to apply to acorn-api pods
       --api-server-replicas int                         acorn-api deployment replica count
       --auto-upgrade-interval string                    For apps configured with automatic upgrades enabled, the interval at which to check for new versions. Upgrade intervals configured at the application level cannot be smaller than this. (default '5m' - 5 minutes)
       --aws-identity-provider-arn string                ARN of cluster's OpenID Connect provider registered in AWS


### PR DESCRIPTION
Enable custom annotations to be set on the acorn-api deployment by adding an `--api-server-pod-annotations` option to the `acorn install` subcommand

e.g.

```sh
$ acorn install --api-server-pod-annotations foo=bar
```