### PR TITLE
Add karpenter do-evict annotation when scale is nil or 1

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -711,6 +711,11 @@ func toDeployment(req router.Request, appInstance *v1.AppInstance, tag name.Refe
 		interpolator.AddMissingAnnotations(appInstance.GetStopped(), dep.Annotations)
 	}
 
+	// Set karpenter do-not-evict annotation if scale is nil or 1. This prevents karpenter from evicting the pod if deployment is not running with more than 1 replica.
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas == 1 {
+		dep.Spec.Template.Annotations["karpenter.sh/do-not-evict"] = "true"
+	}
+
 	return dep, nil
 }
 

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -76,6 +76,10 @@ func TestProbe(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/probes", DeploySpec)
 }
 
+func TestKarpenterAnnotation(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/karpenter", DeploySpec)
+}
+
 func ToDeploymentsTest(t *testing.T, appInstance *v1.AppInstance, tag name.Reference, pullSecrets *PullSecrets) (result []kclient.Object) {
 	t.Helper()
 

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -148,6 +149,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"class":"sample-compute-class-01","image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -148,6 +149,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"class":"sample-compute-class","image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dependencies":[{"targetName":"db"}],"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -128,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dependencies":[{"targetName":"container-name"}],"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/depends/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dependencies":[{"targetName":"db"}],"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -134,6 +135,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dependencies":[{"targetName":"container-name"}],"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -67,6 +67,7 @@ spec:
         allowed-container.io: test-allowed-container-ann
         allowed-global.io: test-global
         allowed.io: test-allowed-app-spec-ann
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
@@ -6,10 +6,10 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: buildimage
+    acorn.io/container-name: scalenil
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: buildimage
+  name: scalenil
   namespace: app-created-namespace
 
 ---
@@ -21,42 +21,42 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: buildimage
+    acorn.io/container-name: scalenil
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: buildimage
+  name: scalenil
   namespace: app-created-namespace
 spec:
   selector:
     matchLabels:
       acorn.io/app-name: app-name
       acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: buildimage
+      acorn.io/container-name: scalenil
       acorn.io/managed: "true"
   strategy: {}
   template:
     metadata:
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"probes":null}'
         karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
         acorn.io/app-namespace: app-namespace
         acorn.io/app-public-name: app-name
-        acorn.io/container-name: buildimage
+        acorn.io/container-name: scalenil
         acorn.io/managed: "true"
         acorn.io/project-name: app-namespace
     spec:
       containers:
-      - image: sha256:build-image
-        name: buildimage
+      - image: image-name
+        name: scalenil
         resources: {}
       enableServiceLinks: false
-      hostname: buildimage
+      hostname: scalenil
       imagePullSecrets:
-      - name: buildimage-pull-1234567890ab
-      serviceAccountName: buildimage
+      - name: scalenil-pull-1234567890ab
+      serviceAccountName: scalenil
       terminationGracePeriodSeconds: 5
 status: {}
 
@@ -69,10 +69,10 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: buildimage
+    acorn.io/container-name: scalenil
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: buildimage
+  name: scalenil
   namespace: app-created-namespace
 spec:
   maxUnavailable: 25%
@@ -80,7 +80,7 @@ spec:
     matchLabels:
       acorn.io/app-name: app-name
       acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: buildimage
+      acorn.io/container-name: scalenil
       acorn.io/managed: "true"
 status:
   currentHealthy: 0
@@ -97,10 +97,10 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
+    acorn.io/container-name: scaleone
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: oneimage
+  name: scaleone
   namespace: app-created-namespace
 
 ---
@@ -112,57 +112,43 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
+    acorn.io/container-name: scaleone
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: oneimage
+  name: scaleone
   namespace: app-created-namespace
 spec:
+  replicas: 1
   selector:
     matchLabels:
       acorn.io/app-name: app-name
       acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
+      acorn.io/container-name: scaleone
       acorn.io/managed: "true"
   strategy: {}
   template:
     metadata:
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null,"scale":1}'
         karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
         acorn.io/app-namespace: app-namespace
         acorn.io/app-public-name: app-name
-        acorn.io/container-name: oneimage
+        acorn.io/container-name: scaleone
         acorn.io/managed: "true"
         acorn.io/project-name: app-namespace
     spec:
       containers:
-      - image: image-name
-        name: oneimage
-        ports:
-        - containerPort: 81
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 81
-        resources: {}
-      - image: foo
-        name: left
-        ports:
-        - containerPort: 91
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 91
+      - image: sha256:build-image
+        name: scaleone
         resources: {}
       enableServiceLinks: false
-      hostname: oneimage
+      hostname: scaleone
       imagePullSecrets:
-      - name: oneimage-pull-1234567890ab
-      serviceAccountName: oneimage
+      - name: scaleone-pull-1234567890ab
+      serviceAccountName: scaleone
       terminationGracePeriodSeconds: 5
 status: {}
 
