### PR TITLE
fail to run dev clone if the directory already exists and is non empty (#2258)

### DIFF
--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -153,6 +153,10 @@ func getRemoteRepo(ctx context.Context, workdir string, vcs v1.VCS, idx int) err
 				return err
 			}
 		} else {
+			if idx == 0 {
+				// We encountered a non-empty directory on our first attempt to checkout code
+				return fmt.Errorf("non-empty directory %q already exists", fullPath)
+			}
 			// Directory is not empty, check that it's a repo, add a new remote and try to fetch
 			fmt.Printf("Fetching into existing directory %q\n", fullPath)
 			err = gitCheckRepo(ctx, workdir)


### PR DESCRIPTION
#2258

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

