### PR TITLE
Account for scale of a container when creating a QuotaRequest

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1638,9 +1638,9 @@ func TestEnforcedQuota(t *testing.T) {
 		return kclient.Update(ctx, obj) == nil
 	})
 
-	// Run a simple app.
-	image, err := c.AcornImageBuild(ctx, "./testdata/simple/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/volume",
+	// Run a scaled app.
+	image, err := c.AcornImageBuild(ctx, "./testdata/scaled/Acornfile", &client.AcornImageBuildOptions{
+		Cwd: "./testdata/scaled",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1668,7 +1668,7 @@ func TestEnforcedQuota(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, quotaRequest.Spec.Resources.Containers, 1)
+	assert.Equal(t, 2, quotaRequest.Spec.Resources.Containers)
 
 	// Update the status of the QuotaRequest to communicate readiness.
 	quotaRequest.Status = adminv1.QuotaRequestInstanceStatus{

--- a/integration/run/testdata/scaled/Acornfile
+++ b/integration/run/testdata/scaled/Acornfile
@@ -1,0 +1,6 @@
+containers: {
+	simple: {
+		scale: 2
+		build: "."
+	}
+}

--- a/integration/run/testdata/scaled/Dockerfile
+++ b/integration/run/testdata/scaled/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest


### PR DESCRIPTION
Prior to this PR, container scale was not reflected in the QuotaRequest.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

