### PR TITLE
Use context.AfterFunc instead of goroutine approach

### DIFF
--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -91,10 +91,9 @@ func (c *DefaultClient) ImagePull(ctx context.Context, imageName string, opts *I
 		return nil, err
 	}
 
-	go func() {
-		<-ctx.Done()
+	stop := context.AfterFunc(ctx, func() {
 		_ = conn.Close()
-	}()
+	})
 
 	if err := conn.WriteJSON(body); err != nil {
 		return nil, err
@@ -104,6 +103,7 @@ func (c *DefaultClient) ImagePull(ctx context.Context, imageName string, opts *I
 	go func() {
 		defer close(result)
 		defer conn.Close()
+		defer stop()
 		for {
 			_, data, err := conn.ReadMessage()
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
@@ -152,10 +152,9 @@ func (c *DefaultClient) ImagePush(ctx context.Context, imageName string, opts *I
 		return nil, err
 	}
 
-	go func() {
-		<-ctx.Done()
+	stop := context.AfterFunc(ctx, func() {
 		_ = conn.Close()
-	}()
+	})
 
 	if err := conn.WriteJSON(body); err != nil {
 		return nil, err
@@ -165,6 +164,7 @@ func (c *DefaultClient) ImagePush(ctx context.Context, imageName string, opts *I
 	go func() {
 		defer close(result)
 		defer conn.Close()
+		defer stop()
 		for {
 			_, data, err := conn.ReadMessage()
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {

--- a/pkg/portforward/portforward.go
+++ b/pkg/portforward/portforward.go
@@ -41,10 +41,12 @@ func PortForward(ctx context.Context, c client.Client, containerName string, add
 		fmt.Printf("Forwarding %s => %d for container [%s]\n", l.Addr().String(), port, containerName)
 		return l, err
 	}
-	go func() {
-		<-ctx.Done()
+
+	stop := context.AfterFunc(ctx, func() {
 		_ = p.Close()
-	}()
+	})
+	defer stop()
+
 	if err := p.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Note that the stop function returned by context.AfterFunc doesn't run 
the function that is passed to context.AfterFunc. It disassociates the 
function from the context (i.e. releases the resources). Calling stop 
after the context is cancelled is valid, so stop should be called to 
ensure that the resources are released.