### PR TITLE
Add support for interpolations to nested Acorns and services

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -104,7 +104,7 @@ func DeploySpec(req router.Request, resp router.Response) (err error) {
 	if err := addPVCs(req, appInstance, resp); err != nil {
 		return err
 	}
-	if err := addAcorns(req, appInstance, tag, pullSecrets, resp); err != nil {
+	if err := addAcorns(req, appInstance, tag, pullSecrets, interpolator, resp); err != nil {
 		return err
 	}
 

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -578,6 +578,10 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 }
 
 func (i *Interpolator) InterpolateGenericMap(args *v1.GenericMap) *v1.GenericMap {
+	if args == nil || args.Data == nil {
+		return nil
+	}
+
 	result := v1.GenericMap{}
 	result.Data = map[string]any{}
 	for k, v := range args.Data {


### PR DESCRIPTION
This will be very helpful for me with some other things I am working on.

This is somewhat of a breaking change. Previously, if you did something like this:

```cue
acorns: myacorn: {
  // ...
  deployArgs: myarg: "@{service.someservice.data.datapoint}"
}
```

then it would be kept as that literal string, and be available for interpolation inside the nested acorn. But now, that will be interpolated at the top level, and the interpolated value will be passed into the nested acorn.

To keep the literal string in the nested acorn, you can do this:

```cue
acorns: myacorn: {
  // ...
  deployArgs: myarg: "@{@{service}.someservice.data.datapoint}"
}
```

In this case, the inner set of `@{}` will basically just disappear.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

