### PR TITLE
Fix an issue with default VolmeStorage not being accounted for in QuotaRequests

### DIFF
--- a/pkg/controller/quota/quota.go
+++ b/pkg/controller/quota/quota.go
@@ -146,16 +146,25 @@ func addStorage(appInstance *v1.AppInstance, quotaRequest *adminv1.QuotaRequestI
 			size = boundSize
 		}
 
-		// No need to proceed if the size is empty
-		if size == "" || size == "0" {
+		// Handle three cases:
+		// 1. The volume's size is explicitly set to 0. This means there is nothing to count.
+		// 2. The volume's size is not set. This means we should assume the default size.
+		// 3. The volume's size is set to a specific value. This means we should use that value.
+		var sizeQuantity resource.Quantity
+		switch size {
+		case "0":
 			continue
+		case "":
+			sizeQuantity = defaultVolumeSize(appInstance, name)
+		default:
+			parsedQuantity, err := resource.ParseQuantity(string(size))
+			if err != nil {
+				return err
+			}
+			sizeQuantity = parsedQuantity
 		}
 
-		parsedSize, err := resource.ParseQuantity(string(size))
-		if err != nil {
-			return err
-		}
-		quotaRequest.Spec.Resources.VolumeStorage.Add(parsedSize)
+		quotaRequest.Spec.Resources.VolumeStorage.Add(sizeQuantity)
 	}
 
 	// Add the secrets needed to the quota request. We only parse net new secrets, not
@@ -167,6 +176,25 @@ func addStorage(appInstance *v1.AppInstance, quotaRequest *adminv1.QuotaRequestI
 		quotaRequest.Spec.Resources.Secrets += 1
 	}
 	return nil
+}
+
+func defaultVolumeSize(appInstance *v1.AppInstance, name string) resource.Quantity {
+	result := *v1.DefaultSize // Safe to dereference because it is statically set in the v1 package.
+
+	// If the volume has a default size set, use that on status.Defaults, use that. Otherwise, if the
+	// VolumeSize default is set on status.Defaults, use that.
+	if defaultVolume, set := appInstance.Status.Defaults.Volumes[name]; set {
+		// We do not expect this to ever fail because VolumeClasses have their sizes validated. However,
+		// if it does fail, we'll just return the default size.
+		parsedQuantity, err := resource.ParseQuantity(string(defaultVolume.Size))
+		if err == nil {
+			result = parsedQuantity
+		}
+	} else if appInstance.Status.Defaults.VolumeSize != nil {
+		result = *appInstance.Status.Defaults.VolumeSize
+	}
+
+	return result
 }
 
 // boundVolumeSize determines if the specified volume will be bound to an existing one. If


### PR DESCRIPTION
Before this PR, we were not accounting for the scenario that the Volume will receive a default size. This caused a number of issues regarding approval of resources.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

