### PR TITLE
Only include MacOS zip

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
   extra_files:
-    - glob: "./releases/*.zip"
+    - glob: "./releases/*-macOS-universal.zip"
 
 signs:
   - id: cosign
@@ -86,7 +86,7 @@ release:
   prerelease: auto
   extra_files:
     - glob: ./cosign.pub
-    - glob: "./releases/*.zip"
+    - glob: "./releases/*-macOS-universal.zip"
 
 brews:
   - description: "Acorn CLI"


### PR DESCRIPTION
This fixes an issue where we try to double upload release assets for Windows zip files which in turn causes a failure to release.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

