### PR TITLE
require command to be passed to acorn kube command (#1184)

### DIFF
--- a/pkg/cli/kube.go
+++ b/pkg/cli/kube.go
@@ -13,12 +13,17 @@ import (
 
 func NewKubectl(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Kube{client: c.ClientFactory}, cobra.Command{
-		Use:          "kube [flags]",
+		Use:          "kube [flags] COMMAND",
+		Args:         cobra.MinimumNArgs(1),
 		Hidden:       true,
 		SilenceUsage: true,
 		Short:        "Run command with KUBECONFIG env set to a generated kubeconfig of the current project",
 		Example: `
-acorn -j acorn kube k9s
+  # Run 'k9s' in the Account API Server for the 'acorn' project:
+  acorn -j acorn kube k9s
+
+  # Access the cluster of the 'aws-us-east-2' region for the current project:
+  acorn -j acorn kube --region aws-us-east-2 $SHELL
 `})
 	cmd.Flags().SetInterspersed(false)
 	return cmd
@@ -26,7 +31,7 @@ acorn -j acorn kube k9s
 
 type Kube struct {
 	client    ClientFactory
-	Region    string `usage:"Get access to the cluster supporting that specific region"`
+	Region    string `usage:"Get access to the cluster supporting the defined region"`
 	WriteFile string `usage:"Write kubeconfig to file" short:"w"`
 }
 
@@ -86,10 +91,6 @@ users:
 	}
 	if err := f.Close(); err != nil {
 		return err
-	}
-
-	if len(args) == 0 {
-		args = []string{os.Getenv("SHELL")}
 	}
 
 	k := exec.Command(args[0], args[1:]...)

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -110,7 +110,7 @@ func Nodes(req router.Request, computeClass *adminv1.ProjectComputeClassInstance
 	return computeClass.Affinity, computeClass.Tolerations
 }
 
-// PriorityClass checks that a defined PriorityClass exists and returns the name of it
+// PriorityClassName checks that a defined PriorityClass exists and returns the name of it
 func PriorityClassName(req router.Request, computeClass *adminv1.ProjectComputeClassInstance) (string, error) {
 	if computeClass == nil || computeClass.PriorityClassName == "" {
 		return "", nil


### PR DESCRIPTION
acorn-io/manager#1184

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

