### PR TITLE
fix: pulling an image twice failed as we provided the wrong repoDigest

### DIFF
--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -252,6 +252,18 @@ func TestImagePull(t *testing.T) {
 
 	image := images[0]
 	assert.Equal(t, tagName, image.Tags[0])
+
+	// Pull a second time while the image exists already
+	progress, err = c.ImagePull(ctx, tagName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for update := range progress {
+		if update.Error != "" {
+			t.Fatal(update.Error)
+		}
+	}
 }
 
 func TestImageDetails(t *testing.T) {

--- a/pkg/server/registry/apigroups/acorn/images/pull.go
+++ b/pkg/server/registry/apigroups/acorn/images/pull.go
@@ -170,7 +170,7 @@ func (i *ImagePull) ImagePull(ctx context.Context, namespace, imageName string, 
 		record := func() error {
 			return i.recordImage(ctx, hash, namespace, imageName, recordRepo)
 		}
-		images.RemoteWrite(metachannel, repo.Digest(hash.Hex), index, fmt.Sprintf("Pulling image %s ", pullTag.Context().Tag(pullTag.Identifier())), record, opts...)
+		images.RemoteWrite(metachannel, repo.Digest(hash.String()), index, fmt.Sprintf("Pulling image %s ", pullTag.Context().Tag(pullTag.Identifier())), record, opts...)
 
 		if sig != nil {
 			images.RemoteWrite(metachannel, repo.Tag(sigTag.TagStr()), sig, fmt.Sprintf("Pulling signature %s ", sigTag.TagStr()), nil, opts...)


### PR DESCRIPTION
Simple change: hash.String() prepends the hash algorithm (sha256) so that we end up with a proper digest sha256:...

Ref https://github.com/acorn-io/manager/issues/461

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

