### PR TITLE
Set session release flag to true by default

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_dev.md
+++ b/docs/docs/100-reference/01-command-line/acorn_dev.md
@@ -45,7 +45,7 @@ acorn dev --name wandering-sound --clone [acorn args]
       --region string             Region in which to deploy the app, immutable
       --replace                   Replace the app with only defined values, resetting undefined fields to default values
   -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
-      --session-release-on-exit   Release the session when the dev command exits
+      --session-release-on-exit   Release the session when the dev command exits (default: true)
       --session-timeout string    Timeout in seconds for the dev session (default "360s")
   -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
 ```

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -50,7 +50,7 @@ type Dev struct {
 	Clone                bool   `usage:"Clone the vcs repository and infer the build context for the given app allowing for local development"`
 	CloneDir             string `usage:"Provide a directory to clone the repository into, use in conjunction with clone flag" default:"." hidden:"true"`
 	SessionTimeout       string `usage:"Timeout in seconds for the dev session" default:"360s"`
-	SessionReleaseOnExit bool   `usage:"Release the session when the dev command exits" default:"true"`
+	SessionReleaseOnExit *bool  `usage:"Release the session when the dev command exits (default: true)"`
 	out                  io.Writer
 	client               ClientFactory
 }

--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -46,7 +46,7 @@ type Options struct {
 	Dangerous         bool
 	BidirectionalSync bool
 	TimeoutSeconds    int32
-	ReleaseOnExit     bool
+	ReleaseOnExit     *bool
 	Logger            Logger
 	BuildStatus       chan<- BuildStatus
 }
@@ -216,7 +216,7 @@ func buildLoop(ctx context.Context, c client.Client, hash clientHash, opts *Opti
 		logger    = opts.Logger
 	)
 
-	if opts.ReleaseOnExit {
+	if opts.ReleaseOnExit == nil || *opts.ReleaseOnExit {
 		defer func() {
 			if err := releaseDevSession(c, appName); err != nil {
 				logger.Errorf("Failed to release dev session app: %v", err)


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This makes sure `session-release-on-exit` is set to true by default, which is the expected behavior before. It gets messed up when the feature is added.

https://github.com/acorn-io/runtime/issues/2278