### PR TITLE
Fix for quota requests not being processed (#1378)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/acorn-io/aml v0.0.0-20231009045340-a31c45f6d100
 	github.com/acorn-io/aml/cli v0.0.0-20231009055509-3c83c1247cf8
 	github.com/acorn-io/aml/legacy v0.0.0-20230929081514-1e9f3394432e
-	github.com/acorn-io/baaah v0.0.0-20231006151510-91fb95b6997d
+	github.com/acorn-io/baaah v0.0.0-20231009165317-af2b68361b8a
 	github.com/acorn-io/mink v0.0.0-20230804175412-8d121aae112c
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/acorn-io/z v0.0.0-20230714155009-a770ecbbdc45

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/acorn-io/aml/cli v0.0.0-20231009055509-3c83c1247cf8 h1:eQhRTIMBGbufCc
 github.com/acorn-io/aml/cli v0.0.0-20231009055509-3c83c1247cf8/go.mod h1:CQ8Bc6t6xgu/K8vU8rl5LBz45aTzTj1eL4yQYZy6zh8=
 github.com/acorn-io/aml/legacy v0.0.0-20230929081514-1e9f3394432e h1:W67DG9AcoNvBwIOR9OFUCZlSJBaHuvM2kXQ2+C6EnLk=
 github.com/acorn-io/aml/legacy v0.0.0-20230929081514-1e9f3394432e/go.mod h1:XnJZSZq/tG/jWPE/tmm2zy90gOZrJRIaOyKpoMulxfE=
-github.com/acorn-io/baaah v0.0.0-20231006151510-91fb95b6997d h1:6b7zZ4If/X0rT3j3MAXXnX/WIZMXfy+7YB8aruifwa4=
-github.com/acorn-io/baaah v0.0.0-20231006151510-91fb95b6997d/go.mod h1:1KSGxZt0E2MDedJESKUUYtxCwsJ3A+xZiw2QD8cVbjU=
+github.com/acorn-io/baaah v0.0.0-20231009165317-af2b68361b8a h1:0bHfiYUw4ojXCUfGHUPmRewrgJ/EpLQ4BaR4yEy8BC4=
+github.com/acorn-io/baaah v0.0.0-20231009165317-af2b68361b8a/go.mod h1:1KSGxZt0E2MDedJESKUUYtxCwsJ3A+xZiw2QD8cVbjU=
 github.com/acorn-io/cmd v0.0.0-20230929053520-ebe1b9879b38 h1:oJMGvI702ZW5L0JjJfGV9ekzU2IqqTGjmAQl4gkO6Ro=
 github.com/acorn-io/cmd v0.0.0-20230929053520-ebe1b9879b38/go.mod h1:bo9ONX4kagbQmXcG4bnfoK53MBFFtbUZ5fR7s9NfS+M=
 github.com/acorn-io/mink v0.0.0-20230804175412-8d121aae112c h1:3equCG9oMf2I5iDZxllb41jmNNSTiIpU3IegCHBtVyk=


### PR DESCRIPTION
This change does three things:
1. Updates the baaah dependency to fix a race condition during controller start. This was affecting quota requests.
2. Changes an import name that was slightly confusing.
3. Changes the determination of checking if quota is enforced from checking namespaces (the old way) to checking project instances (the new way).

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/manager/issues/1378