### PR TITLE
Migrate legacy project namespaces (#2130)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apigroup.go
+++ b/pkg/server/registry/apigroups/acorn/apigroup.go
@@ -72,6 +72,11 @@ func Stores(c kclient.WithWatch, cfg, localCfg *clientgo.Config) (map[string]res
 		return nil, err
 	}
 
+	projectStorage, err := projects.NewStorage(c, true)
+	if err != nil {
+		return nil, err
+	}
+
 	volumesStorage := volumes.NewStorage(c)
 
 	stores := map[string]rest.Storage{
@@ -93,7 +98,7 @@ func Stores(c kclient.WithWatch, cfg, localCfg *clientgo.Config) (map[string]res
 		"images/details":                images.NewImageDetails(c, transport),
 		"images/sign":                   images.NewImageSign(c, transport),
 		"images/verify":                 images.NewImageVerify(c, transport),
-		"projects":                      projects.NewStorage(c, true),
+		"projects":                      projectStorage,
 		"volumes":                       volumesStorage,
 		"volumeclasses":                 class.NewClassStorage(c),
 		"containerreplicas":             containersStorage,

--- a/pkg/server/registry/apigroups/acorn/projects/storage.go
+++ b/pkg/server/registry/apigroups/acorn/projects/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/mink/pkg/stores"
@@ -18,12 +19,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewStorage(c kclient.WithWatch, namespaceCheck bool) rest.Storage {
+func NewStorage(c kclient.WithWatch, namespaceCheck bool) (rest.Storage, error) {
+	if err := migrateLegacyNamespaces(context.Background(), c); err != nil {
+		return nil, err
+	}
+
 	remoteResource := translation.NewSimpleTranslationStrategy(&translator{}, remote.NewRemote(&v1.ProjectInstance{}, c))
 	validator := &Validator{Client: c}
 	return stores.NewBuilder(c.Scheme(), &apiv1.Project{}).
@@ -32,7 +39,7 @@ func NewStorage(c kclient.WithWatch, namespaceCheck bool) rest.Storage {
 		WithValidateCreate(validator).
 		WithValidateUpdate(validator).
 		WithTableConverter(tables.ProjectConverter).
-		Build()
+		Build(), nil
 }
 
 type projectCreater struct {
@@ -76,4 +83,41 @@ func (pr *projectCreater) Create(ctx context.Context, object types.Object) (type
 	}
 
 	return pr.creater.Create(ctx, object)
+}
+
+func migrateLegacyNamespaces(ctx context.Context, c kclient.Client) error {
+	// Once a project namespace is managed by the project instance, then this label will be set on it.
+	// Therefore, using this label selector ensures the migration only happens once for a namespace.
+	notManaged, err := klabels.NewRequirement(labels.AcornManaged, selection.DoesNotExist, nil)
+	if err != nil {
+		return err
+	}
+
+	nsSelector := klabels.SelectorFromSet(map[string]string{
+		labels.AcornProject: "true",
+	}).Add(*notManaged)
+	namespaces := corev1.NamespaceList{}
+	if err := c.List(ctx, &namespaces, kclient.MatchingLabelsSelector{Selector: nsSelector}); err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces.Items {
+		project := &v1.ProjectInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns.Name,
+			},
+			Spec: v1.ProjectInstanceSpec{
+				DefaultRegion: ns.Annotations[labels.AcornProjectDefaultRegion],
+			},
+		}
+
+		if supportedRegions := ns.Annotations[labels.AcornProjectSupportedRegions]; supportedRegions != "" {
+			project.Spec.SupportedRegions = strings.Split(supportedRegions, ",")
+		}
+		if err = c.Create(ctx, project); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
If a project namespace existing prior to upgrading to the latest version, then the namespace needs to be migrated to a new project instance. This change does this by using a proper label selector to find namespaces that need to be migrated.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/runtime/issues/2130