### PR TITLE
Return 403 instead of 401 when failing to pull an image for image details

### DIFF
--- a/pkg/server/registry/apigroups/acorn/images/detail.go
+++ b/pkg/server/registry/apigroups/acorn/images/detail.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -91,7 +90,7 @@ func translateRegistryErrors(in error, imageName string) error {
 		case http.StatusNotFound:
 			return errors.NewNotFound(schema.GroupResource{Group: api.Group, Resource: "images"}, imageName)
 		case http.StatusUnauthorized:
-			return errors.NewUnauthorized(fmt.Sprintf("pulling image %s: %v", imageName, terr))
+			return errors.NewForbidden(schema.GroupResource{Group: api.Group, Resource: "images"}, imageName, terr)
 		case http.StatusForbidden:
 			return errors.NewForbidden(schema.GroupResource{Group: api.Group, Resource: "images"}, imageName, terr)
 		}


### PR DESCRIPTION
It is a bit weird that we are returning a 401 in this circumstance. Let's do 403 instead.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

