### PR TITLE
add: default acorn.io/signed-name annotation for signatures (opt-out for verification) (#2149)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_pull.md
+++ b/docs/docs/100-reference/01-command-line/acorn_pull.md
@@ -15,6 +15,7 @@ acorn pull [flags] IMAGE
   -a, --annotation strings   Annotations to check for during verification
   -h, --help                 help for pull
   -k, --key string           Key to use for verifying (default "./cosign.pub")
+      --no-verify-name       Do not verify the image name in the signature
   -v, --verify               Verify the image signature BEFORE pulling and only pull on success
 ```
 

--- a/integration/client/signatures/rules_test.go
+++ b/integration/client/signatures/rules_test.go
@@ -176,7 +176,7 @@ func TestImageAllowRules(t *testing.T) {
 	require.Error(t, err, "should error since image %s is not signed by the required key", tagName)
 
 	// sign image
-	nsig, err := signImage(ctx, c, targetDigest, "./testdata/cosign.key")
+	nsig, err := signImage(ctx, c, targetDigest, tagName, "./testdata/cosign.key")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/signatures/signature_test.go
+++ b/integration/client/signatures/signature_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/v2/pkg/signature"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "embed"
 )
@@ -59,7 +60,7 @@ func TestImageSignature(t *testing.T) {
 	assert.Empty(t, details.SignatureDigest, "signature digest should be empty before signing")
 
 	// sign
-	sig, err := signImage(ctx, c, targetDigest, "./testdata/cosign.key")
+	sig, err := signImage(ctx, c, targetDigest, remoteTagName, "./testdata/cosign.key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,12 +86,28 @@ func TestImageSignature(t *testing.T) {
 		PublicKey: string(pem2),
 	}
 
+	_, err = c.ImageVerify(ctx, remoteTagName, vOpts)
+	require.NoError(t, err, "expected no error when verifying image %s with valid public key", remoteTagName)
+
 	_, err = c.ImageVerify(ctx, targetDigest.String(), vOpts)
-	assert.NoError(t, err, "expected no error when verifying image with valid public key")
+	require.Error(t, err, "expected error when verifying image with valid public key but referenced by digest which was not used for signing (acorn.io/signedName annotation)")
+
+	vOpts.NoVerifyName = true
+	_, err = c.ImageVerify(ctx, targetDigest.String(), vOpts)
+	require.NoError(t, err, "expected no error when verifying image with valid public key and digest as reference - where NoVerifyName is set")
+	vOpts.NoVerifyName = false
+
+	// Now sign again using the digest as the reference
+	_, err = signImage(ctx, c, targetDigest, targetDigest.String(), "./testdata/cosign.key")
+	require.NoError(t, err, "expected no error when signing image with digest as reference")
+
+	// Verify again - this time successfully using the digest as the reference
+	_, err = c.ImageVerify(ctx, targetDigest.String(), vOpts)
+	require.NoError(t, err, "expected no error when verifying image with valid public key and digest as reference")
 
 	// 1.3 - Details with Signature Hash
 	details, err = c.ImageDetails(ctx, targetDigest.DigestStr(), nil)
-	assert.NoError(t, err, "expected no error when getting details of signed image")
+	require.NoError(t, err, "expected no error when getting details of signed image")
 
 	assert.NotEmpty(t, details.SignatureDigest)
 
@@ -101,5 +118,5 @@ func TestImageSignature(t *testing.T) {
 	}
 
 	_, err = c.ImageVerify(ctx, targetDigest.String(), vOpts)
-	assert.Error(t, err, "expected error when verifying image with invalid annotations")
+	require.Error(t, err, "expected error when verifying image with invalid annotations")
 }

--- a/integration/client/signatures/util.go
+++ b/integration/client/signatures/util.go
@@ -12,13 +12,22 @@ import (
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
 
-func signImage(ctx context.Context, c client.Client, targetDigest name.Digest, key string) (*v1.ImageSignature, error) {
+func signImage(ctx context.Context, c client.Client, targetDigest name.Digest, targetName, key string) (*v1.ImageSignature, error) {
 	sigSigner, err := signature.SignerVerifierFromKeyRef(ctx, key, func(_ bool) ([]byte, error) { return []byte(""), nil })
 	if err != nil {
 		return nil, err
 	}
 
-	payload, sig, err := sigsig.SignImage(sigSigner, targetDigest, map[string]interface{}{})
+	annotations := map[string]string{
+		acornsign.SignatureAnnotationSignedName: targetName,
+	}
+
+	iannotations := map[string]interface{}{}
+	for k, v := range annotations {
+		iannotations[k] = v
+	}
+
+	payload, sig, err := sigsig.SignImage(sigSigner, targetDigest, iannotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -334,8 +334,9 @@ type ImageSignature struct {
 	Auth *RegistryAuth `json:"auth,omitempty"`
 
 	// - Verification / Deduplication
-	PublicKey   string                  `json:"publicKeys,omitempty"` // either reference or PEM encoded key
-	Annotations v1.SignatureAnnotations `json:"annotations,omitempty"`
+	PublicKey    string                  `json:"publicKeys,omitempty"` // either reference or PEM encoded key
+	Annotations  v1.SignatureAnnotations `json:"annotations,omitempty"`
+	NoVerifyName bool                    `json:"noVerifyName,omitempty"` // do not verify the image name in the signature
 
 	// - Signing
 	Payload      []byte `json:"payload,omitempty"`

--- a/pkg/apis/internal.acorn.io/v1/imageallowrules.go
+++ b/pkg/apis/internal.acorn.io/v1/imageallowrules.go
@@ -3,17 +3,7 @@
 package v1
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/strings/slices"
 )
 
 type SignedBy struct {
@@ -24,19 +14,6 @@ type SignedBy struct {
 type SignatureAnnotations struct {
 	Match       map[string]string                 `json:"match,omitempty"`
 	Expressions []metav1.LabelSelectorRequirement `json:"expressions,omitempty"`
-}
-
-type LabelSelectorOpts struct {
-	LabelRequirementErrorFilters []utilerrors.Matcher
-}
-
-func (r *SignatureAnnotations) AsSelector(opts LabelSelectorOpts) (labels.Selector, error) {
-	labelselector := &metav1.LabelSelector{
-		MatchLabels:      r.Match,
-		MatchExpressions: r.Expressions,
-	}
-
-	return labelSelectorAsSelector(labelselector, opts)
 }
 
 type SignatureRules struct {
@@ -64,68 +41,4 @@ type ImageAllowRuleInstanceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ImageAllowRuleInstance `json:"items"`
-}
-
-// Util Functions
-
-// labelSelectorAsSelector is adapted from k8s.io/apimachinery@v0.27.3/pkg/apis/meta/v1/helpers.go to include filtering of errors, e.g. to ignore the max length error for label values
-func labelSelectorAsSelector(ps *metav1.LabelSelector, opts LabelSelectorOpts) (labels.Selector, error) {
-	if ps == nil {
-		return labels.Nothing(), nil
-	}
-	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
-		return labels.Everything(), nil
-	}
-	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
-	for k, v := range ps.MatchLabels {
-		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
-		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	for _, expr := range ps.MatchExpressions {
-		var op selection.Operator
-		switch expr.Operator {
-		case metav1.LabelSelectorOpIn:
-			op = selection.In
-		case metav1.LabelSelectorOpNotIn:
-			op = selection.NotIn
-		case metav1.LabelSelectorOpExists:
-			op = selection.Exists
-		case metav1.LabelSelectorOpDoesNotExist:
-			op = selection.DoesNotExist
-		default:
-			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
-		}
-		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
-		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	selector := labels.NewSelector()
-	selector = selector.Add(requirements...)
-	return selector, nil
-}
-
-var LabelValueMaxLengthErrMsg string = validation.MaxLenError(validation.LabelValueMaxLength)
-
-const LabelValueRegexpErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
-
-func IgnoreInvalidFieldErrors(detailsPrefixes ...string) func(error) bool {
-	return func(err error) bool {
-		if ferr := err.(*field.Error); errors.As(err, &ferr) && ferr.Type == field.ErrorTypeInvalid {
-			filteredErrs := slices.Filter(nil, strings.Split(ferr.Detail, ";"), func(s string) bool {
-				for _, prefix := range detailsPrefixes {
-					if strings.HasPrefix(strings.TrimSpace(s), prefix) {
-						return false
-					}
-				}
-				return true
-			})
-			return len(filteredErrs) == 0
-		}
-		return false
-	}
 }

--- a/pkg/apis/internal.acorn.io/v1/imageallowrules.go
+++ b/pkg/apis/internal.acorn.io/v1/imageallowrules.go
@@ -3,8 +3,17 @@
 package v1
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/strings/slices"
 )
 
 type SignedBy struct {
@@ -17,13 +26,17 @@ type SignatureAnnotations struct {
 	Expressions []metav1.LabelSelectorRequirement `json:"expressions,omitempty"`
 }
 
-func (r *SignatureAnnotations) AsSelector() (labels.Selector, error) {
+type LabelSelectorOpts struct {
+	LabelRequirementErrorFilters []utilerrors.Matcher
+}
+
+func (r *SignatureAnnotations) AsSelector(opts LabelSelectorOpts) (labels.Selector, error) {
 	labelselector := &metav1.LabelSelector{
 		MatchLabels:      r.Match,
 		MatchExpressions: r.Expressions,
 	}
 
-	return metav1.LabelSelectorAsSelector(labelselector)
+	return labelSelectorAsSelector(labelselector, opts)
 }
 
 type SignatureRules struct {
@@ -51,4 +64,68 @@ type ImageAllowRuleInstanceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ImageAllowRuleInstance `json:"items"`
+}
+
+// Util Functions
+
+// labelSelectorAsSelector is adapted from k8s.io/apimachinery@v0.27.3/pkg/apis/meta/v1/helpers.go to include filtering of errors, e.g. to ignore the max length error for label values
+func labelSelectorAsSelector(ps *metav1.LabelSelector, opts LabelSelectorOpts) (labels.Selector, error) {
+	if ps == nil {
+		return labels.Nothing(), nil
+	}
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
+		return labels.Everything(), nil
+	}
+	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
+	for k, v := range ps.MatchLabels {
+		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	for _, expr := range ps.MatchExpressions {
+		var op selection.Operator
+		switch expr.Operator {
+		case metav1.LabelSelectorOpIn:
+			op = selection.In
+		case metav1.LabelSelectorOpNotIn:
+			op = selection.NotIn
+		case metav1.LabelSelectorOpExists:
+			op = selection.Exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	selector := labels.NewSelector()
+	selector = selector.Add(requirements...)
+	return selector, nil
+}
+
+var LabelValueMaxLengthErrMsg string = validation.MaxLenError(validation.LabelValueMaxLength)
+
+const LabelValueRegexpErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+
+func IgnoreInvalidFieldErrors(detailsPrefixes ...string) func(error) bool {
+	return func(err error) bool {
+		if ferr := err.(*field.Error); errors.As(err, &ferr) && ferr.Type == field.ErrorTypeInvalid {
+			filteredErrs := slices.Filter(nil, strings.Split(ferr.Detail, ";"), func(s string) bool {
+				for _, prefix := range detailsPrefixes {
+					if strings.HasPrefix(strings.TrimSpace(s), prefix) {
+						return false
+					}
+				}
+				return true
+			})
+			return len(filteredErrs) == 0
+		}
+		return false
+	}
 }

--- a/pkg/cli/images_verify.go
+++ b/pkg/cli/images_verify.go
@@ -9,6 +9,7 @@ import (
 	acornsign "github.com/acorn-io/runtime/pkg/cosign"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pterm/pterm"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -35,9 +36,10 @@ acorn image verify my-image --key acorn://ibuildthecloud
 }
 
 type ImageVerify struct {
-	client      ClientFactory
-	Key         string            `usage:"Key to use for verifying" short:"k" local:"true"`
-	Annotations map[string]string `usage:"Annotations to check for in the signature" short:"a" local:"true" name:"annotation"`
+	client       ClientFactory
+	Key          string            `usage:"Key to use for verifying" short:"k" local:"true"`
+	Annotations  map[string]string `usage:"Annotations to check for in the signature" short:"a" local:"true" name:"annotation"`
+	NoVerifyName bool              `usage:"Do not verify the image name in the signature" local:"true" default:"false"`
 }
 
 func (a *ImageVerify) Run(cmd *cobra.Command, args []string) error {
@@ -68,6 +70,13 @@ func (a *ImageVerify) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	targetDigest := ref.Context().Digest(details.AppImage.Digest)
+
+	if !a.NoVerifyName {
+		// verify the image name in the signature
+		a.Annotations[acornsign.SignatureAnnotationSignedRef] = imageName
+	}
+
+	logrus.Debugf("Verifying Image %s (digest: %s) using key %s and annotations: %#v\n", imageName, targetDigest, a.Key, a.Annotations)
 
 	vOpts := &client.ImageVerifyOptions{
 		Annotations: a.Annotations,

--- a/pkg/cli/images_verify.go
+++ b/pkg/cli/images_verify.go
@@ -71,17 +71,13 @@ func (a *ImageVerify) Run(cmd *cobra.Command, args []string) error {
 
 	targetDigest := ref.Context().Digest(details.AppImage.Digest)
 
-	if !a.NoVerifyName {
-		// verify the image name in the signature
-		a.Annotations[acornsign.SignatureAnnotationSignedRef] = imageName
-	}
-
 	logrus.Debugf("Verifying Image %s (digest: %s) using key %s and annotations: %#v\n", imageName, targetDigest, a.Key, a.Annotations)
 
 	vOpts := &client.ImageVerifyOptions{
-		Annotations: a.Annotations,
-		PublicKey:   a.Key,
-		Auth:        auth,
+		Annotations:  a.Annotations,
+		PublicKey:    a.Key,
+		Auth:         auth,
+		NoVerifyName: a.NoVerifyName,
 	}
 
 	// load public key from file (if it is a file, not a remote reference)

--- a/pkg/cli/pull.go
+++ b/pkg/cli/pull.go
@@ -19,10 +19,11 @@ func NewPull(c CommandContext) *cobra.Command {
 }
 
 type Pull struct {
-	client      ClientFactory
-	Verify      bool              `usage:"Verify the image signature BEFORE pulling and only pull on success" short:"v" local:"true" default:"false"`
-	Key         string            `usage:"Key to use for verifying" short:"k" local:"true" default:"./cosign.pub"`
-	Annotations map[string]string `usage:"Annotations to check for during verification" short:"a" local:"true" name:"annotation"`
+	client       ClientFactory
+	Verify       bool              `usage:"Verify the image signature BEFORE pulling and only pull on success" short:"v" local:"true" default:"false"`
+	Key          string            `usage:"Key to use for verifying" short:"k" local:"true" default:"./cosign.pub"`
+	Annotations  map[string]string `usage:"Annotations to check for during verification" short:"a" local:"true" name:"annotation"`
+	NoVerifyName bool              `usage:"Do not verify the image name in the signature" local:"true" default:"false"`
 }
 
 func (s *Pull) Run(cmd *cobra.Command, args []string) error {
@@ -38,9 +39,10 @@ func (s *Pull) Run(cmd *cobra.Command, args []string) error {
 
 	if s.Verify {
 		v := ImageVerify{
-			client:      s.client,
-			Key:         s.Key,
-			Annotations: s.Annotations,
+			client:       s.client,
+			Key:          s.Key,
+			Annotations:  s.Annotations,
+			NoVerifyName: s.NoVerifyName,
 		}
 		if err := v.Run(cmd, args); err != nil {
 			return fmt.Errorf("NOT pulling image due to verification issue: %w", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -370,9 +370,10 @@ type ImageSignOptions struct {
 }
 
 type ImageVerifyOptions struct {
-	PublicKey   string              `json:"publicKeys,omitempty"`
-	Annotations map[string]string   `json:"annotations,omitempty"`
-	Auth        *apiv1.RegistryAuth `json:"auth,omitempty"`
+	PublicKey    string              `json:"publicKeys,omitempty"`
+	Annotations  map[string]string   `json:"annotations,omitempty"`
+	Auth         *apiv1.RegistryAuth `json:"auth,omitempty"`
+	NoVerifyName bool                `json:"noVerifyName,omitempty"`
 }
 
 func (o EventStreamOptions) ListOptions() *kclient.ListOptions {

--- a/pkg/client/verify.go
+++ b/pkg/client/verify.go
@@ -11,8 +11,9 @@ import (
 
 func (c *DefaultClient) ImageVerify(ctx context.Context, image string, opts *ImageVerifyOptions) (*apiv1.ImageSignature, error) {
 	sigInput := &apiv1.ImageSignature{
-		PublicKey: opts.PublicKey,
-		Auth:      opts.Auth,
+		PublicKey:    opts.PublicKey,
+		Auth:         opts.Auth,
+		NoVerifyName: opts.NoVerifyName,
 	}
 
 	if opts.PublicKey == "" {

--- a/pkg/client/verify.go
+++ b/pkg/client/verify.go
@@ -24,18 +24,11 @@ func (c *DefaultClient) ImageVerify(ctx context.Context, image string, opts *Ima
 		Match: opts.Annotations,
 	}
 
-	imageDetails, err := c.ImageDetails(ctx, image, &ImageDetailsOptions{Auth: opts.Auth})
-	if err != nil {
-		return nil, err
-	}
-
-	image = strings.ReplaceAll(imageDetails.AppImage.ID, "/", "+")
-
 	sigResult := &apiv1.ImageSignature{}
-	err = c.RESTClient.Post().
+	err := c.RESTClient.Post().
 		Namespace(c.Namespace).
 		Resource("images").
-		Name(image).
+		Name(strings.ReplaceAll(image, "/", "+")).
 		SubResource("verify").
 		Body(sigInput).Do(ctx).Into(sigResult)
 

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -207,7 +208,7 @@ func VerifySignature(ctx context.Context, opts VerifyOpts) error {
 		errs = append(errs, err)
 	}
 
-	err = &VerificationFailure{&ErrNoMatchingSignatures{fmt.Errorf("failed to find valid signature for %s matching given identity and annotations using %d loaded verifiers/keys", opts.ImageRef.String(), len(opts.Verifiers))}}
+	err = &VerificationFailure{&ErrNoMatchingSignatures{fmt.Errorf("failed to find valid signature for %s matching given identity and %d annotation rules using %d loaded verifiers/keys", opts.ImageRef.String(), len(opts.AnnotationRules.Match)+len(opts.AnnotationRules.Expressions), len(opts.Verifiers))}}
 	logrus.Debugf("%s: %v", err, errors.Join(errs...))
 	return err
 }
@@ -256,12 +257,14 @@ func DecodePEM(raw []byte, signatureAlgorithm crypto.Hash) (signature.Verifier, 
 var ErrAnnotationsUnmatched = cosign.NewVerificationError("annotations unmatched")
 
 func checkAnnotations(payloads []payload.SimpleContainerImage, annotationRule v1.SignatureAnnotations) error {
-	sel, err := annotationRule.AsSelector()
+	// We're using Kubernetes' label selector logic here, but we need to override the error handling
+	// since the annotations we're matching on are less restricted than Kubernetes labels
+	sel, err := annotationRule.AsSelector(v1.LabelSelectorOpts{LabelRequirementErrorFilters: []utilerrors.Matcher{v1.IgnoreInvalidFieldErrors(v1.LabelValueMaxLengthErrMsg, v1.LabelValueRegexpErrMsg)}})
 	if err != nil {
 		return fmt.Errorf("failed to parse annotation rule: %w", err)
 	}
 
-	if sel.Empty() {
+	if sel == nil || sel.Empty() {
 		return nil
 	}
 
@@ -275,7 +278,6 @@ func checkAnnotations(payloads []payload.SimpleContainerImage, annotationRule v1
 	}
 
 	labelMaps := generateVariations(kvLists) // alternatively we can re-write the label matching logic to work with a map[string][]string
-	logrus.Debugf("Checking against %d generated label maps: %+v", len(labelMaps), labelMaps)
 
 	for _, labelMap := range labelMaps {
 		if sel.Matches(labels.Set(labelMap)) {

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/imageallowrules/selector"
 	"github.com/acorn-io/runtime/pkg/images"
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -259,7 +260,7 @@ var ErrAnnotationsUnmatched = cosign.NewVerificationError("annotations unmatched
 func checkAnnotations(payloads []payload.SimpleContainerImage, annotationRule v1.SignatureAnnotations) error {
 	// We're using Kubernetes' label selector logic here, but we need to override the error handling
 	// since the annotations we're matching on are less restricted than Kubernetes labels
-	sel, err := annotationRule.AsSelector(v1.LabelSelectorOpts{LabelRequirementErrorFilters: []utilerrors.Matcher{v1.IgnoreInvalidFieldErrors(v1.LabelValueMaxLengthErrMsg, v1.LabelValueRegexpErrMsg)}})
+	sel, err := selector.GenerateSelector(annotationRule, selector.LabelSelectorOpts{LabelRequirementErrorFilters: []utilerrors.Matcher{selector.IgnoreInvalidFieldErrors(selector.LabelValueMaxLengthErrMsg, selector.LabelValueRegexpErrMsg)}})
 	if err != nil {
 		return fmt.Errorf("failed to parse annotation rule: %w", err)
 	}

--- a/pkg/cosign/types.go
+++ b/pkg/cosign/types.go
@@ -1,0 +1,11 @@
+package cosign
+
+const (
+	SignatureAnnotationSignedRef = "acorn.io/signedRef" // If an image was signed by `acorn image sign foo/bar:v1`, this annotation should be set to `foo/bar:v1` (the payload usually only includes the image digest)
+)
+
+func GetDefaultSignatureAnnotations(imageRef string) map[string]interface{} {
+	return map[string]interface{}{
+		SignatureAnnotationSignedRef: imageRef,
+	}
+}

--- a/pkg/cosign/types.go
+++ b/pkg/cosign/types.go
@@ -1,11 +1,11 @@
 package cosign
 
 const (
-	SignatureAnnotationSignedRef = "acorn.io/signedRef" // If an image was signed by `acorn image sign foo/bar:v1`, this annotation should be set to `foo/bar:v1` (the payload usually only includes the image digest)
+	SignatureAnnotationSignedName = "acorn.io/signedName" // If an image was signed by `acorn image sign foo/bar:v1`, this annotation should be set to `foo/bar:v1` (the payload usually only includes the image digest)
 )
 
-func GetDefaultSignatureAnnotations(imageRef string) map[string]interface{} {
+func GetDefaultSignatureAnnotations(imageName string) map[string]interface{} {
 	return map[string]interface{}{
-		SignatureAnnotationSignedRef: imageRef,
+		SignatureAnnotationSignedName: imageName,
 	}
 }

--- a/pkg/cosign/types.go
+++ b/pkg/cosign/types.go
@@ -1,7 +1,7 @@
 package cosign
 
 const (
-	SignatureAnnotationSignedName = "acorn.io/signedName" // If an image was signed by `acorn image sign foo/bar:v1`, this annotation should be set to `foo/bar:v1` (the payload usually only includes the image digest)
+	SignatureAnnotationSignedName = "acorn.io/signed-name" // If an image was signed by `acorn image sign foo/bar:v1`, this annotation should be set to `foo/bar:v1` (the payload usually only includes the image digest)
 )
 
 func GetDefaultSignatureAnnotations(imageName string) map[string]interface{} {

--- a/pkg/imageallowrules/selector/selector.go
+++ b/pkg/imageallowrules/selector/selector.go
@@ -77,7 +77,7 @@ const LabelValueRegexpErrMsg string = "a valid label must be an empty string or 
 
 func IgnoreInvalidFieldErrors(detailsPrefixes ...string) func(error) bool {
 	return func(err error) bool {
-		if ferr := err.(*field.Error); errors.As(err, &ferr) && ferr.Type == field.ErrorTypeInvalid {
+		if ferr := (*field.Error)(nil); errors.As(err, &ferr) && ferr.Type == field.ErrorTypeInvalid {
 			filteredErrs := slices.Filter(nil, strings.Split(ferr.Detail, ";"), func(s string) bool {
 				for _, prefix := range detailsPrefixes {
 					if strings.HasPrefix(strings.TrimSpace(s), prefix) {

--- a/pkg/imageallowrules/selector/selector.go
+++ b/pkg/imageallowrules/selector/selector.go
@@ -1,0 +1,93 @@
+package selector
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/strings/slices"
+)
+
+// UTIL
+
+type LabelSelectorOpts struct {
+	LabelRequirementErrorFilters []utilerrors.Matcher
+}
+
+func GenerateSelector(r v1.SignatureAnnotations, opts LabelSelectorOpts) (labels.Selector, error) {
+	labelselector := &metav1.LabelSelector{
+		MatchLabels:      r.Match,
+		MatchExpressions: r.Expressions,
+	}
+
+	return labelSelectorAsSelector(labelselector, opts)
+}
+
+// labelSelectorAsSelector is adapted from k8s.io/apimachinery@v0.27.3/pkg/apis/meta/v1/helpers.go to include filtering of errors, e.g. to ignore the max length error for label values
+func labelSelectorAsSelector(ps *metav1.LabelSelector, opts LabelSelectorOpts) (labels.Selector, error) {
+	if ps == nil {
+		return labels.Nothing(), nil
+	}
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
+		return labels.Everything(), nil
+	}
+	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
+	for k, v := range ps.MatchLabels {
+		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	for _, expr := range ps.MatchExpressions {
+		var op selection.Operator
+		switch expr.Operator {
+		case metav1.LabelSelectorOpIn:
+			op = selection.In
+		case metav1.LabelSelectorOpNotIn:
+			op = selection.NotIn
+		case metav1.LabelSelectorOpExists:
+			op = selection.Exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		if utilerrors.FilterOut(err, opts.LabelRequirementErrorFilters...) != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	selector := labels.NewSelector()
+	selector = selector.Add(requirements...)
+	return selector, nil
+}
+
+var LabelValueMaxLengthErrMsg string = validation.MaxLenError(validation.LabelValueMaxLength)
+
+const LabelValueRegexpErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+
+func IgnoreInvalidFieldErrors(detailsPrefixes ...string) func(error) bool {
+	return func(err error) bool {
+		if ferr := err.(*field.Error); errors.As(err, &ferr) && ferr.Type == field.ErrorTypeInvalid {
+			filteredErrs := slices.Filter(nil, strings.Split(ferr.Detail, ";"), func(s string) bool {
+				for _, prefix := range detailsPrefixes {
+					if strings.HasPrefix(strings.TrimSpace(s), prefix) {
+						return false
+					}
+				}
+				return true
+			})
+			return len(filteredErrs) == 0
+		}
+		return false
+	}
+}

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3978,6 +3978,12 @@ func schema_pkg_apis_apiacornio_v1_ImageSignature(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1.SignatureAnnotations"),
 						},
 					},
+					"noVerifyName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"payload": {
 						SchemaProps: spec.SchemaProps{
 							Description: "- Signing",

--- a/pkg/server/registry/apigroups/acorn/images/verify.go
+++ b/pkg/server/registry/apigroups/acorn/images/verify.go
@@ -85,6 +85,9 @@ func (t *ImageVerifyStrategy) ImageVerify(ctx context.Context, namespace string,
 	}
 
 	if !signature.NoVerifyName {
+		if signature.Annotations.Match == nil {
+			signature.Annotations.Match = make(map[string]string, 1)
+		}
 		if _, ok := signature.Annotations.Match[acornsign.SignatureAnnotationSignedName]; !ok {
 			signature.Annotations.Match[acornsign.SignatureAnnotationSignedName] = signature.Name
 		}

--- a/pkg/server/registry/apigroups/acorn/images/verify.go
+++ b/pkg/server/registry/apigroups/acorn/images/verify.go
@@ -84,6 +84,12 @@ func (t *ImageVerifyStrategy) ImageVerify(ctx context.Context, namespace string,
 		return acornsign.NewVerificationFailure(&acornsign.ErrNoSignaturesFound{Err: fmt.Errorf("no signatures found for image %s", targetName)})
 	}
 
+	if !signature.NoVerifyName {
+		if _, ok := signature.Annotations.Match[acornsign.SignatureAnnotationSignedName]; !ok {
+			signature.Annotations.Match[acornsign.SignatureAnnotationSignedName] = signature.Name
+		}
+	}
+
 	verifyOpts := &acornsign.VerifyOpts{
 		AnnotationRules:    signature.Annotations,
 		SignatureAlgorithm: "sha256",

--- a/pkg/server/registry/apigroups/acorn/images/verify.go
+++ b/pkg/server/registry/apigroups/acorn/images/verify.go
@@ -78,10 +78,13 @@ func (t *ImageVerifyStrategy) ImageVerify(ctx context.Context, namespace string,
 		return err
 	}
 
-	targetName := imageDetails.Name
+	ref, err = images.GetImageReference(ctx, t.client, namespace, imageDetails.AppImage.ID)
+	if err != nil {
+		return err
+	}
 
 	if imageDetails.SignatureDigest == "" {
-		return acornsign.NewVerificationFailure(&acornsign.ErrNoSignaturesFound{Err: fmt.Errorf("no signatures found for image %s", targetName)})
+		return acornsign.NewVerificationFailure(&acornsign.ErrNoSignaturesFound{Err: fmt.Errorf("no signatures found for image %s", signature.Name)})
 	}
 
 	if !signature.NoVerifyName {


### PR DESCRIPTION
This is a security requirement for IRBs in Manager and for upcoming IRAs in Runtime.
During signing this is transparent for the user (we just add that annotation - it may be overridden by the user, making verification fail where the check is enforced).
During verification it can be turned off by the `--no-verify-name` flag (open to better names) and we will enforce it where we require it.

This required some changes in the way we verify the signature annotations, since the upstream packages we use for this are a little too strict (they're for Kubernetes label validation).

New flags: `--no-verify-name` on `acorn image verify` and `acorn pull`.

Ref #2149

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

