### PR TITLE
change: move role definitions around (aws specific and infra specific)

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -744,10 +744,7 @@ func Roles() ([]kclient.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := roles.ClusterRoles()
-	r = append(r, roles.SuperAdminRole())
-	r = append(r, roles.AWSRoles()...)
-	for _, role := range r {
+	for _, role := range roles.ClusterRoles() {
 		role := role
 		objs = append(objs, &role)
 	}

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -3,7 +3,6 @@ package roles
 import (
 	admin_acorn_io "github.com/acorn-io/runtime/pkg/apis/admin.acorn.io"
 	api_acorn_io "github.com/acorn-io/runtime/pkg/apis/api.acorn.io"
-	"github.com/acorn-io/runtime/pkg/awspermissions"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,28 +15,9 @@ const (
 	Build       = "acorn:project:build"
 	ClusterView = "acorn:cluster:view"
 	ClusterEdit = "acorn:cluster:edit"
-
-	// AWS
-	GroupAWSAcornIO     = "aws.acorn.io"
-	GroupRoleAWSAcornIO = "role.aws.acorn.io"
-
-	AWSAdmin = "acorn:aws:admin"
-
-	// Cluster Agent Special
-	SuperAdmin = "acorn:super-admin"
 )
 
 var (
-	awsRoles = map[string][]rbacv1.PolicyRule{
-		AWSAdmin: {
-			{
-				APIGroups: []string{awspermissions.AWSAPIGroup, awspermissions.AWSRoleAPIGroup},
-				Verbs:     []string{"*"},
-				Resources: []string{"*"},
-			},
-		},
-	}
-
 	clusterRoles = map[string][]rbacv1.PolicyRule{
 		ClusterView: {
 			{
@@ -270,32 +250,4 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			Rules: projectRoles[Build],
 		},
 	})
-}
-
-func AWSRoles() []rbacv1.ClusterRole {
-	return []rbacv1.ClusterRole{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: AWSAdmin,
-			},
-			Rules: awsRoles[AWSAdmin],
-		},
-	}
-}
-
-func SuperAdminRole() rbacv1.ClusterRole {
-	return rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: SuperAdmin,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "deletecollection", "create"},
-				Resources: []string{
-					"*",
-				},
-			},
-		},
-	}
 }


### PR DESCRIPTION
Too avoid future confusion, we're moving infra-specific roles to other places.

Related: https://github.com/acorn-io/infra-provisioning-cdk/pull/167 & https://github.com/acorn-io/manager/pull/1340

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

