### PR TITLE
Add interpolation support for permissionsin the Acornfile

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -742,7 +742,7 @@ func ToDeployments(req router.Request, appInstance *v1.AppInstance, tag name.Ref
 			return nil, err
 		}
 		if perms.HasRules() {
-			perms, err := toPermissions(req.Ctx, req.Client, perms, dep.GetLabels(), dep.GetAnnotations(), appInstance)
+			perms, err := toPermissions(req.Ctx, req.Client, perms, dep.GetLabels(), dep.GetAnnotations(), appInstance, secrets)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -737,7 +737,7 @@ func ToDeployments(req router.Request, appInstance *v1.AppInstance, tag name.Ref
 		if err != nil {
 			return nil, err
 		}
-		sa, err := toServiceAccount(req, dep.GetName(), dep.GetLabels(), dep.GetAnnotations(), appInstance, perms)
+		sa, err := toServiceAccount(req, dep.GetName(), dep.GetLabels(), dep.GetAnnotations(), appInstance, perms, secrets)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -60,7 +60,7 @@ func toJobs(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSe
 		if err != nil {
 			return nil, err
 		}
-		sa, err := toServiceAccount(req, job.GetName(), job.GetLabels(), stripPruneAndUpdate(job.GetAnnotations()), appInstance, perms)
+		sa, err := toServiceAccount(req, job.GetName(), job.GetLabels(), stripPruneAndUpdate(job.GetAnnotations()), appInstance, perms, interpolator)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -65,7 +65,7 @@ func toJobs(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSe
 			return nil, err
 		}
 		if perms.HasRules() {
-			perms, err := toPermissions(req.Ctx, req.Client, perms, job.GetLabels(), stripPruneAndUpdate(job.GetAnnotations()), appInstance)
+			perms, err := toPermissions(req.Ctx, req.Client, perms, job.GetLabels(), stripPruneAndUpdate(job.GetAnnotations()), appInstance, interpolator)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/appdefinition/serviceaccount.go
+++ b/pkg/controller/appdefinition/serviceaccount.go
@@ -23,11 +23,10 @@ func toServiceAccount(req router.Request, saName string, labelMap, annotations m
 			Annotations: annotations,
 		},
 	}
-	interpolatedPerms := v1.Permissions{}
-	for _, rule := range perms.GetRules() {
-		interpolatedPerms.Rules = append(interpolatedPerms.Rules, interpolator.ForPolicyRule(rule))
+	for i, rule := range perms.Rules {
+		perms.Rules[i] = interpolator.ForPolicyRule(rule)
 	}
-	return sa, addAWS(req, appInstance, sa, interpolatedPerms)
+	return sa, addAWS(req, appInstance, sa, perms)
 }
 
 func addAWS(req router.Request, appInstance *v1.AppInstance, sa *corev1.ServiceAccount, perms v1.Permissions) error {

--- a/pkg/controller/appdefinition/testdata/interpolation/existing.yaml.d/secret.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/existing.yaml.d/secret.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   key1: "dmFsdWUx"
   key2: "dmFsdWUy"
+  verb: "Z2V0"

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.golden
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.golden
@@ -1,6 +1,53 @@
-`apiVersion: v1
+`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage-app-name-app-namespace-1234567890ab-app-namespace
+  namespace: app-namespace
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage-app-name-app-namespace-1234567890ab-app-namespace
+  namespace: app-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: oneimage-app-name-app-namespace-1234567890ab-app-namespace
+subjects:
+- kind: ServiceAccount
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    acorn.io/permissions: '{"serviceName":"oneimage","rules":[{"verbs":["@{secret.sec-1.verb}"],"apiGroups":["apps"],"resources":["deployments"]}]}'
   creationTimestamp: null
   labels:
     acorn.io/app-name: app-name
@@ -39,7 +86,7 @@ spec:
       annotations:
         acorn.io/container-spec: '{"environment":[{"name":"foo","secret":{},"value":"prefix
           @{secret.sec-1.key1} after"},{"name":"foo-not-interpolated","secret":{},"value":"prefix
-          @{other.sec-1.key1} after"}],"files":{"content-test":{"content":"cHJlZml4IEB7c2VjcmV0cy5zZWMtMS5rZXkxfSBzdWZmaXggQHtzZWNyZXRzLnNlYy0xLmtleTJ9","mode":"0644","secret":{}}},"image":"image-name","metrics":{},"probes":null}'
+          @{other.sec-1.key1} after"}],"files":{"content-test":{"content":"cHJlZml4IEB7c2VjcmV0cy5zZWMtMS5rZXkxfSBzdWZmaXggQHtzZWNyZXRzLnNlYy0xLmtleTJ9","mode":"0644","secret":{}}},"image":"image-name","metrics":{},"permissions":{"rules":[{"apiGroups":["apps"],"resources":["deployments"],"verbs":["@{secret.sec-1.verb}"]}]},"probes":null}'
         karpenter.sh/do-not-evict: "true"
       creationTimestamp: null
       labels:
@@ -145,6 +192,15 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  permissions:
+  - rules:
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - get
+    serviceName: oneimage
 status:
   appImage:
     id: test
@@ -167,6 +223,14 @@ status:
             secret: {}
         image: image-name
         metrics: {}
+        permissions:
+          rules:
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            verbs:
+            - '@{secret.sec-1.verb}'
         probes: null
   appStatus: {}
   columns: {}

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.golden
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.golden
@@ -47,7 +47,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    acorn.io/permissions: '{"serviceName":"oneimage","rules":[{"verbs":["@{secret.sec-1.verb}"],"apiGroups":["apps"],"resources":["deployments"]}]}'
+    acorn.io/permissions: '{"serviceName":"oneimage","rules":[{"verbs":["get"],"apiGroups":["apps"],"resources":["deployments"]}]}'
   creationTimestamp: null
   labels:
     acorn.io/app-name: app-name

--- a/pkg/controller/appdefinition/testdata/interpolation/input.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/input.yaml
@@ -10,6 +10,15 @@ spec:
   endpoints:
   - target: oneimage
     hostname: localhost
+  permissions:
+  - rules:
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - "@{secret.sec-1.verb}"
+    serviceName: oneimage
 status:
   namespace: app-created-namespace
   appImage:
@@ -24,3 +33,11 @@ status:
         files:
           content-test:
             content: "cHJlZml4IEB7c2VjcmV0cy5zZWMtMS5rZXkxfSBzdWZmaXggQHtzZWNyZXRzLnNlYy0xLmtleTJ9"
+        permissions:
+          rules:
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            verbs:
+            - "@{secret.sec-1.verb}"

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -564,6 +564,27 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 	}, !strings.Contains(newKey, ".")
 }
 
+func (i *Interpolator) ForPolicyRule(rule v1.PolicyRule) v1.PolicyRule {
+	rule.APIGroups = i.ForStringSlice(rule.APIGroups)
+	rule.Resources = i.ForStringSlice(rule.Resources)
+	rule.Verbs = i.ForStringSlice(rule.Verbs)
+	rule.ResourceNames = i.ForStringSlice(rule.ResourceNames)
+	rule.NonResourceURLs = i.ForStringSlice(rule.NonResourceURLs)
+	return rule
+}
+
+func (i *Interpolator) ForStringSlice(s []string) []string {
+	for idx := range s {
+		newVal, err := i.Replace(s[idx])
+		if err != nil {
+			i.saveError(err)
+		} else {
+			s[idx] = newVal
+		}
+	}
+	return s
+}
+
 func (i *Interpolator) Objects() []kclient.Object {
 	if len(i.data) == 0 {
 		return nil


### PR DESCRIPTION
I need this for something else I am working on, as the `resources` section of my permissions request will depend on the output of a service.

This is an example of how you can use this:

```cue
services: yeet: data: verb: "get"

containers: nginx: {
  image: "nginx:latest"
  permissions: rules: [{
    apiGroup: "apps"
    resources: ["deployments"]
    verbs: ["@{services.yeet.data.verb}"]
    resourceNames: ["@{acorn.name}"]
  }]
}
```

The CLI prompts the user but doesn't have the ability to actually fill in the interpolations, since it doesn't have a kclient to do it with, like the Acorn controller does:

```
•  WARNING:  This application would like to request the following runtime permissions.
                 This could be VERY DANGEROUS to the cluster if you do not trust this
                 application. If you are unsure say no.

SERVICE   VERBS/ACTIONS                RESOURCES/API                    SCOPE
nginx     @{services.yeet.data.verb}   deployments.apps/@{acorn.name}   project
```

I assume this is okay.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

