### PR TITLE
Change auth url for logging into manager

### DIFF
--- a/pkg/manager/urls.go
+++ b/pkg/manager/urls.go
@@ -29,7 +29,7 @@ func scheme(address string) string {
 }
 
 func toLoginURL(address, password string) string {
-	return fmt.Sprintf("%s://%s/auth/login?p=%s", scheme(address), address, password)
+	return fmt.Sprintf("%s://%s/auth/cli?p=%s", scheme(address), address, password)
 }
 
 func toTokenRequestURL(address, password string) string {


### PR DESCRIPTION
By going to /auth/login every time, we are forcing the browser to do a
full logout/login. /auth/cli will only do a login if the token is
expired, so it's a little friendlier UX (and let's us test the switch
from beta.acorn.io to acorn.io more easily).

Signed-off-by: Craig Jellick <craig@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

