### PR TITLE
Don't set omitempty for fields in the Resources struct

### DIFF
--- a/pkg/apis/internal.admin.acorn.io/v1/baseresources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/baseresources.go
@@ -10,15 +10,15 @@ import (
 // BaseResources defines resources that should be tracked at any scoped. The two main exclusions
 // currently are Secrets and Projects as they have situations they should be not be tracked.
 type BaseResources struct {
-	Apps       int `json:"apps,omitempty"`
-	Containers int `json:"containers,omitempty"`
-	Jobs       int `json:"jobs,omitempty"`
-	Volumes    int `json:"volumes,omitempty"`
-	Images     int `json:"images,omitempty"`
+	Apps       int `json:"apps"`
+	Containers int `json:"containers"`
+	Jobs       int `json:"jobs"`
+	Volumes    int `json:"volumes"`
+	Images     int `json:"images"`
 
-	VolumeStorage resource.Quantity `json:"volumeStorage,omitempty"`
-	Memory        resource.Quantity `json:"memory,omitempty"`
-	CPU           resource.Quantity `json:"cpu,omitempty"`
+	VolumeStorage resource.Quantity `json:"volumeStorage"`
+	Memory        resource.Quantity `json:"memory"`
+	CPU           resource.Quantity `json:"cpu"`
 }
 
 // Add will add the BaseResources of another BaseResources struct into the current one.

--- a/pkg/apis/internal.admin.acorn.io/v1/quotarequests.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/quotarequests.go
@@ -77,7 +77,7 @@ type QuotaRequestInstanceList struct {
 // QuotaRequestResources defines resources that should can be created by an AppInstance.
 type QuotaRequestResources struct {
 	BaseResources `json:",inline"`
-	Secrets       int `json:"secrets,omitempty"`
+	Secrets       int `json:"secrets"`
 }
 
 // Add will add the QuotaRequestResources of another QuotaRequestResources struct into the current one.

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -13021,32 +13021,37 @@ func schema_pkg_apis_internaladminacornio_v1_BaseResources(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"apps": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"containers": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"jobs": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"volumes": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"images": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"volumeStorage": {
@@ -13068,6 +13073,7 @@ func schema_pkg_apis_internaladminacornio_v1_BaseResources(ref common.ReferenceC
 						},
 					},
 				},
+				Required: []string{"apps", "containers", "jobs", "volumes", "images", "volumeStorage", "memory", "cpu"},
 			},
 		},
 		Dependencies: []string{
@@ -14102,32 +14108,37 @@ func schema_pkg_apis_internaladminacornio_v1_QuotaRequestResources(ref common.Re
 				Properties: map[string]spec.Schema{
 					"apps": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"containers": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"jobs": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"volumes": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"images": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 					"volumeStorage": {
@@ -14150,11 +14161,13 @@ func schema_pkg_apis_internaladminacornio_v1_QuotaRequestResources(ref common.Re
 					},
 					"secrets": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 				},
+				Required: []string{"apps", "containers", "jobs", "volumes", "images", "volumeStorage", "memory", "cpu", "secrets"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This makes it clearer at an JSON level when an individual field is empty. Now these fields will not get omitted if something tries to retrieve the JSON representation of the Resources struct.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

