### PR TITLE
Improve error messaging for QuotaRequestInstances

### DIFF
--- a/pkg/controller/quota/quota.go
+++ b/pkg/controller/quota/quota.go
@@ -44,18 +44,15 @@ func WaitForAllocation(req router.Request, resp router.Response) error {
 	}
 
 	/*
-		Determine how to proceed depending on if the quotaRequest exists and what it has written to its status. The four scenarios
-		are QuotaRequest:
+		Determine how to proceed depending on if the quotaRequest exists and what it has written to its status. The three scenarios
+		are the QuotaRequest:
 
-		1. Exists and has set FailedResources implying that the quota allocation failed.
-		2. Exists and had an error while trying to allocate quota.
-		3. Does not exist or has not yet been allocated the resources requested.
-		4. Exists and has successfully allocated the resources requested.
+		1. Exists and had an error while trying to allocate quota.
+		2. Does not exist or has not yet been allocated the resources requested.
+		3. Exists and has successfully allocated the resources requested.
 	*/
-	if quotaRequest.Status.FailedResources != nil {
-		status.Error(fmt.Errorf("failed to provision the following resources: %v", quotaRequest.Status.FailedResources.ToString()))
-	} else if cond := quotaRequest.Status.Condition(adminv1.QuotaRequestCondition); cond.Error {
-		status.Error(fmt.Errorf("error occurred while trying to allocate quota: %v", cond.Message))
+	if cond := quotaRequest.Status.Condition(adminv1.QuotaRequestCondition); cond.Error {
+		status.Error(fmt.Errorf("quota allocation failed: %v", cond.Message))
 	} else if err != nil || !quotaRequest.Spec.Resources.Equals(quotaRequest.Status.AllocatedResources) {
 		status.Unknown("waiting for quota allocation")
 	} else if quotaRequest.Status.Condition(adminv1.QuotaRequestCondition).Success {


### PR DESCRIPTION
This changes the logic in such a way that we better communicate what issue is occurring with a QuotaRequestInstance.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

