### PR TITLE
Fix upgrade with existing invalid acornfiles

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appimage.go
+++ b/pkg/apis/internal.acorn.io/v1/appimage.go
@@ -13,7 +13,7 @@ type AppImage struct {
 	Profiles  []string    `json:"profiles,omitempty"`
 	VCS       VCS         `json:"vcs,omitempty"`
 
-	AcornfileV0 bool `json:"acornfileV0,omitempty"`
+	AcornfileV1 bool `json:"acornfileV1,omitempty"`
 }
 
 type VCS struct {

--- a/pkg/build/app.go
+++ b/pkg/build/app.go
@@ -84,7 +84,7 @@ func getContextFromAppImage(dataFiles appdefinition.DataFiles, appImage *v1.AppI
 		}
 	}
 
-	if err := addFile(tempDir, appdefinition.AcornfileFile, appImage.Acornfile); err != nil {
+	if err := addFile(tempDir, appdefinition.AcornfileV1File, appImage.Acornfile); err != nil {
 		return "", err
 	}
 	if err := addFile(tempDir, appdefinition.ImageDataFile, imageData); err != nil {

--- a/pkg/controller/appdefinition/testdata/parseappimage/expected.golden
+++ b/pkg/controller/appdefinition/testdata/parseappimage/expected.golden
@@ -14,6 +14,7 @@ status:
           dockerfile: "custom-dockerfile"
         }
       }
+    acornfileV1: true
     imageData:
       containers:
         buildimage:

--- a/pkg/controller/appdefinition/testdata/parseappimage/input.yaml
+++ b/pkg/controller/appdefinition/testdata/parseappimage/input.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: random
 status:
   appImage:
+    acornfileV1: true
     acornfile: |
       containers: {
         oneimage: image: "image-name"

--- a/pkg/controller/appdefinition/testdata/parsedevmode/expected.golden
+++ b/pkg/controller/appdefinition/testdata/parsedevmode/expected.golden
@@ -13,6 +13,7 @@ status:
       containers: {
         oneimage: image: args.image
       }
+    acornfileV1: true
     imageData:
       containers:
         oneimage:

--- a/pkg/controller/appdefinition/testdata/parsedevmode/input.yaml
+++ b/pkg/controller/appdefinition/testdata/parsedevmode/input.yaml
@@ -6,6 +6,7 @@ metadata:
 status:
   devSession: {}
   appImage:
+    acornfileV1: true
     acornfile: |
       args: image: "not-foo"
       profiles: devMode: image: "foo"

--- a/pkg/imagedetails/details.go
+++ b/pkg/imagedetails/details.go
@@ -12,7 +12,7 @@ type Details struct {
 	Params     *v1.ParamSpec  `json:"params,omitempty"`
 }
 
-func ParseDetails(acornfile string, acornfileV0 bool, deployArgs map[string]any, profiles []string) (*Details, error) {
+func ParseDetails(acornfile string, acornfileV1 bool, deployArgs map[string]any, profiles []string) (*Details, error) {
 	result := &Details{
 		DeployArgs: v1.NewGenericMap(deployArgs),
 		Profiles:   profiles,
@@ -22,13 +22,13 @@ func ParseDetails(acornfile string, acornfileV0 bool, deployArgs map[string]any,
 		appDef *appdefinition.AppDefinition
 		err    error
 	)
-	if acornfileV0 {
-		appDef, err = appdefinition.NewLegacyAppDefinition([]byte(acornfile))
+	if acornfileV1 {
+		appDef, err = appdefinition.NewAppDefinition([]byte(acornfile))
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		appDef, err = appdefinition.NewAppDefinition([]byte(acornfile))
+		appDef, err = appdefinition.NewLegacyAppDefinition([]byte(acornfile))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -119,7 +119,7 @@ func getImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 		return nil, err
 	}
 
-	details, err := ParseDetails(appImageWithData.AppImage.Acornfile, appImageWithData.AppImage.AcornfileV0, opts.DeployArgs, opts.Profiles)
+	details, err := ParseDetails(appImageWithData.AppImage.Acornfile, appImageWithData.AppImage.AcornfileV1, opts.DeployArgs, opts.Profiles)
 	if err != nil {
 		return &apiv1.ImageDetails{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6402,7 +6402,7 @@ func schema_pkg_apis_internalacornio_v1_AppImage(ref common.ReferenceCallback) c
 							Ref:     ref("github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1.VCS"),
 						},
 					},
-					"acornfileV0": {
+					"acornfileV1": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

