### PR TITLE
Always update ready status/conditions

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -86,12 +86,12 @@ func routes(router *router.Router, cfg *rest.Config, registryTransport http.Roun
 	appMeetsPreconditions.Middleware(appdefinition.ImagePulled).HandlerFunc(permissions.ConsumerPermissions)
 	appMeetsPreconditions.Middleware(appdefinition.ImagePulled).HandlerFunc(appdefinition.DeploySpec)
 	appMeetsPreconditions.Middleware(appdefinition.ImagePulled).HandlerFunc(secrets.CreateSecrets)
-	appMeetsPreconditions.HandlerFunc(appstatus.SetStatus)
-	appMeetsPreconditions.HandlerFunc(appstatus.ReadyStatus)
 	appMeetsPreconditions.HandlerFunc(networkpolicy.ForApp)
 	appMeetsPreconditions.HandlerFunc(appdefinition.AddAcornProjectLabel)
 	appMeetsPreconditions.HandlerFunc(appdefinition.UpdateObservedFields)
 
+	appRouter.HandlerFunc(appstatus.SetStatus)
+	appRouter.HandlerFunc(appstatus.ReadyStatus)
 	appRouter.HandlerFunc(appstatus.CLIStatus)
 
 	projectRouter := router.Type(&v1.ProjectInstance{})


### PR DESCRIPTION
When quota allocation fails previously no other status on the
appInstance would be calculated so you can get odd states like
"ready" but quota has failed (this happens on an upgrade) or
an app stuck in pending but the status is not set to error
in a way that the UI would recognize.