### PR TITLE
Remove advanced help (#1442)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_dev.md
+++ b/docs/docs/100-reference/01-command-line/acorn_dev.md
@@ -24,17 +24,28 @@ acorn dev --name wandering-sound --clone [acorn args]
 ### Options
 
 ```
-      --args-file string     Default args to apply to run/update command (default ".args.acorn")
-      --auto-upgrade         Enabled automatic upgrades.
-  -b, --bidirectional-sync   In interactive mode download changes in addition to uploading
-      --clone                Clone the vcs repository and infer the build context for the given app allowing for local development
-  -f, --file string          Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                 help for dev
-      --help-advanced        Show verbose help text
-  -n, --name string          Name of app to create
-      --notify-upgrade       If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string        Output API request without creating app (json, yaml)
-      --replace              Replace the app with only defined values, resetting undefined fields to default values
+      --annotation strings      Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --args-file string        Default args to apply to run/update command (default ".args.acorn")
+      --auto-upgrade            Enabled automatic upgrades.
+  -b, --bidirectional-sync      In interactive mode download changes in addition to uploading
+      --clone                   Clone the vcs repository and infer the build context for the given app allowing for local development
+      --compute-class strings   Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
+  -e, --env strings             Environment variables to set on running containers
+  -f, --file string             Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                    help for dev
+      --interval string         If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
+  -l, --label strings           Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --link strings            Link external app as a service in the current app (format app-name:container-name)
+  -m, --memory strings          Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
+  -n, --name string             Name of app to create
+      --notify-upgrade          If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string           Output API request without creating app (json, yaml)
+  -p, --publish strings         Publish port of application (format [public:]private) (ex 81:80)
+  -P, --publish-all             Publish all (true) or none (false) of the defined ports of application
+      --region string           Region in which to deploy the app, immutable
+      --replace                 Replace the app with only defined values, resetting undefined fields to default values
+  -s, --secret strings          Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
+  -v, --volume stringArray      Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -50,23 +50,72 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
 
    # To proceed with an upgrade you've been notified of:
    acorn update --confirm-upgrade myapp
+
+More Usages:
+     # Publish and Expose Port Syntax
+     - Publish port 80 for any containers that define it as a port
+      	acorn run -p 80 .
+
+     - Publish container "myapp" using the hostname app.example.com
+      	acorn run --publish app.example.com:myapp .
+
+     - Expose port 80 to the rest of the cluster as port 8080
+      	acorn run --expose 8080:80/http .
+
+     # Labels and Annotations Syntax
+     - Add a label to all resources created by the app
+       	acorn run --label key=value .
+
+     - Add a label to resources created for all containers
+      	acorn run --label containers:key=value .
+
+     - Add a label to the resources created for the volume named "myvolume"
+      	acorn run --label volumes:myvolume:key=value .
+
+     # Link Syntax
+     - Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
+       	acorn run --link mydatabase:db .
+
+     # Secret Syntax
+     - Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
+         acorn run --secret mycredentials:creds .
+
+     # Volume Syntax
+     - Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
+        acorn run --volume mydata,size=5G,class=fast .
+     - Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
+        acorn run --volume mydata:data .
 ```
 
 ### Options
 
 ```
-      --args-file string     Default args to apply to run/update command (default ".args.acorn")
-      --auto-upgrade         Enabled automatic upgrades.
-  -b, --bidirectional-sync   In interactive mode download changes in addition to uploading
-  -i, --dev                  Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
-  -f, --file string          Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                 help for run
-      --help-advanced        Show verbose help text
-  -n, --name string          Name of app to create
-      --notify-upgrade       If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string        Output API request without creating app (json, yaml)
-  -q, --quiet                Do not print status
-      --wait                 Wait for app to become ready before command exiting (default: true)
+      --annotation strings      Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --args-file string        Default args to apply to run/update command (default ".args.acorn")
+      --auto-upgrade            Enabled automatic upgrades.
+  -b, --bidirectional-sync      In interactive mode download changes in addition to uploading
+      --compute-class strings   Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
+      --dangerous               Automatically approve all privileges requested by the application
+  -i, --dev                     Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
+  -e, --env strings             Environment variables to set on running containers
+  -f, --file string             Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                    help for run
+      --interval string         If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
+  -l, --label strings           Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --link strings            Link external app as a service in the current app (format app-name:container-name)
+  -m, --memory strings          Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
+  -n, --name string             Name of app to create
+      --notify-upgrade          If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string           Output API request without creating app (json, yaml)
+  -p, --publish strings         Publish port of application (format [public:]private) (ex 81:80)
+  -P, --publish-all             Publish all (true) or none (false) of the defined ports of application
+  -q, --quiet                   Do not print status
+      --region string           Region in which to deploy the app, immutable
+      --replace                 Replace the app with only defined values, resetting undefined fields to default values
+  -s, --secret strings          Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
+  -u, --update                  Update the app if it already exists
+  -v, --volume stringArray      Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
+      --wait                    Wait for app to become ready before command exiting (default: true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -26,18 +26,30 @@ acorn update [flags] ACORN_NAME [deploy flags]
 ### Options
 
 ```
-      --args-file string   Default args to apply to run/update command (default ".args.acorn")
-      --auto-upgrade       Enabled automatic upgrades.
-      --confirm-upgrade    When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
-  -f, --file string        Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help               help for update
-      --help-advanced      Show verbose help text
-      --image string       Acorn image name
-      --notify-upgrade     If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string      Output API request without creating app (json, yaml)
-      --pull               Re-pull the app's image, which will cause the app to re-deploy if the image has changed
-  -q, --quiet              Do not print status
-      --wait               Wait for app to become ready before command exiting (default: true)
+      --annotation strings      Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --args-file string        Default args to apply to run/update command (default ".args.acorn")
+      --auto-upgrade            Enabled automatic upgrades.
+      --compute-class strings   Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
+      --confirm-upgrade         When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
+      --dangerous               Automatically approve all privileges requested by the application
+  -e, --env strings             Environment variables to set on running containers
+  -f, --file string             Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                    help for update
+      --image string            Acorn image name
+      --interval string         If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
+  -l, --label strings           Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --link strings            Link external app as a service in the current app (format app-name:container-name)
+  -m, --memory strings          Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
+      --notify-upgrade          If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string           Output API request without creating app (json, yaml)
+  -p, --publish strings         Publish port of application (format [public:]private) (ex 81:80)
+  -P, --publish-all             Publish all (true) or none (false) of the defined ports of application
+      --pull                    Re-pull the app's image, which will cause the app to re-deploy if the image has changed
+  -q, --quiet                   Do not print status
+      --region string           Region in which to deploy the app, immutable
+  -s, --secret strings          Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
+  -v, --volume stringArray      Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
+      --wait                    Wait for app to become ready before command exiting (default: true)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -38,7 +38,6 @@ acorn dev --name wandering-sound --clone [acorn args]
 		cmd.Printf("Error registering completion function for --compute-class flag: %v\n", err)
 	}
 	cmd.PersistentFlags().Lookup("dangerous").Hidden = true
