### PR TITLE
stop recursive deletion of secrets in app rm

### DIFF
--- a/pkg/cli/rm_helper.go
+++ b/pkg/cli/rm_helper.go
@@ -23,7 +23,7 @@ func getSecretsToRemove(arg string, client client.Client, cmd *cobra.Command) ([
 	}
 
 	for _, secret := range secrets {
-		if strings.HasPrefix(secret.Name, arg+".") {
+		if after, found := strings.CutPrefix(secret.Name, arg+"."); found && !strings.ContainsRune(after, '.') {
 			result = append(result, secret.Name)
 		}
 	}

--- a/pkg/cli/rm_helper.go
+++ b/pkg/cli/rm_helper.go
@@ -23,6 +23,7 @@ func getSecretsToRemove(arg string, client client.Client, cmd *cobra.Command) ([
 	}
 
 	for _, secret := range secrets {
+		// We only want to delete secrets for the given app and not nested apps
 		if after, found := strings.CutPrefix(secret.Name, arg+"."); found && !strings.ContainsRune(after, '.') {
 			result = append(result, secret.Name)
 		}

--- a/pkg/cli/rm_helper_test.go
+++ b/pkg/cli/rm_helper_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"testing"
+
+	v1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/cli/testdata"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetSecretsToRemove(t *testing.T) {
+	client := &testdata.MockClient{}
+	client.Secrets = []v1.Secret{
+		{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "found.secret"},
+			Type:       "",
+			Data:       nil,
+			Keys:       nil,
+		},
+		{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "found.secret.nested"},
+			Type:       "",
+			Data:       nil,
+			Keys:       nil,
+		},
+	}
+	cmd := &cobra.Command{}
+	tests := []struct {
+		name     string
+		arg      string
+		expected []string
+	}{
+		{
+			"simple",
+			"found",
+			[]string{"found.secret"},
+		},
+		{
+			"nested",
+			"found.secret",
+			[]string{"found.secret.nested"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secrets, err := getSecretsToRemove(tt.arg, client, cmd)
+			assert.NoError(t, err)
+			assert.EqualValues(t, tt.expected, secrets)
+		})
+	}
+}


### PR DESCRIPTION

Not deleting nested secrets:
```
11:48:08 ~/acorns/mine/docs/my-todo-list [master] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a all

ACORNS:
NAME          IMAGE                              COMMIT         CREATED    ENDPOINTS                                      MESSAGE
shy-leaf.db   ghcr.io/acorn-io/mariadb:v1.0.0*   4935ab94ff11   105s ago                                                  OK
shy-leaf      5d4106248b46                       e245bcac2bc3   106s ago   https://shy-leaf-c589960e.cy6wnw.on-acorn.io   OK

CONTAINERS:
NAME                                   ACORN         IMAGE                                                                     STATE     RESTARTCOUNT   CREATED    MESSAGE
shy-leaf.app-66886ff945-kzk29          shy-leaf      sha256:a2d484276f212bb0d9e999c982baf1490b3c4eee796149ca519c21cf48b36ed7   running   0              78s ago    
shy-leaf.db.mariadb-54cb4fccbc-94ct9   shy-leaf.db   mariadb:10.11                                                             running   0              102s ago   

VOLUMES:
NAME                  BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
shy-leaf.db.db-data   db-data        1Gi        ebs-retain     bound     RWO            99s ago

SECRETS:
NAME                TYPE      KEYS                  CREATED
shy-leaf.db.admin   basic     [password username]   103s ago
shy-leaf.db.user    basic     [password username]   103s ago
11:48:14 ~/acorns/mine/docs/my-todo-list [master] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a rm -a shy-leaf
Removed: shy-leaf
  •  No secrets associated with shy-leaf
11:48:26 ~/acorns/mine/docs/my-todo-list [master] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a all

ACORNS:
NAME      IMAGE     COMMIT    CREATED   ENDPOINTS   MESSAGE

CONTAINERS:
NAME      ACORN     IMAGE     STATE     RESTARTCOUNT   CREATED   MESSAGE

VOLUMES:
NAME                  BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS     ACCESS-MODES   CREATED
shy-leaf.db.db-data   db-data        1Gi        ebs-retain     released   RWO            2m2s ago

SECRETS:
NAME                TYPE      KEYS                  CREATED
shy-leaf.db.admin   basic     [password username]   2m6s ago
shy-leaf.db.user    basic     [password username]   2m6s ago
```

Still deletes related secrets:
```
11:51:44 ~/go/github.com/keyallis/manager/tests/e2e [nightly-changes] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a all

ACORNS:
NAME        IMAGE          COMMIT         CREATED   ENDPOINTS                                       MESSAGE
holy-frog   3be40fc067fa   7fad92520e86   34s ago   https://holy-frog-7b5972df.cy6wnw.on-acorn.io   OK

CONTAINERS:
NAME                              ACORN       IMAGE                                                                     STATE     RESTARTCOUNT   CREATED   MESSAGE
holy-frog.app-75545555c7-dn597    holy-frog   sha256:61420d0e56410d93957f57c1ff507122ebfb60676f3b0592001897505c187e3a   running   0              12s ago   
holy-frog.cache-c86cd768f-7cqfn   holy-frog   redis:alpine                                                              running   0              33s ago   
holy-frog.db-6979d945d4-pfzpd     holy-frog   postgres:alpine                                                           running   0              33s ago   

VOLUMES:
NAME               BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
holy-frog.pgdata   pgdata         1Gi        ebs-retain     bound     RWO            31s ago

SECRETS:
NAME                           TYPE      KEYS      CREATED
holy-frog.quickstart-pg-pass   token     [token]   34s ago
11:51:54 ~/go/github.com/keyallis/manager/tests/e2e [nightly-changes] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a rm -af holy-frog 
Removed: holy-frog
Removed volume: holy-frog.pgdata
Removed: holy-frog.quickstart-pg-pass
11:52:18 ~/go/github.com/keyallis/manager/tests/e2e [nightly-changes] (manager-056418f8.wcwa44.on-acorn.io/keyallis/acorn) % a all

ACORNS:
NAME      IMAGE     COMMIT    CREATED   ENDPOINTS   MESSAGE

CONTAINERS:
NAME      ACORN     IMAGE     STATE     RESTARTCOUNT   CREATED   MESSAGE

VOLUMES:
NAME      BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED

SECRETS:
NAME      TYPE      KEYS      CREATED
```


### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

