### PR TITLE
Avoid dev session region errors when no region is specified

### DIFF
--- a/pkg/server/registry/apigroups/acorn/devsessions/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/devsessions/strategy.go
@@ -33,9 +33,14 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) (result fi
 	}
 
 	if devSession.Spec.Region != app.GetRegion() {
-		result = append(result, field.Invalid(field.NewPath("spec", "region"), devSession.Spec.Region,
-			fmt.Sprintf("Region on devSession [%s] and app [%s] must match", devSession.Spec.Region, app.GetRegion())))
-		return
+		if devSession.Spec.Region != "" {
+			result = append(result, field.Invalid(field.NewPath("spec", "region"), devSession.Spec.Region,
+				fmt.Sprintf("Region on devSession [%s] and app [%s] must match", devSession.Spec.Region, app.GetRegion())))
+			return
+		}
+
+		// If the dev session's region is blank, then set it to the app's region.
+		devSession.Spec.Region = app.GetRegion()
 	}
 
 	if devSession.Spec.SpecOverride == nil {


### PR DESCRIPTION
When starting a dev session on a new app without setting a region on the app, an error might crop up complaining about regions. This does not happen if a region is explicitly set on the app.

Therefore, since users don't explicitly create dev session objects, setting the region for them when the dev session region is unset is reasonable.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

