### PR TITLE
fix: close orphaned grpc connections in dev mode and silence related logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/hexops/valast v1.4.4
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
-	github.com/loft-sh/devspace v1.1.1-0.20230918143357-5f97e998676e
+	github.com/loft-sh/devspace v1.1.1-0.20231020132550-69e7df31933d
 	github.com/moby/buildkit v0.11.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/fuzzysearch v1.1.5 h1:Ag7aKU08wp0R9QCfF4GoGST9HbmAIeLP7xwMrOBEp1c=
 github.com/lithammer/fuzzysearch v1.1.5/go.mod h1:1R1LRNk7yKid1BaQkmuLQaHruxcC4HmAH30Dh61Ih1Q=
-github.com/loft-sh/devspace v1.1.1-0.20230918143357-5f97e998676e h1:1io5eZaWJ5mLrO0VDOkvlaXnGPJ7iAPVFFgJTKJ2oUA=
-github.com/loft-sh/devspace v1.1.1-0.20230918143357-5f97e998676e/go.mod h1:ZkURPkP4R3O8TGlnoY/GCw79LHmWIIFyUfzrXrV+yk0=
+github.com/loft-sh/devspace v1.1.1-0.20231020132550-69e7df31933d h1:w8teuH/cvVHkOsJjZjN6PmXAnERGXuULpIyQV/lUiNE=
+github.com/loft-sh/devspace v1.1.1-0.20231020132550-69e7df31933d/go.mod h1:ZkURPkP4R3O8TGlnoY/GCw79LHmWIIFyUfzrXrV+yk0=
 github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee h1:hZ79+pKEbCBrH1dVmgZ4jtFrrDPxgM4zqEP1lHlSnvI=
 github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee/go.mod h1:pq83B8lgfCY7tKdegTTXU6DZxGQkcWMowUTOTpTQmqk=
 github.com/loft-sh/utils v0.0.16 h1:XnD6Sb6gRWIHgM34U94dHcQ5MtxN5kAGZQ5eddAxC+c=


### PR DESCRIPTION
Ref: https://github.com/acorn-io/manager/issues/1211

Upstream fix: https://github.com/devspace-sh/devspace/pull/2739

The upstream fix resolves the issue of having lots of dangling, unused grpc connections.
But even with the fix, we'd see at least 2 lines of the annoying logs coming from the PING connection check right before closing the connection - that's why we silence grpc info/warn logs as well.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