@@ -175,18 +161,18 @@ metadata:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
     acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
+    acorn.io/container-name: scaleone
     acorn.io/managed: "true"
     acorn.io/project-name: app-namespace
-  name: oneimage
+  name: scaleone
   namespace: app-created-namespace
 spec:
-  maxUnavailable: 25%
+  maxUnavailable: 1
   selector:
     matchLabels:
       acorn.io/app-name: app-name
       acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
+      acorn.io/container-name: scaleone
       acorn.io/managed: "true"
 status:
   currentHealthy: 0
@@ -195,38 +181,94 @@ status:
   expectedPods: 0
 
 ---
-apiVersion: internal.acorn.io/v1
-kind: ServiceInstance
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  annotations:
-    acorn.io/app-generation: "0"
   creationTimestamp: null
   labels:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
-    acorn.io/container-name: oneimage
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: scaleotwo
     acorn.io/managed: "true"
-    acorn.io/public-name: app-name.oneimage
-  name: oneimage
+    acorn.io/project-name: app-namespace
+  name: scaleotwo
   namespace: app-created-namespace
-spec:
-  appName: app-name
-  appNamespace: app-namespace
-  container: oneimage
-  default: true
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
   labels:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace
-    acorn.io/container-name: oneimage
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: scaleotwo
     acorn.io/managed: "true"
-  ports:
-  - port: 80
-    protocol: http
-    targetPort: 81
-  - port: 90
-    protocol: tcp
-    targetPort: 91
+    acorn.io/project-name: app-namespace
+  name: scaleotwo
+  namespace: app-created-namespace
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: scaleotwo
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null,"scale":2}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: scaleotwo
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: sha256:build-image
+        name: scaleotwo
+        resources: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: scaleotwo-pull-1234567890ab
+      serviceAccountName: scaleotwo
+      terminationGracePeriodSeconds: 5
 status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: scaleotwo
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: scaleotwo
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: scaleotwo
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
 
 ---
 apiVersion: v1
@@ -238,7 +280,7 @@ metadata:
   labels:
     acorn.io/managed: "true"
     acorn.io/pull-secret: "true"
-  name: buildimage-pull-1234567890ab
+  name: scalenil-pull-1234567890ab
   namespace: app-created-namespace
 type: kubernetes.io/dockerconfigjson
 
@@ -252,7 +294,21 @@ metadata:
   labels:
     acorn.io/managed: "true"
     acorn.io/pull-secret: "true"
-  name: oneimage-pull-1234567890ab
+  name: scaleone-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: scaleotwo-pull-1234567890ab
   namespace: app-created-namespace
 type: kubernetes.io/dockerconfigjson
 
@@ -273,33 +329,29 @@ status:
     vcs: {}
   appSpec:
     containers:
-      buildimage:
+      scalenil:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        probes: null
+      scaleone:
         build:
           context: .
           dockerfile: custom-dockerfile
         image: sha256:build-image
         metrics: {}
         probes: null
-      oneimage:
+        scale: 1
+      scaleotwo:
         build:
           context: .
-          dockerfile: Dockerfile
-        image: image-name
+          dockerfile: custom-dockerfile
+        image: sha256:build-image
         metrics: {}
-        ports:
-        - port: 80
-          protocol: http
-          targetPort: 81
         probes: null
-        sidecars:
-          left:
-            image: foo
-            metrics: {}
-            ports:
-            - port: 90
-              protocol: tcp
-              targetPort: 91
-            probes: null
+        scale: 2
   appStatus: {}
   columns: {}
   conditions:

--- a/pkg/controller/appdefinition/testdata/deployspec/karpenter/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/karpenter/input.yaml
@@ -1,0 +1,31 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      scalenil:
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+      scaleone:
+        scale: 1
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."
+      scaleotwo:
+        scale: 2
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -66,6 +66,7 @@ spec:
         container-scoped-ann: test-container
         containerAnn: test-container-ann
         global-scoped-ann: test-global
+        karpenter.sh/do-not-evict: "true"
         named-scoped-ann: test-named
       creationTimestamp: null
       labels:

