### PR TITLE
Adjust RBAC to run on OpenShift

### DIFF
--- a/pkg/imagesystem/registry.go
+++ b/pkg/imagesystem/registry.go
@@ -159,9 +159,13 @@ func GetRegistryObjects(ctx context.Context, c client.Reader) (result []client.O
 		)
 	}
 
+	sa := registryServiceAccount(system.ImagesNamespace)
+	result = append(result, sa)
+
 	result = append(result,
 		registryDeployment(
 			system.ImagesNamespace,
+			sa.GetName(),
 			system.DefaultImage(),
 			system.ResourceRequirementsFor(*cfg.RegistryMemory, *cfg.RegistryCPU),
 			volumeSource,

--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -39,7 +39,16 @@ func registryService(namespace string) []client.Object {
 	}
 }
 
-func registryDeployment(namespace, registryImage string, requirements corev1.ResourceRequirements, volumeSource corev1.VolumeSource) []client.Object {
+func registryServiceAccount(namespace string) client.Object {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      system.RegistryServiceAccountName,
+			Namespace: system.ImagesNamespace,
+		},
+	}
+}
+
+func registryDeployment(namespace, serviceAccountName, registryImage string, requirements corev1.ResourceRequirements, volumeSource corev1.VolumeSource) []client.Object {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      system.RegistryName,
@@ -115,6 +124,7 @@ func registryDeployment(namespace, registryImage string, requirements corev1.Res
 							},
 						},
 					},
+					ServiceAccountName: serviceAccountName,
 					Volumes: []corev1.Volume{
 						{
 							VolumeSource: volumeSource,

--- a/pkg/install/role.yaml
+++ b/pkg/install/role.yaml
@@ -85,6 +85,13 @@ rules:
   - apiGroups: ["management.cattle.io"]
     resources: ["projects"]
     verbs: ["updatepsa"]
+  - verbs: ["use"]
+    apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - nonroot-v2
+    resources:
+    - securitycontextconstraints
 
 ---
 kind: ClusterRoleBinding
@@ -99,3 +106,29 @@ subjects:
   - kind: ServiceAccount
     namespace: acorn-system
     name: acorn-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: acorn-image-system
+rules:
+  - verbs: ["use"]
+    apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - nonroot-v2
+    resources:
+    - securitycontextconstraints
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: acorn-image-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acorn-image-system
+subjects:
+  - kind: ServiceAccount
+    namespace: acorn-image-system
+    name: acorn-image-system

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -21,13 +21,14 @@ const (
 )
 
 var (
-	RegistryName                   = "registry"
-	RegistryPVCSize                = "10Gi"
-	RegistryPort                   = 5000
-	BuildKitName                   = "buildkitd"
-	ControllerName                 = "acorn-controller"
-	APIServerName                  = "acorn-api"
-	BuildkitPort             int32 = 8080
-	ContainerdConfigPathName       = "containerd-config-path"
-	DefaultManagerAddress          = "beta.acorn.io"
+	RegistryName                     = "registry"
+	RegistryPVCSize                  = "10Gi"
+	RegistryPort                     = 5000
+	RegistryServiceAccountName       = "acorn-image-system"
+	BuildKitName                     = "buildkitd"
+	ControllerName                   = "acorn-controller"
+	APIServerName                    = "acorn-api"
+	BuildkitPort               int32 = 8080
+	ContainerdConfigPathName         = "containerd-config-path"
+	DefaultManagerAddress            = "beta.acorn.io"
 )


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This PR is related to issue #1834 in that it adds the ability to run acorn runtime on OCP. 

This PR does the following:

    - Add acorn-image-system ClusterRole, ClusterRoleBinding, and SA
    - Bind nonroot-v2 SCC to acorn-image-system ClusterRole
    - Bind nonroot-v2 SCC to acorn-system ClusterRole

As a side note, the registry and controller pods seems to work fine as any UID, but apiserver requires UID 1000 for some stuff at the moment. Later, should evaluate if the apiserver deployment can move to any UID. I hit permission errors with the `apiserver.local.config` certs directory when trying to move to any UID.

This is my first PR to this repo, so if I'm missing anything here, please feel free to correct me. I tried running `make test` but started hanging partly through the integration suite, so I might need to configure something else for OCP here. I still want to get this PR open/reviewed for general feedback, so I'll work on getting my test setup going in the background. I didn't add unit tests as I think this is covered by the repo's existing integration tests/deployments being functional.

I don't think there are upgrade impacts here as both the registry and controller deployments seem to function as any UID already.



