### PR TITLE
Pass through necessary env vars to .gorleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,9 +38,15 @@ universal_binaries:
           output: true
           env:
             - AC_IDENTITY={{ if index .Env "AC_IDENTITY" }}{{ .Env.AC_IDENTITY }}{{ end }}
+            - AC_PROJECT={{ if index .Env "AC_PROJECT" }}{{ .Env.AC_PROJECT }}{{ end }}
             - AC_PROVIDER={{ if index .Env "AC_PROVIDER" }}{{ .Env.AC_PROVIDER }}{{ end }}
             - AC_USERNAME={{ if index .Env "AC_USERNAME" }}{{ .Env.AC_USERNAME }}{{ end }}
             - AC_PASSWORD={{ if index .Env "AC_PASSWORD" }}{{ .Env.AC_PASSWORD }}{{ end }}
+            - AC_P12={{ if index .Env "AC_P12" }}{{ .Env.AC_P12 }}{{ end }}
+            - AC_P12_PASSWORD={{ if index .Env "AC_P12_PASSWORD" }}{{ .Env.AC_P12_PASSWORD }}{{ end }}
+            - AC_ISSUER_ID={{ if index .Env "AC_ISSUER_ID" }}{{ .Env.AC_ISSUER_ID }}{{ end }}
+            - AC_KEY_ID={{ if index .Env "AC_KEY_ID" }}{{ .Env.AC_KEY_ID }}{{ end }}
+            - AC_PRIVATE_KEY={{ if index .Env "AC_PRIVATE_KEY" }}{{ .Env.AC_PRIVATE_KEY }}{{ end }}
 
 archives:
   - id: default


### PR DESCRIPTION
This env vars were not needed before we re-enabled notarizaiton. Now that we have, they'll need to get passed through to goreleaser.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

