### PR TITLE
fix acorn kube -w

### DIFF
--- a/pkg/cli/kube.go
+++ b/pkg/cli/kube.go
@@ -8,6 +8,7 @@ import (
 
 	cli "github.com/acorn-io/runtime/pkg/cli/builder"
 	"github.com/acorn-io/runtime/pkg/client"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +55,7 @@ func (s *Kube) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err = cobra.MinimumNArgs(1)(cmd, args); err != nil {
-		return err
+		return errors.Wrap(err, "command required when not using '-w' flag")
 	}
 
 	ctx, cancel := context.WithCancel(cmd.Context())

--- a/pkg/cli/kube.go
+++ b/pkg/cli/kube.go
@@ -14,11 +14,13 @@ import (
 func NewKubectl(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Kube{client: c.ClientFactory}, cobra.Command{
 		Use:          "kube [flags] COMMAND",
-		Args:         cobra.MinimumNArgs(1),
 		Hidden:       true,
 		SilenceUsage: true,
 		Short:        "Run command with KUBECONFIG env set to a generated kubeconfig of the current project",
 		Example: `
+  # Write the kubeconfig for the current project that would be used to the provided file:
+  acorn kube -w <filepath>
+
   # Run 'k9s' in the Account API Server for the 'acorn' project:
   acorn -j acorn kube k9s
 
@@ -49,6 +51,10 @@ func (s *Kube) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		return os.WriteFile(s.WriteFile, data, 0644)
+	}
+
+	if err = cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(cmd.Context())


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

