### PR TITLE
Fix: Confusing behavior when using two part publish syntax (#717)

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/imagerules"
 	"github.com/acorn-io/runtime/pkg/imagesource"
 	"github.com/acorn-io/runtime/pkg/rulerequest"
+	"github.com/acorn-io/runtime/pkg/services"
 	"github.com/acorn-io/runtime/pkg/wait"
 	"github.com/acorn-io/z"
 	"github.com/sirupsen/logrus"
@@ -310,6 +311,10 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	app, err = rulerequest.PromptRun(cmd.Context(), c, s.Dangerous, image, opts)
 	if err != nil {
+		return err
+	}
+
+	if _, err := services.ValidateTargetServiceName(opts.Publish, app.Status.AppSpec.Containers); err != nil {
 		return err
 	}
 	fmt.Println(app.Name)

--- a/pkg/controller/appdefinition/parse.go
+++ b/pkg/controller/appdefinition/parse.go
@@ -1,19 +1,28 @@
 package appdefinition
 
 import (
+	"fmt"
+
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/appdefinition"
 	"github.com/acorn-io/runtime/pkg/condition"
 	"github.com/acorn-io/runtime/pkg/controller/permissions"
+	"github.com/acorn-io/runtime/pkg/services"
 )
 
 func ParseAppImage(req router.Request, resp router.Response) error {
 	appInstance := req.Object.(*v1.AppInstance)
 	status := condition.Setter(appInstance, resp, v1.AppInstanceConditionParsed)
 	appImage := appInstance.Status.AppImage
+	containers := appImage.ImageData.Containers
 
 	if appImage.Acornfile == "" {
+		return nil
+	}
+
+	if _, err := services.ValidateTargetServiceName(appInstance.Spec.Publish, containers); err != nil {
+		status.Error(fmt.Errorf("invalid container name for publish: %s", err.Error()))
 		return nil
 	}
 

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/imagesystem"
 	"github.com/acorn-io/runtime/pkg/labels"
 	"github.com/acorn-io/runtime/pkg/pullsecret"
+	"github.com/acorn-io/runtime/pkg/services"
 	"github.com/acorn-io/runtime/pkg/tags"
 	"github.com/acorn-io/runtime/pkg/volume"
 	"github.com/acorn-io/z"
@@ -110,6 +111,10 @@ func (s *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 	if err := s.validateName(app); err != nil {
 		result = append(result, field.Invalid(field.NewPath("metadata", "name"), app.Name, err.Error()))
 		return
+	}
+
+	if invalidName, err := services.ValidateTargetServiceName(app.Spec.Publish, app.Status.AppSpec.Containers); err != nil {
+		result = append(result, field.Invalid(field.NewPath("spec", "publish"), invalidName, err.Error()))
 	}
 
 	project := new(v1.ProjectInstance)


### PR DESCRIPTION
## Root Cause:
- Absence of validation for container name using provided publish flags.

## Solution
- Add validation around with `ParseAppImage` functionality.
- The same functionality is required with `acorn run --update`, whenever a user tries to update the publish flag with the wrong container name

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

