### PR TITLE
Add ability to set devSession timeout on CLI

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_dev.md
+++ b/docs/docs/100-reference/01-command-line/acorn_dev.md
@@ -24,28 +24,30 @@ acorn dev --name wandering-sound --clone [acorn args]
 ### Options
 
 ```
-      --annotation strings      Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --args-file string        Default args to apply to run/update command (default ".args.acorn")
-      --auto-upgrade            Enabled automatic upgrades.
-  -b, --bidirectional-sync      In interactive mode download changes in addition to uploading
-      --clone                   Clone the vcs repository and infer the build context for the given app allowing for local development
-      --compute-class strings   Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
-  -e, --env strings             Environment variables to set on running containers
-  -f, --file string             Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                    help for dev
-      --interval string         If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
-  -l, --label strings           Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --link strings            Link external app as a service in the current app (format app-name:container-name)
-  -m, --memory strings          Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
-  -n, --name string             Name of app to create
-      --notify-upgrade          If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string           Output API request without creating app (json, yaml)
-  -p, --publish strings         Publish port of application (format [public:]private) (ex 81:80)
-  -P, --publish-all             Publish all (true) or none (false) of the defined ports of application
-      --region string           Region in which to deploy the app, immutable
-      --replace                 Replace the app with only defined values, resetting undefined fields to default values
-  -s, --secret strings          Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
-  -v, --volume stringArray      Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
+      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --args-file string          Default args to apply to run/update command (default ".args.acorn")
+      --auto-upgrade              Enabled automatic upgrades.
+  -b, --bidirectional-sync        In interactive mode download changes in addition to uploading
+      --clone                     Clone the vcs repository and infer the build context for the given app allowing for local development
+      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
+  -e, --env strings               Environment variables to set on running containers
+  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                      help for dev
+      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
+  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --link strings              Link external app as a service in the current app (format app-name:container-name)
+  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
+  -n, --name string               Name of app to create
+      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string             Output API request without creating app (json, yaml)
+  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
+  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
+      --region string             Region in which to deploy the app, immutable
+      --replace                   Replace the app with only defined values, resetting undefined fields to default values
+  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
+      --session-release-on-exit   Release the session when the dev command exits
+      --session-timeout string    Timeout in seconds for the dev session (default "360s")
+  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -215,6 +215,10 @@ func (c *DefaultClient) appUpdate(ctx context.Context, name string, opts *AppUpd
 	}
 
 	if opts.DevSessionClient != nil {
+		timeout := int32(360)
+		if opts.DevSessionTimeoutSeconds != 0 {
+			timeout = opts.DevSessionTimeoutSeconds
+		}
 		return app, translatePermissions(apply.New(c.Client).Ensure(ctx, &apiv1.DevSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -222,7 +226,7 @@ func (c *DefaultClient) appUpdate(ctx context.Context, name string, opts *AppUpd
 			},
 			Spec: v1.DevSessionInstanceSpec{
 				Client:                *opts.DevSessionClient,
-				SessionTimeoutSeconds: 360,
+				SessionTimeoutSeconds: timeout,
 				SessionStartTime:      metav1.Now(),
 				SessionRenewTime:      metav1.Now(),
 				SpecOverride:          &app.Spec,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -89,27 +89,28 @@ func New(restConfig *rest.Config, project, namespace string) (Client, error) {
 }
 
 type AppUpdateOptions struct {
-	Annotations         []v1.ScopedLabel
-	Labels              []v1.ScopedLabel
-	PublishMode         v1.PublishMode
-	Volumes             []v1.VolumeBinding
-	Secrets             []v1.SecretBinding
-	Links               []v1.ServiceBinding
-	Publish             []v1.PortBinding
-	Env                 []v1.NameValue
-	Profiles            []string
-	Permissions         []v1.Permissions
-	DeployArgs          map[string]any
-	Stop                *bool
-	Image               string
-	Replace             bool // Replace is used to indicate whether the update should be a patch (replace=false: only change specified fields) or a full update (replace=true: reset unspecified fields to defaults)
-	AutoUpgrade         *bool
-	NotifyUpgrade       *bool
-	AutoUpgradeInterval string
-	Memory              v1.MemoryMap
-	ComputeClasses      v1.ComputeClassMap
-	Region              string
-	DevSessionClient    *v1.DevSessionInstanceClient
+	Annotations              []v1.ScopedLabel
+	Labels                   []v1.ScopedLabel
+	PublishMode              v1.PublishMode
+	Volumes                  []v1.VolumeBinding
+	Secrets                  []v1.SecretBinding
+	Links                    []v1.ServiceBinding
+	Publish                  []v1.PortBinding
+	Env                      []v1.NameValue
+	Profiles                 []string
+	Permissions              []v1.Permissions
+	DeployArgs               map[string]any
+	Stop                     *bool
+	Image                    string
+	Replace                  bool // Replace is used to indicate whether the update should be a patch (replace=false: only change specified fields) or a full update (replace=true: reset unspecified fields to defaults)
+	AutoUpgrade              *bool
+	NotifyUpgrade            *bool
+	AutoUpgradeInterval      string
+	Memory                   v1.MemoryMap
+	ComputeClasses           v1.ComputeClassMap
+	Region                   string
+	DevSessionClient         *v1.DevSessionInstanceClient
+	DevSessionTimeoutSeconds int32
 }
 
 type ContainerLogsWriter interface {


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This PR adds ability to set dev session timeout on CLI. It can also keep session open when cli exits. This gives developer ability to run devsession as long as they want without the side effect of reverting code.

