### PR TITLE
change: also recheck permissions if generation changed but image didn't

### DIFF
--- a/pkg/controller/appdefinition/parse.go
+++ b/pkg/controller/appdefinition/parse.go
@@ -5,6 +5,7 @@ import (
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/appdefinition"
 	"github.com/acorn-io/runtime/pkg/condition"
+	"github.com/acorn-io/runtime/pkg/controller/permissions"
 )
 
 func ParseAppImage(req router.Request, resp router.Response) error {
@@ -28,6 +29,13 @@ func ParseAppImage(req router.Request, resp router.Response) error {
 	if err != nil {
 		status.Error(err)
 		return nil
+	}
+
+	// Migration for AppScopedPermissions
+	if len(appInstance.Status.Staged.AppScopedPermissions) == 0 &&
+		appInstance.Status.Staged.PermissionsObservedGeneration == appInstance.Generation &&
+		len(appInstance.Status.Staged.ImagePermissionsDenied) == 0 {
+		appInstance.Status.Staged.AppScopedPermissions = permissions.GetAppScopedPermissions(appInstance, appSpec)
 	}
 
 	appInstance.Status.AppSpec = *appSpec

--- a/pkg/controller/permissions/permissions_check.go
+++ b/pkg/controller/permissions/permissions_check.go
@@ -63,8 +63,8 @@ func CheckPermissions(req router.Request, _ router.Response) error {
 	}
 
 	// Early exit
-	if app.Status.Staged.AppImage.ID == "" ||
-		app.Status.Staged.AppImage.Digest == app.Status.AppImage.Digest ||
+	if (app.Status.Staged.AppImage.ID == "" ||
+		app.Status.Staged.AppImage.Digest == app.Status.AppImage.Digest) &&
 		app.Status.Staged.PermissionsObservedGeneration == app.Generation {
 		// IAR disabled? Allow the Image if we're not re-checking permissions
 		if enabled, err := config.GetFeature(req.Ctx, req.Client, profiles.FeatureImageAllowRules); err != nil {

--- a/pkg/controller/permissions/permissions_check.go
+++ b/pkg/controller/permissions/permissions_check.go
@@ -164,15 +164,15 @@ func CheckPermissions(req router.Request, _ router.Response) error {
 
 func GetAppScopedPermissions(app *v1.AppInstance, appSpec *v1.AppSpec) []v1.Permissions {
 	// ServiceNames of the current app level (i.e. not nested Acorns/Services)
-	scvnames := maps.Keys(appSpec.Containers)
-	scvnames = append(scvnames, maps.Keys(appSpec.Jobs)...)
-	scvnames = append(scvnames, maps.Keys(appSpec.Services)...)
+	svcnames := maps.Keys(appSpec.Containers)
+	svcnames = append(svcnames, maps.Keys(appSpec.Jobs)...)
+	svcnames = append(svcnames, maps.Keys(appSpec.Services)...)
 
 	// Only consider the scope of the current app level (i.e. not nested Acorns/Services)
 	grantedPerms := app.Spec.GetGrantedPermissions()
 	scopedGrantedPerms := []v1.Permissions{}
 	for i, p := range grantedPerms {
-		if slices.Contains(scvnames, p.ServiceName) {
+		if slices.Contains(svcnames, p.ServiceName) {
 			scopedGrantedPerms = append(scopedGrantedPerms, grantedPerms[i])
 		}
 	}


### PR DESCRIPTION


### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

