### PR TITLE
Don't add compute for Jobs to QuotaRequestInstances

### DIFF
--- a/pkg/controller/quota/quota.go
+++ b/pkg/controller/quota/quota.go
@@ -94,7 +94,11 @@ func EnsureQuotaRequest(req router.Request, resp router.Response) error {
 	// Add the more complex values to the quota request
 	addContainers(app.Containers, quotaRequest)
 	addCompute(app.Containers, appInstance, quotaRequest)
-	addCompute(app.Jobs, appInstance, quotaRequest)
+	// TODO: This is a stop-gap until we figure out how to handle the compute resources of
+	//       jobs. The problem is that Jobs are not always running, so we can't just add
+	//       their compute resources to the quota request permananetly. To some degree it'll
+	//       have to be dynamic, but we can't do that until we have a better idea of how.
+	// addCompute(app.Jobs, appInstance, quotaRequest)
 	if err := addStorage(appInstance, quotaRequest); err != nil {
 		status.Error(err)
 		return err


### PR DESCRIPTION
This is a stop-gap until we figure out how to handle the compute resources of jobs. The problem is that Jobs are not always running, so we can't just add their compute resources to the quota request permananetly. To some degree it'll have to be dynamic, but we can't do that until we have a better idea of how.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

