### PR TITLE
Make cluster-scoped permission encompass project-scoped

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appspec.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec.go
@@ -315,7 +315,7 @@ func (p PolicyRule) Grants(currentNamespace string, requested PolicyRule) bool {
 
 	for _, ns := range p.ResolveNamespaces(currentNamespace) {
 		for _, requestedNamespace := range requested.ResolveNamespaces(currentNamespace) {
-			if ns == requestedNamespace &&
+			if (ns == requestedNamespace || ns == "") &&
 				matches(p.Verbs, requested.Verbs, false) &&
 				matches(p.APIGroups, requested.APIGroups, false) &&
 				matches(p.Resources, requested.Resources, false) &&

--- a/pkg/apis/internal.acorn.io/v1/appspec_test.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec_test.go
@@ -149,3 +149,105 @@ func TestSimplify(t *testing.T) {
 		},
 	}))
 }
+
+func TestGrantsAllClusterGrantsProject(t *testing.T) {
+	requested := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"project"},
+				},
+			},
+		},
+	}
+
+	granted := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"cluster"},
+				},
+			},
+		},
+	}
+	gotMissing, _ := GrantsAll("acorn", requested, granted)
+	assert.Equal(t, []Permissions(nil), gotMissing, "cluster permissions should grant project permissions")
+}
+
+func TestGrantsAllClusterGrantsNamespace(t *testing.T) {
+	requested := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"namespace:bar"},
+				},
+			},
+		},
+	}
+
+	granted := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"cluster"},
+				},
+			},
+		},
+	}
+	gotMissing, _ := GrantsAll("acorn", requested, granted)
+	assert.Equal(t, []Permissions(nil), gotMissing, "cluster permissions should grant namespace permissions")
+}
+
+func TestGrantsAllProjectNotGrantCluster(t *testing.T) {
+	requested := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"cluster"},
+				},
+			},
+		},
+	}
+
+	granted := []Permissions{
+		{
+			ServiceName: "foo",
+			Rules: []PolicyRule{
+				{
+					PolicyRule: rbacv1.PolicyRule{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"group-a"},
+					},
+					Scopes: []string{"project"},
+				},
+			},
+		},
+	}
+	gotMissing, _ := GrantsAll("acorn", requested, granted)
+	assert.Equal(t, requested, gotMissing, "project permissions should not grant cluster permissions")
+}


### PR DESCRIPTION
After this change, if you are granted cluster-scoped permission, then
you are also grant project-scoped for any project.

This commit also includes some simplifications to the handler that
checks permissions.