-	toggleHiddenFlags(cmd, hideUpdateFlags, true)
 	cmd.Flags().SetInterspersed(false)
 	return cmd
 }
@@ -49,16 +48,11 @@ type Dev struct {
 	Replace           bool   `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
 	Clone             bool   `usage:"Clone the vcs repository and infer the build context for the given app allowing for local development"`
 	CloneDir          string `usage:"Provide a directory to clone the repository into, use in conjunction with clone flag" default:"." hidden:"true"`
-	HelpAdvanced      bool   `usage:"Show verbose help text"`
 	out               io.Writer
 	client            ClientFactory
 }
 
 func (s *Dev) Run(cmd *cobra.Command, args []string) error {
-	if s.HelpAdvanced {
-		setAdvancedHelp(cmd, hideUpdateFlags, AdvancedHelp)
-		return cmd.Help()
-	}
 	c, err := s.client.CreateDefault()
 	if err != nil {
 		return err

--- a/pkg/cli/testdata/run/acorn_run_help.txt
+++ b/pkg/cli/testdata/run/acorn_run_help.txt
@@ -43,17 +43,66 @@ Examples:
    # To proceed with an upgrade you've been notified of:
    acorn update --confirm-upgrade myapp
 
+More Usages:
+     # Publish and Expose Port Syntax
+     - Publish port 80 for any containers that define it as a port
+      	acorn run -p 80 .
+
+     - Publish container "myapp" using the hostname app.example.com
+      	acorn run --publish app.example.com:myapp .
+
+     - Expose port 80 to the rest of the cluster as port 8080
+      	acorn run --expose 8080:80/http .
+
+     # Labels and Annotations Syntax
+     - Add a label to all resources created by the app
+       	acorn run --label key=value .
+
+     - Add a label to resources created for all containers
+      	acorn run --label containers:key=value .
+
+     - Add a label to the resources created for the volume named "myvolume"
+      	acorn run --label volumes:myvolume:key=value .
+
+     # Link Syntax
+     - Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
+       	acorn run --link mydatabase:db .
+
+     # Secret Syntax
+     - Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
+         acorn run --secret mycredentials:creds .
+
+     # Volume Syntax
+     - Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
+        acorn run --volume mydata,size=5G,class=fast .
+     - Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
+        acorn run --volume mydata:data .
+
 Flags:
-      --args-file string     Default args to apply to run/update command (default ".args.acorn")
-      --auto-upgrade         Enabled automatic upgrades.
-  -b, --bidirectional-sync   In interactive mode download changes in addition to uploading
-  -i, --dev                  Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
-  -f, --file string          Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                 help for run
-      --help-advanced        Show verbose help text
-  -n, --name string          Name of app to create
-      --notify-upgrade       If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string        Output API request without creating app (json, yaml)
-  -q, --quiet                Do not print status
-      --wait                 Wait for app to become ready before command exiting (default: true)
+      --annotation strings      Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --args-file string        Default args to apply to run/update command (default ".args.acorn")
+      --auto-upgrade            Enabled automatic upgrades.
+  -b, --bidirectional-sync      In interactive mode download changes in addition to uploading
+      --compute-class strings   Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
+      --dangerous               Automatically approve all privileges requested by the application
+  -i, --dev                     Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
+  -e, --env strings             Environment variables to set on running containers
+  -f, --file string             Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                    help for run
+      --interval string         If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
+  -l, --label strings           Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
+      --link strings            Link external app as a service in the current app (format app-name:container-name)
+  -m, --memory strings          Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
+  -n, --name string             Name of app to create
+      --notify-upgrade          If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string           Output API request without creating app (json, yaml)
+  -p, --publish strings         Publish port of application (format [public:]private) (ex 81:80)
+  -P, --publish-all             Publish all (true) or none (false) of the defined ports of application
+  -q, --quiet                   Do not print status
+      --region string           Region in which to deploy the app, immutable
+      --replace                 Replace the app with only defined values, resetting undefined fields to default values
+  -s, --secret strings          Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
+  -u, --update                  Update the app if it already exists
+  -v, --volume stringArray      Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
+      --wait                    Wait for app to become ready before command exiting (default: true)
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -8,9 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var hideUpdateFlags = []string{"dangerous", "memory", "secret", "volume", "region", "publish-all",
-	"publish", "link", "label", "interval", "env", "compute-class", "annotation"}
-
 func NewUpdate(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Update{out: c.StdOut, client: c.ClientFactory}, cobra.Command{
 		Use:               "update [flags] ACORN_NAME [deploy flags]",
@@ -28,7 +25,6 @@ func NewUpdate(c CommandContext) *cobra.Command {
     acorn update --auto-upgrade my-app`,
 	})
 
-	toggleHiddenFlags(cmd, hideUpdateFlags, true)
 	cmd.Flags().SetInterspersed(false)
 	return cmd
 }
@@ -61,18 +57,12 @@ type Update struct {
 	Pull           bool   `usage:"Re-pull the app's image, which will cause the app to re-deploy if the image has changed"`
 	Wait           *bool  `usage:"Wait for app to become ready before command exiting (default: true)"`
 	Quiet          bool   `usage:"Do not print status" short:"q"`
-	HelpAdvanced   bool   `usage:"Show verbose help text"`
 
 	out    io.Writer
 	client ClientFactory
 }
 
 func (s *Update) Run(cmd *cobra.Command, args []string) error {
-	if s.HelpAdvanced {
-		setAdvancedHelp(cmd, hideUpdateFlags, "")
-		return cmd.Help()
-	}
-
 	// we can't enforce the one argument requirement at the Cobra level since we have to make --help-advanced possible
 	// so enforce the argument requirement here
 	if len(args) == 0 {


### PR DESCRIPTION
acorn-io/manager#1442

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

