### PR TITLE
change: only exclude AcornDNS cluster domains from cert-manager annotations (#2153)

### DIFF
--- a/pkg/controller/config/dns.go
+++ b/pkg/controller/config/dns.go
@@ -101,7 +101,7 @@ func (h *configHandler) Handle(req router.Request, resp router.Response) error {
 		}
 	}
 
-	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
+	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") && domain != "" && token != "" {
 		if err := tls.ProvisionWildcardCert(req, resp, domain, token); err != nil {
 			return err
 		}

--- a/pkg/controller/service/testdata/ingress/basic/expected.golden
+++ b/pkg/controller/service/testdata/ingress/basic/expected.golden
@@ -77,7 +77,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/cert-manager/expected.golden
+++ b/pkg/controller/service/testdata/ingress/cert-manager/expected.golden
@@ -77,7 +77,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/expected.golden
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/expected.golden
@@ -61,7 +61,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-custom-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/customdomainwithannotations/expected.golden
+++ b/pkg/controller/service/testdata/ingress/customdomainwithannotations/expected.golden
@@ -82,7 +82,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/customdomainwithcerts/expected.golden
+++ b/pkg/controller/service/testdata/ingress/customdomainwithcerts/expected.golden
@@ -77,7 +77,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/labels/expected.golden
+++ b/pkg/controller/service/testdata/ingress/labels/expected.golden
@@ -93,7 +93,7 @@ metadata:
     conl3: value
     globall1: value
     globall2: value
-  name: con1-cluster-domain
+  name: con1-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/letsencrypt/expected.golden
+++ b/pkg/controller/service/testdata/ingress/letsencrypt/expected.golden
@@ -37,7 +37,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: app1
     acorn.io/managed: "true"
-  name: app1-cluster-domain
+  name: app1-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.golden
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.golden
@@ -93,7 +93,7 @@ metadata:
     conl3: value
     globall1: value
     globall2: value
-  name: con1-cluster-domain
+  name: con1-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.golden
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.golden
@@ -93,7 +93,7 @@ metadata:
     conl3: value
     globall1: value
     globall2: value
-  name: con1-cluster-domain
+  name: con1-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/router/expected.golden
+++ b/pkg/controller/service/testdata/router/expected.golden
@@ -61,7 +61,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/managed: "true"
     acorn.io/router-name: router-name
-  name: router-name-cluster-domain
+  name: router-name-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/service/basic/expected.golden
+++ b/pkg/controller/service/testdata/service/basic/expected.golden
@@ -69,7 +69,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/controller/service/testdata/service/tcp-http-overlap/expected.golden
+++ b/pkg/controller/service/testdata/service/tcp-http-overlap/expected.golden
@@ -65,7 +65,7 @@ metadata:
     acorn.io/app-namespace: app-namespace
     acorn.io/container-name: oneimage
     acorn.io/managed: "true"
-  name: oneimage-cluster-domain
+  name: oneimage-acorn-domain
   namespace: app-created-namespace
 spec:
   rules:

--- a/pkg/publish/ingress.go
+++ b/pkg/publish/ingress.go
@@ -222,7 +222,7 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 					if err != nil {
 						return nil, err
 					}
-					if domain == acornDomain {
+					if domain == acornDomain || strings.HasSuffix(domain, profiles.ClusterDomainDefault) {
 						acornDomainTargets[hostname] = Target{Port: port.TargetPort, Service: svc.Name}
 						acornDomainRules = append(acornDomainRules, getIngressRule(svc, hostname, port.Port))
 					} else {

--- a/pkg/publish/ingress.go
+++ b/pkg/publish/ingress.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	customDomain  = "custom-domain"
-	clusterDomain = "cluster-domain"
+	customDomain = "custom-domain"
+	acornDomain  = "acorn-domain"
 )
 
 var (
@@ -193,7 +193,7 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
-	acornDomain := string(dnsSecret.Data["domain"])
+	acornDNSDomain := string(dnsSecret.Data["domain"])
 
 	var (
 		// Separate rules for acorn domain and custom domain
@@ -222,7 +222,7 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 					if err != nil {
 						return nil, err
 					}
-					if domain == acornDomain || strings.HasSuffix(domain, profiles.ClusterDomainDefault) {
+					if domain == acornDNSDomain || strings.HasSuffix(domain, profiles.ClusterDomainDefault) {
 						acornDomainTargets[hostname] = Target{Port: port.TargetPort, Service: svc.Name}
 						acornDomainRules = append(acornDomainRules, getIngressRule(svc, hostname, port.Port))
 					} else {
@@ -245,7 +245,7 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 		name   string
 		target map[string]Target
 	}{
-		{rules: acornDomainRules, name: clusterDomain, target: acornDomainTargets},
+		{rules: acornDomainRules, name: acornDomain, target: acornDomainTargets},
 		{rules: customDomainRules, name: customDomain, target: customDomainTargets},
 	} {
 		if len(rules.rules) == 0 {


### PR DESCRIPTION
Ref #2153

Before, we excluded **all** cluster-domains, including custom cluster-domains, meaning those endpoints wouldn't get certificates and you had to explicitly specify a domain via `-p` to get https on the custom domain.

Additionally: 

- fix: do not try to provision wildcard cert if no domain/token is present

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

