### PR TITLE
Improve help and error messages for `acorn copy` (#2119)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_copy.md
@@ -10,6 +10,7 @@ acorn copy [flags] SOURCE DESTINATION
 
   This command copies Acorn images between remote image registries.
   It does not interact with images stored in the Acorn internal registry, or with the Acorn API in any way.
+  To set up credentials for a registry, use 'acorn login -l <registry>'. It only works with locally stored credentials.
 ```
 
 ### Examples

--- a/docs/docs/100-reference/01-command-line/acorn_image_copy.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_copy.md
@@ -10,6 +10,7 @@ acorn image copy [flags] SOURCE DESTINATION
 
   This command copies Acorn images between remote image registries.
   It does not interact with images stored in the Acorn internal registry, or with the Acorn API in any way.
+  To set up credentials for a registry, use 'acorn login -l <registry>'. It only works with locally stored credentials.
 ```
 
 ### Examples

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -276,6 +276,12 @@ func (a *ImageCopy) copyTag(source name.Reference, newTag string, sourceOpts []r
 
 	dest := source.Context().Tag(newTag)
 
+	// Parse it again to make sure that the tag provided by the user is valid
+	_, err = name.ParseReference(dest.String())
+	if err != nil {
+		return err
+	}
+
 	if !a.Force {
 		if err := errIfImageExistsAndIsDifferent(sourceIndex, dest, sourceOpts); err != nil {
 			return err

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -25,7 +25,8 @@ func NewImageCopy(c CommandContext) *cobra.Command {
 		Use: `copy [flags] SOURCE DESTINATION
 
   This command copies Acorn images between remote image registries.
-  It does not interact with images stored in the Acorn internal registry, or with the Acorn API in any way.`,
+  It does not interact with images stored in the Acorn internal registry, or with the Acorn API in any way.
+  To set up credentials for a registry, use 'acorn login -l <registry>'. It only works with locally stored credentials.`,
 		Aliases:           []string{"cp"},
 		SilenceUsage:      true,
 		Short:             "Copy Acorn images between registries",
@@ -248,6 +249,11 @@ func (a *ImageCopy) copyRepo(args []string, sourceOpts, destOpts []remote.Option
 }
 
 func (a *ImageCopy) copyTag(source name.Reference, newTag string, sourceOpts []remote.Option) error {
+	// -a is not supported for this operation, so check if it is set and return an error if so
+	if a.AllTags {
+		return errors.New("cannot use --all-tags with a tag destination")
+	}
+
 	sourceIndex, err := remote.Index(source, sourceOpts...)
 	if err != nil {
 		return err

--- a/pkg/cli/copy.go
+++ b/pkg/cli/copy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/acorn-io/baaah/pkg/typed"
@@ -16,7 +17,6 @@ import (
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
 )
@@ -57,9 +57,9 @@ func (a *ImageCopy) Run(cmd *cobra.Command, args []string) (err error) {
 			var terr *transport.Error
 			if ok := errors.As(err, &terr); ok {
 				if terr.StatusCode == http.StatusForbidden {
-					logrus.Warnf("Registry authentication failed. Try running 'acorn login -l <registry>'")
+					_, _ = fmt.Fprintln(os.Stderr, "Registry authentication failed. Try running 'acorn login -l <registry>'")
 				} else if terr.StatusCode == http.StatusUnauthorized {
-					logrus.Warnf("Registry authorization failed. Ensure that you have the correct permissions to push to this registry. Run 'acorn login -l <registry>' if you have not logged in yet.")
+					_, _ = fmt.Fprintln(os.Stderr, "Registry authorization failed. Ensure that you have the correct permissions to push to this registry. Run 'acorn login -l <registry>' if you have not logged in yet.")
 				}
 			}
 		}
@@ -277,8 +277,7 @@ func (a *ImageCopy) copyTag(source name.Reference, newTag string, sourceOpts []r
 	dest := source.Context().Tag(newTag)
 
 	// Parse it again to make sure that the tag provided by the user is valid
-	_, err = name.ParseReference(dest.String())
-	if err != nil {
+	if _, err := name.ParseReference(dest.String()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
for #2119

This improves the error messages for `acorn copy` when authn/authz fails. It also returns an error when the user tries to use `-a` with the `acorn copy <image> <new tag>` syntax, since that is undefined behavior.

I also made it clear in the help message that the user needs to log in to registries with `acorn login -l` since this command does not interact with the Acorn API.

I also improved the tag validation for `acorn copy <image> <new tag>` syntax.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

