### PR TITLE
Fix missing permissions error message

### DIFF
--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -20,7 +20,7 @@ type ErrRulesNeeded struct {
 func (e *ErrRulesNeeded) Error() string {
 	prefix := PrefixErrRulesNeeded
 	if len(e.Missing) > 0 {
-		perms, err := json.Marshal(e.Permissions)
+		perms, err := json.Marshal(e.Missing)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The permissions field was mistakenly used instead of the missing field.