### PR TITLE
Lower default volume size to 1Gi and change unit to be in gibibytes

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	DefaultSizeQuantity = Quantity("10G")
+	DefaultSizeQuantity = Quantity("1Gi")
 	MinSizeQuantity     = Quantity("5M")
 	DefaultSize         = MustParseResourceQuantity(DefaultSizeQuantity)
 	MinSize             = MustParseResourceQuantity(MinSizeQuantity)

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -284,7 +284,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 1Gi
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -276,7 +276,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 1Gi
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -206,7 +206,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 1Gi
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
@@ -115,7 +115,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 1Gi
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
@@ -115,7 +115,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 1Gi
 status: {}
 
 ---


### PR DESCRIPTION
This PR lowers the default volume size to `1Gi`.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