--- a/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"foo","metrics":{"path":"/","port":80},"ports":[{"protocol":"http","targetPort":80}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
         prometheus.io/path: /
         prometheus.io/port: "80"
         prometheus.io/scrape: "true"

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/files-bug/expected.golden
+++ b/pkg/controller/appdefinition/testdata/files-bug/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"probes":null,"sidecars":{"sidecar":{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0755","secret":{}}},"image":"image-name","metrics":{},"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/files/expected.golden
+++ b/pkg/controller/appdefinition/testdata/files/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"content-test-mode":{"content":"YmFzZS1tb2Rl","mode":"0123","secret":{}},"secret-test":{"mode":"644","secret":{"key":"key-name","name":"ref"}}},"image":"image-name","metrics":{},"probes":null,"sidecars":{"sidecar":{"files":{"sidecar-content-test":{"content":"c2lkZWNhcg==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0123","secret":{}}},"image":"image-name","metrics":{},"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.golden
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"environment":[{"name":"env-name","secret":{},"value":"env-value"}],"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -136,6 +137,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
@@ -65,6 +65,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -134,6 +135,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
@@ -65,6 +65,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
@@ -65,6 +65,7 @@ spec:
         cona3: value
         globala1: value
         globala2: value
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.golden
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.golden
@@ -40,6 +40,7 @@ spec:
         acorn.io/container-spec: '{"environment":[{"name":"foo","secret":{},"value":"prefix
           @{secret.sec-1.key1} after"},{"name":"foo-not-interpolated","secret":{},"value":"prefix
           @{other.sec-1.key1} after"}],"files":{"content-test":{"content":"cHJlZml4IEB7c2VjcmV0cy5zZWMtMS5rZXkxfSBzdWZmaXggQHtzZWNyZXRzLnNlYy0xLmtleTJ9","mode":"0644","secret":{}}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","memory":2097152,"metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -138,6 +139,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","memory":1048576,"metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -128,6 +128,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
@@ -128,6 +128,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
@@ -218,6 +218,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
@@ -128,6 +128,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -323,6 +324,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
@@ -128,6 +128,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -323,6 +324,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/probes/expected.golden
+++ b/pkg/controller/appdefinition/testdata/probes/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":[]}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -131,6 +132,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"probes":[{"http":{"headers":{"foo":"bar"},"url":"http://localhost/foo/bar"},"type":"readiness"},{"tcp":{"url":"garbage://1.1.1.1:1234/foo/bar"},"type":"startup"},{"exec":{"command":["/bin/true"]},"type":"liveness"}]}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.golden
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -128,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null,"sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.golden
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -128,6 +129,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null,"sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","metrics":{},"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/secret/expected.golden
+++ b/pkg/controller/appdefinition/testdata/secret/expected.golden
@@ -46,6 +46,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"noaction":{"secret":{"name":"secret_dir_noaction","onChange":"noAction"}},"redeploy":{"secret":{"name":"secret_dir_redeploy","onChange":"redeploy"}}},"environment":[{"name":"NOACTION","secret":{"key":"key","name":"secret_env_noaction","onChange":"noAction"}},{"name":"REDEPLOY","secret":{"key":"key","name":"secret_env_redeploy","onChange":"redeploy"}}],"files":{"mode":{"mode":"0123","secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"noaction":{"secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"redeploy":{"secret":{"key":"key","name":"secret_file_redeploy","onChange":"redeploy"}}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
         secret-rev.acorn.io/secret_dir_redeploy: 677d9197a43dc1b2d2fcbc026c51462c8d16f90a1cbfc11d58a868b1f0256449
         secret-rev.acorn.io/secret_env_redeploy: 0b0c304d11b643e599d08d89090ab1bc4e7d25cd0b345e1194f99ce0411c4983
         secret-rev.acorn.io/secret_file_redeploy: 22e3f3fe588737e91b552db39c1b1abc0760633b6a840e61757fa771735c21a9

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.golden
@@ -50,6 +50,7 @@ spec:
         acorn.io/container-spec: '{"annotations":{"both":"con1val","con1":"value"},"image":"foo","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":80,"protocol":"http","targetPort":81},{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}'
         both: con1val
         con1: value
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -167,6 +168,7 @@ spec:
         acorn.io/container-spec: '{"annotations":{"both":"con2val","con2":"value"},"image":"foo","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":80,"protocol":"tcp","targetPort":81},{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}'
         both: con2val
         con2: value
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -272,6 +274,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"foo","metrics":{},"ports":[{"port":100,"protocol":"udp","publish":true,"targetPort":101},{"port":100,"protocol":"udp","targetPort":101}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name
@@ -136,6 +137,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/template/expected.golden
+++ b/pkg/controller/appdefinition/testdata/template/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/temp":{"secret":{},"volume":"bar"},"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.golden
@@ -39,6 +39,7 @@ spec:
       annotations:
         acorn.io/container-spec: '{"build":{"baseImage":"image-name","context":".","contextDirs":{"/var/tmp":"./foo"},"dockerfile":"Dockerfile"},"dirs":{"/var/tmp":{"contextDir":"./foo","secret":{}}},"image":"image-name","metrics":{},"probes":null}'
         acorn.io/image-mapping: '{"image-name":"image-name"}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.golden
@@ -38,6 +38,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/volumes/reuse-existing/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/reuse-existing/expected.golden
@@ -40,6 +40,7 @@ spec:
     metadata:
       annotations:
         acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
         acorn.io/app-name: app-name


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

We are putting karpenter do-not-evict annotation to acorn when scale is 1. This prevents karpenter from evict the pod if it is not running in more than 1 replica.

Context: https://acorn-io.slack.com/archives/C03FU91U4SX/p1694540878630259