### PR TITLE
change: proper error handling for fetching pubkeys from GitHub API (#2185)

### DIFF
--- a/pkg/cosign/github.go
+++ b/pkg/cosign/github.go
@@ -17,11 +17,21 @@ type GitHubPublicKey struct {
 func getGitHubPublicKeys(username string) ([]GitHubPublicKey, error) {
 	logrus.Debugf("Getting public keys for GitHub user %s", username)
 	url := fmt.Sprintf("https://api.github.com/users/%s/keys", username)
-	resp, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status code %d (%s) from GitHub API: %s", resp.StatusCode, resp.Status, string(body))
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Ref #2185 

The error will be given to the user via CLI when doing `acorn image verify` and to the admin via controller logs (since we do the verification server-side, `acorn image verify` will also count against the rate limit of the Runtime installation's egress IP).

For the future we **could** think about an option for administrators to add GitHub credentials to the controller (e.g. a GitHub App has a rate limit of 15k requests per 60 minutes).
Alternatively we could figure out a smart way of caching public keys for GitHub users, not sure about the cache timeout there to pick up new keys or dismiss removed keys :thinking: 

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

