### PR TITLE
change: allow non-file input for acorn image sign --key

### DIFF
--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -130,10 +130,17 @@ func (k *KeysBytes) Password() []byte {
 	return k.password
 }
 
-func ImportKeyPair(keyPath string, pass []byte) (*KeysBytes, error) {
-	pemBytes, err := os.ReadFile(filepath.Clean(keyPath))
-	if err != nil {
-		return nil, err
+func ImportKeyPair(keyRef string, pass []byte) (*KeysBytes, error) {
+	pemBytes := []byte(keyRef)
+
+	finfo, err := os.Stat(keyRef)
+	if (err != nil && !os.IsNotExist(err)) || (err == nil && finfo.IsDir()) {
+		return nil, fmt.Errorf("invalid key file")
+	} else if err == nil {
+		pemBytes, err = os.ReadFile(filepath.Clean(keyRef))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	pemBlock, _ := pem.Decode(pemBytes)


### PR DESCRIPTION

Ref #2166 

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

