### PR TITLE
Stop setting auto-upgrade to false on update (#2161)

### DIFF
--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -59,16 +59,16 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	imageSource := imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+	imageSource := imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, z.Dereference(s.AutoUpgrade))
 
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
 	}
 
-	// If auto-upgrade is not set, set it to the implied value.
-	if !z.Dereference(opts.AutoUpgrade) {
-		opts.AutoUpgrade = z.Pointer(autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
+	// If auto-upgrade is not set, set it to true if auto-upgrade is implied
+	if !z.Dereference(opts.AutoUpgrade) && autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)) {
+		opts.AutoUpgrade = z.Pointer(true)
 	}
 
 	return dev.Dev(cmd.Context(), c, &dev.Options{

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -232,7 +232,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	var (
-		imageSource = imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, s.AutoUpgrade != nil && *s.AutoUpgrade)
+		imageSource = imagesource.NewImageSource(s.client.AcornConfigFile(), s.File, args, s.Profile, nil, z.Dereference(s.AutoUpgrade))
 		app         *apiv1.App
 		updated     bool
 	)
@@ -242,9 +242,9 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	// If auto-upgrade is not set, set it to the implied value.
-	if !z.Dereference(opts.AutoUpgrade) {
-		opts.AutoUpgrade = z.Pointer(autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)))
+	// If auto-upgrade is not set, set it to true if auto-upgrade is implied
+	if !z.Dereference(opts.AutoUpgrade) && autoupgrade.Implied(imageSource.Image, s.Interval, z.Dereference(opts.NotifyUpgrade)) {
+		opts.AutoUpgrade = z.Pointer(true)
 	}
 
 	// Force install prompt if needed


### PR DESCRIPTION
If an Acorn is created with auto-upgrade enabled, then a user should have to explicitly disable it with an upgrade call. Currently, any upgrade on a static, non-auto-upgrade tag, will disable auto-upgrade if the flag is not passed. This change fixes this behavior.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/runtime/issues/2161