### PR TITLE
Add --quiet to install

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -63,6 +63,7 @@ acorn install
       --propagate-project-annotation strings            The list of keys of annotations to propagate from acorn project to app namespaces
       --propagate-project-label strings                 The list of keys of labels to propagate from acorn project to app namespaces
       --publish-builders                                Publish the builders through ingress to so build traffic does not traverse the api-server
+      --quiet                                           Only output errors encountered during installation
       --record-builds                                   Keep a record of each acorn build that happens
       --registry-cpu string                             The CPU to allocate to the registry in the format of <req>:<limit> (example 200m:1000m)
       --registry-memory string                          The memory to allocate to the registry in the format of <req>:<limit> (example 256Mi:1Gi)

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -29,10 +29,10 @@ acorn install`,
 }
 
 type Install struct {
-	SkipChecks bool `usage:"Bypass installation checks"`
-
-	Image  string `usage:"Override the default image used for the deployment"`
-	Output string `usage:"Output manifests instead of applying them (json, yaml)" short:"o"`
+	SkipChecks bool   `usage:"Bypass installation checks"`
+	Quiet      bool   `usage:"Only output errors encountered during installation"`
+	Image      string `usage:"Override the default image used for the deployment"`
+	Output     string `usage:"Output manifests instead of applying them (json, yaml)" short:"o"`
 
 	APIServerReplicas                  *int     `usage:"acorn-api deployment replica count" name:"api-server-replicas"`
 	APIServerPodAnnotations            []string `usage:"annotations to apply to acorn-api pods" name:"api-server-pod-annotations" split:"false"`
@@ -96,6 +96,7 @@ func (i *Install) Run(cmd *cobra.Command, args []string) error {
 
 	opts := &install.Options{
 		SkipChecks:                          i.SkipChecks,
+		Quiet:                               i.Quiet,
 		OutputFormat:                        i.Output,
 		Config:                              i.Config,
 		APIServerReplicas:                   i.APIServerReplicas,

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -66,6 +66,7 @@ type Options struct {
 	ControllerServiceAccountAnnotations map[string]string
 	Config                              apiv1.Config
 	Progress                            progress.Builder
+	Quiet                               bool
 }
 
 func (o *Options) complete() *Options {
@@ -75,7 +76,11 @@ func (o *Options) complete() *Options {
 	}
 
 	if o.Progress == nil {
-		o.Progress = &term.Builder{}
+		if o.Quiet {
+			o.Progress = &term.QuietBuilder{}
+		} else {
+			o.Progress = &term.Builder{}
+		}
 	}
 
 	if o.APIServerReplicas == nil {
@@ -293,7 +298,9 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		}
 	}
 
-	pterm.Success.Println("Installation done")
+	if !opts.Quiet {
+		pterm.Success.Println("Installation done")
+	}
 	return nil
 }
 

--- a/pkg/term/quiet.go
+++ b/pkg/term/quiet.go
@@ -1,0 +1,42 @@
+package term
+
+import (
+	"github.com/acorn-io/runtime/pkg/install/progress"
+	"github.com/sirupsen/logrus"
+)
+
+type QuietBuilder struct {
+}
+
+func (b *QuietBuilder) New(msg string) progress.Progress {
+	return newQuietSpinner(msg)
+}
+
+type quietSpinner struct {
+	text string
+}
+
+func newQuietSpinner(text string) *quietSpinner {
+	return &quietSpinner{
+		text: text,
+	}
+}
+
+func (s *quietSpinner) Fail(err error) error {
+	if err != nil {
+		logrus.Errorf("Error encountered during '%v': %v", s.text, err)
+	}
+	return err
+}
+
+func (*quietSpinner) Infof(string, ...any) {
+	// No-op, we're being quiet
+}
+
+func (*quietSpinner) SuccessWithWarning(string, ...any) {
+	// No-op, we're being quiet
+}
+
+func (*quietSpinner) Success() {
+	// No-op, we're being quiet
+}


### PR DESCRIPTION
This will suppress all installation output except for errors
encountered. The motivation is to use this flag when manager installs
acorn because these interactive terminal messages aren't useful in that
scenario.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

