### PR TITLE
Make the MarshalJSON method on GenericMap a pointer receiver

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/map.go
+++ b/pkg/apis/internal.acorn.io/v1/map.go
@@ -78,7 +78,7 @@ func (g *GenericMap) Merge(from *GenericMap) *GenericMap {
 }
 
 // MarshalJSON may get called on pointers or values, so implement MarshalJSON on value.
-func (g GenericMap) MarshalJSON() ([]byte, error) {
+func (g *GenericMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(g.GetData())
 }
 


### PR DESCRIPTION
This change is being made to avoid panics calling a value method on a nil pointer.

