### PR TITLE
Add missing permission for jobs

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -55,6 +55,7 @@ var (
 					"secrets",
 					"services",
 					"events",
+					"jobs",
 				},
 			},
 			{
@@ -111,6 +112,7 @@ var (
 					"apps/pullimage",
 					"apps/ignorecleanup",
 					"events",
+					"jobs/restart",
 				},
 			},
 			{


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

We are missing permission regarding to the new job api.
