### PR TITLE
Fix: update publish flag (#717)

### DIFF
--- a/docs/docs/50-running/02-networking.md
+++ b/docs/docs/50-running/02-networking.md
@@ -34,6 +34,7 @@ Publishing ports makes the services available outside of the cluster. HTTP ports
 | `-p app:80`                 | Publish container `app` port 80 in the Acorn to 80 on cluster with its protocol.         |
 | `-p app:80/tcp`             | Publish container `app` port 80/tcp in the Acorn to 80 as a cluster service.             |
 | `-p app:80/http`            | Publish container `app` port 80/http in the Acorn to 80 with a random hostname.          |
+| `-p example.com:80`         | Publish 80/http in the Acorn to external name `example.com`.                             |
 | `-p app.example.com:app`    | Publish container `app` protocol HTTP from the Acorn to external name `app.example.com`. |
 | `-p app.example.com:app:80` | Publish container `app` port 80 from the Acorn to external name `app.example.com`.       |
 


### PR DESCRIPTION
- Added Missing publish flag for `example.com:80`

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

