### PR TITLE
Remove unneeded egress restrictions on builder pods

### DIFF
--- a/pkg/controller/networkpolicy/testdata/networkpolicy/builder/expected.golden
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/builder/expected.golden
@@ -7,21 +7,6 @@ metadata:
   name: buildkitd
   namespace: acorn-image-system
 spec:
-  egress:
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-        - 10.42.0.0/24
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-    - podSelector:
-        matchLabels:
-          app: registry
   ingress:
   - from:
     - namespaceSelector:
@@ -36,6 +21,5 @@ spec:
       app: buildkitd
   policyTypes:
   - Ingress
-  - Egress
 status: {}
 `


### PR DESCRIPTION
This egress restriction was extraneous and we can remove it.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

