### PR TITLE
Add pre-stop hooks for containers that expose ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/acorn-io/images-mirror/tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
 FROM ghcr.io/acorn-io/images-mirror/moby/buildkit:v0.11.6 AS buildkit
 FROM ghcr.io/acorn-io/images-mirror/registry:2.8.1 AS registry
 FROM ghcr.io/acorn-io/images-mirror/rancher/klipper-lb:v0.3.5 AS klipper-lb
+FROM ghcr.io/acorn-io/sleep:latest AS sleep
 
 FROM ghcr.io/acorn-io/images-mirror/golang:1.21-alpine AS helper
 WORKDIR /usr/src
@@ -20,7 +21,8 @@ RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-
 FROM ghcr.io/acorn-io/images-mirror/golang:1.21 AS build
 COPY / /src
 WORKDIR /src
-RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build make build
+COPY --from=sleep /sleep /src/pkg/controller/appdefinition/embed/acorn-sleep
+RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build GO_TAGS=netgo,image make build
 
 FROM ghcr.io/acorn-io/images-mirror/nginx:1.23.2-alpine AS base
 RUN apk add --no-cache ca-certificates iptables ip6tables fuse3 git openssh pigz xz \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+GO_TAGS ?= netgo
 build:
-	CGO_ENABLED=0 go build -o bin/acorn -tags netgo -ldflags "-s -w" .
+	CGO_ENABLED=0 go build -o bin/acorn -tags "${GO_TAGS}" -ldflags "-s -w" .
 
 tidy:
 	go mod tidy

--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -109,7 +109,7 @@ func toJob(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSec
 		return nil, nil
 	}
 
-	containers, initContainers := toContainers(appInstance, tag, name, container, interpolator)
+	containers, initContainers := toContainers(appInstance, tag, name, container, interpolator, false)
 
 	containers = append(containers, corev1.Container{
 		Name:            jobs.Helper,
@@ -123,7 +123,7 @@ func toJob(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSec
 		return nil, err
 	}
 
-	volumes, err := toVolumes(appInstance, container, interpolator)
+	volumes, err := toVolumes(appInstance, container, interpolator, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/appdefinition/pre_stop_test.go
+++ b/pkg/controller/appdefinition/pre_stop_test.go
@@ -1,0 +1,22 @@
+package appdefinition
+
+import (
+	"testing"
+
+	"github.com/acorn-io/baaah/pkg/router/tester"
+	"github.com/acorn-io/runtime/pkg/scheme"
+)
+
+func TestPreStop(t *testing.T) {
+	acornSleepBinary = []byte("acorn-sleep")
+	t.Cleanup(func() {
+		acornSleepBinary = nil
+	})
+
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/basic", DeploySpec)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/stateful", DeploySpec)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/job", DeploySpec)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/dev", DeploySpec)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/no-ports", DeploySpec)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/deployspec/pre-stop/ports-only-sidecar", DeploySpec)
+}

--- a/pkg/controller/appdefinition/router.go
+++ b/pkg/controller/appdefinition/router.go
@@ -74,7 +74,7 @@ func toRouter(appInstance *v1.AppInstance, routerName string, router v1.Router) 
 					Annotations: deploymentAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					TerminationGracePeriodSeconds: z.Pointer[int64](5),
+					TerminationGracePeriodSeconds: z.Pointer[int64](10),
 					EnableServiceLinks:            new(bool),
 					Containers: []corev1.Container{
 						{
@@ -106,6 +106,17 @@ func toRouter(appInstance *v1.AppInstance, routerName string, router v1.Router) 
 									TCPSocket: &corev1.TCPSocketAction{
 										Port: intstr.IntOrString{
 											IntVal: 8080,
+										},
+									},
+								},
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh",
+											"-c",
+											"sleep 5 && /usr/sbin/nginx -s quit",
 										},
 									},
 								},

--- a/pkg/controller/appdefinition/sleep_dev.go
+++ b/pkg/controller/appdefinition/sleep_dev.go
@@ -1,0 +1,6 @@
+//go:build !image
+
+package appdefinition
+
+// If the binary is being built on its own and not part of an image, then don't worry about this binary.
+var acornSleepBinary []byte

--- a/pkg/controller/appdefinition/sleep_image.go
+++ b/pkg/controller/appdefinition/sleep_image.go
@@ -1,0 +1,8 @@
+//go:build image
+
+package appdefinition
+
+import _ "embed"
+
+//go:embed embed/acorn-sleep
+var acornSleepBinary []byte

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
@@ -81,7 +81,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -198,7 +198,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
@@ -81,7 +81,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -184,7 +184,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -158,7 +158,7 @@ spec:
       imagePullSecrets:
       - name: web-pull-1234567890ab
       serviceAccountName: web
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/depends/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -162,7 +162,7 @@ spec:
       imagePullSecrets:
       - name: web-pull-1234567890ab
       serviceAccountName: web
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -173,7 +173,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -96,7 +96,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: scalenil-pull-1234567890ab
       serviceAccountName: scalenil
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -159,7 +159,7 @@ spec:
       imagePullSecrets:
       - name: scaleone-pull-1234567890ab
       serviceAccountName: scaleone
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -255,7 +255,7 @@ spec:
       imagePullSecrets:
       - name: scaleotwo-pull-1234567890ab
       serviceAccountName: scaleotwo
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -96,7 +96,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
@@ -70,7 +70,7 @@ spec:
       imagePullSecrets:
       - name: nginx-pull-abcdef123456
       serviceAccountName: nginx
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/basic/expected.golden
@@ -1,0 +1,365 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: buildimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: sha256:build-image
+        name: buildimage
+        resources: {}
+      enableServiceLinks: false
+      hostname: buildimage
+      imagePullSecrets:
+      - name: buildimage-pull-1234567890ab
+      serviceAccountName: buildimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 25%
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"scale":3,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: oneimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: image-name
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /.acorn/sleep/1234567890abcdef
+        name: oneimage
+        ports:
+        - containerPort: 81
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 81
+        resources: {}
+        volumeMounts:
+        - mountPath: /.acorn/sleep
+          name: 1234567890abcdef
+      - image: foo
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /.acorn/sleep/1234567890abcdef
+        name: left
+        ports:
+        - containerPort: 91
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 91
+        resources: {}
+        volumeMounts:
+        - mountPath: /.acorn/sleep
+          name: 1234567890abcdef
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: oneimage-pull-1234567890ab
+      serviceAccountName: oneimage
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          defaultMode: 484
+          name: 1234567890abcdef
+        name: 1234567890abcdef
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+binaryData:
+  1234567890abcdef: YWNvcm4tc2xlZXA=
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+  name: 1234567890abcdef
+  namespace: app-created-namespace
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: buildimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      buildimage:
+        build:
+          context: .
+          dockerfile: custom-dockerfile
+        image: sha256:build-image
+        metrics: {}
+        probes: null
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        scale: 3
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/basic/input.yaml
@@ -1,0 +1,36 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+    image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        scale: 3
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+      buildimage:
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/dev/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/dev/expected.golden
@@ -1,0 +1,338 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: buildimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: sha256:build-image
+        name: buildimage
+        resources: {}
+      enableServiceLinks: false
+      hostname: buildimage
+      imagePullSecrets:
+      - name: buildimage-pull-1234567890ab
+      serviceAccountName: buildimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 25%
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"scale":3,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: oneimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: image-name
+        name: oneimage
+        ports:
+        - containerPort: 81
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 81
+        resources: {}
+      - image: foo
+        name: left
+        ports:
+        - containerPort: 91
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 91
+        resources: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: oneimage-pull-1234567890ab
+      serviceAccountName: oneimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: buildimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      buildimage:
+        build:
+          context: .
+          dockerfile: custom-dockerfile
+        image: sha256:build-image
+        metrics: {}
+        probes: null
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        scale: 3
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  devSession:
+    client:
+      imageSource: {}
+    sessionRenewTime: null
+    sessionStartTime: null
+    sessionTimeoutSeconds: 60
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/dev/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/dev/input.yaml
@@ -1,0 +1,38 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+    image: test
+status:
+  devSession:
+    sessionTimeoutSeconds: 60
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        scale: 3
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+      buildimage:
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
@@ -1,0 +1,178 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+    apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  backoffLimit: 1000
+  template:
+    metadata:
+      annotations:
+        acorn.io/config-hash: ""
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/job-name: oneimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - env:
+        - name: ACORN_EVENT
+          value: create
+        image: image-name
+        name: oneimage
+        ports:
+        - containerPort: 81
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 81
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - env:
+        - name: ACORN_EVENT
+          value: create
+        image: foo
+        name: left
+        ports:
+        - containerPort: 91
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 91
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/runtime:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: oneimage-pull-1234567890ab
+      restartPolicy: Never
+      serviceAccountName: oneimage
+      terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
+status: {}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    jobs:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus:
+    jobs:
+      oneimage: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/input.yaml
@@ -1,0 +1,30 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    jobs:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/no-ports/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/no-ports/expected.golden
@@ -1,0 +1,277 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: buildimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: sha256:build-image
+        name: buildimage
+        resources: {}
+      enableServiceLinks: false
+      hostname: buildimage
+      imagePullSecrets:
+      - name: buildimage-pull-1234567890ab
+      serviceAccountName: buildimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 25%
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"probes":null,"scale":3,"sidecars":{"left":{"image":"foo","metrics":{},"probes":null}}}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: oneimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: image-name
+        name: oneimage
+        resources: {}
+      - image: foo
+        name: left
+        resources: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: oneimage-pull-1234567890ab
+      serviceAccountName: oneimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: buildimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      buildimage:
+        build:
+          context: .
+          dockerfile: custom-dockerfile
+        image: sha256:build-image
+        metrics: {}
+        probes: null
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        probes: null
+        scale: 3
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/no-ports/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/no-ports/input.yaml
@@ -1,0 +1,28 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+    image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        scale: 3
+        sidecars:
+          left:
+            image: "foo"
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+      buildimage:
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/ports-only-sidecar/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/ports-only-sidecar/expected.golden
@@ -1,0 +1,344 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","metrics":{},"probes":null}'
+        karpenter.sh/do-not-evict: "true"
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: buildimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: sha256:build-image
+        name: buildimage
+        resources: {}
+      enableServiceLinks: false
+      hostname: buildimage
+      imagePullSecrets:
+      - name: buildimage-pull-1234567890ab
+      serviceAccountName: buildimage
+      terminationGracePeriodSeconds: 10
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: buildimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: buildimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 25%
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: buildimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","metrics":{},"probes":null,"scale":3,"sidecars":{"left":{"image":"foo","metrics":{},"ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: oneimage
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: image-name
+        name: oneimage
+        resources: {}
+      - image: foo
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /.acorn/sleep/1234567890abcdef
+        name: left
+        ports:
+        - containerPort: 91
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 91
+        resources: {}
+        volumeMounts:
+        - mountPath: /.acorn/sleep
+          name: 1234567890abcdef
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: oneimage-pull-1234567890ab
+      serviceAccountName: oneimage
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          defaultMode: 484
+          name: 1234567890abcdef
+        name: 1234567890abcdef
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: oneimage
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: v1
+binaryData:
+  1234567890abcdef: YWNvcm4tc2xlZXA=
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+  name: 1234567890abcdef
+  namespace: app-created-namespace
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: buildimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      buildimage:
+        build:
+          context: .
+          dockerfile: custom-dockerfile
+        image: sha256:build-image
+        metrics: {}
+        probes: null
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        probes: null
+        scale: 3
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/ports-only-sidecar/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/ports-only-sidecar/input.yaml
@@ -1,0 +1,32 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+    image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        scale: 3
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+      buildimage:
+        image: "sha256:build-image"
+        build:
+          dockerfile: "custom-dockerfile"
+          context: "."

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/existing.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterVolumeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: test-custom-class
+description: Just a simple test volume class
+default: true
+storageClassName: custom-class
+size:
+  min: 1Gi
+  max: 10Gi
+  default: 3Gi
+allowedAccessModes: ["readWriteOnce"]

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/expected.golden
@@ -1,0 +1,236 @@
+`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: container-name
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: container-name
+  namespace: app-created-namespace
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: container-name
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: container-name
+  namespace: app-created-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: container-name
+      acorn.io/managed: "true"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","metrics":{},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
+        karpenter.sh/do-not-evict: "true"
+      creationTimestamp: null
+      labels:
+        acorn.io/app-name: app-name
+        acorn.io/app-namespace: app-namespace
+        acorn.io/app-public-name: app-name
+        acorn.io/container-name: container-name
+        acorn.io/managed: "true"
+        acorn.io/project-name: app-namespace
+    spec:
+      containers:
+      - image: image-name
+        name: container-name
+        ports:
+        - containerPort: 81
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 81
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/tmp
+          name: foo
+      enableServiceLinks: false
+      hostname: container-name
+      imagePullSecrets:
+      - name: container-name-pull-1234567890ab
+      serviceAccountName: container-name
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: foo
+        persistentVolumeClaim:
+          claimName: foo
+status: {}
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/app-public-name: app-name
+    acorn.io/container-name: container-name
+    acorn.io/managed: "true"
+    acorn.io/project-name: app-namespace
+  name: container-name
+  namespace: app-created-namespace
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      acorn.io/app-name: app-name
+      acorn.io/app-namespace: app-namespace
+      acorn.io/container-name: container-name
+      acorn.io/managed: "true"
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: container-name
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.container-name
+  name: container-name
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: container-name
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/container-name: container-name
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+status: {}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.foo
+    acorn.io/volume-class: test-custom-class
+    acorn.io/volume-name: foo
+  name: foo
+  namespace: app-created-namespace
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+  storageClassName: custom-class
+status: {}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: container-name-pull-1234567890ab
+  namespace: app-created-namespace
+type: kubernetes.io/dockerconfigjson
+
+---
+apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      container-name:
+        dirs:
+          /var/tmp:
+            secret: {}
+            volume: foo
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+    volumes:
+      foo: {}
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults:
+    volumes:
+      foo:
+        accessModes:
+        - readWriteOnce
+        class: test-custom-class
+        size: 3Gi
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/stateful/input.yaml
@@ -1,0 +1,31 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      container-name:
+        image: "image-name"
+        dirs:
+          "/var/tmp":
+            volume: foo
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+    volumes:
+      foo: {}
+  defaults:
+    volumes:
+      foo:
+        class: test-custom-class
+        size: 3Gi
+        accessModes: [ "readWriteOnce" ]

--- a/pkg/controller/appdefinition/testdata/deployspec/scale/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/scale/expected.golden
@@ -60,7 +60,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -156,7 +156,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -158,7 +158,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/files-bug/expected.golden
+++ b/pkg/controller/appdefinition/testdata/files-bug/expected.golden
@@ -71,7 +71,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: secrets-1234567890ab
         secret:

--- a/pkg/controller/appdefinition/testdata/files/expected.golden
+++ b/pkg/controller/appdefinition/testdata/files/expected.golden
@@ -81,7 +81,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: secret--ref
         secret:

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.golden
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.golden
@@ -69,7 +69,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -181,7 +181,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.golden
@@ -67,7 +67,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.golden
@@ -97,7 +97,7 @@ spec:
       imagePullSecrets:
       - name: con1-pull-1234567890ab
       serviceAccountName: con1
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.golden
@@ -67,7 +67,7 @@ spec:
       imagePullSecrets:
       - name: app1-pull-1234567890ab
       serviceAccountName: app1
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -170,7 +170,7 @@ spec:
       imagePullSecrets:
       - name: app2-pull-1234567890ab
       serviceAccountName: app2
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.golden
@@ -97,7 +97,7 @@ spec:
       imagePullSecrets:
       - name: con1-pull-1234567890ab
       serviceAccountName: con1
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.golden
@@ -97,7 +97,7 @@ spec:
       imagePullSecrets:
       - name: con1-pull-newuid123456
       serviceAccountName: con1
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.golden
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.golden
@@ -75,7 +75,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: secrets-1234567890ab
         secret:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.golden
@@ -84,7 +84,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.golden
@@ -84,7 +84,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.golden
@@ -80,7 +80,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.golden
@@ -80,7 +80,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.golden
@@ -80,7 +80,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/expected.golden
@@ -71,7 +71,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -174,7 +174,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.golden
@@ -80,7 +80,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -173,7 +173,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -76,7 +76,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.golden
@@ -173,7 +173,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.golden
@@ -271,7 +271,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.golden
@@ -173,7 +173,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -382,7 +382,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.golden
@@ -173,7 +173,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -382,7 +382,7 @@ spec:
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       serviceAccountName: twoimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/probes/expected.golden
+++ b/pkg/controller/appdefinition/testdata/probes/expected.golden
@@ -64,7 +64,7 @@ spec:
       imagePullSecrets:
       - name: nodefault-pull-1234567890ab
       serviceAccountName: nodefault
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -185,7 +185,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.golden
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -161,7 +161,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.golden
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -161,7 +161,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/router/expected.golden
+++ b/pkg/controller/appdefinition/testdata/router/expected.golden
@@ -37,6 +37,13 @@ spec:
         command:
         - /docker-entrypoint.sh
         image: ghcr.io/acorn-io/runtime:main
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 5 && /usr/sbin/nginx -s quit
         name: nginx
         ports:
         - containerPort: 8080
@@ -53,7 +60,7 @@ spec:
           subPath: config
       enableServiceLinks: false
       serviceAccountName: router-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       tolerations:
       - key: taints.acorn.io/workload
         operator: Exists

--- a/pkg/controller/appdefinition/testdata/secret/expected.golden
+++ b/pkg/controller/appdefinition/testdata/secret/expected.golden
@@ -95,7 +95,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: secret--secret_dir_noaction
         secret:

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.golden
@@ -81,7 +81,7 @@ spec:
       imagePullSecrets:
       - name: con1-pull-1234567890ab
       serviceAccountName: con1
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -202,7 +202,7 @@ spec:
       imagePullSecrets:
       - name: con2-pull-1234567890ab
       serviceAccountName: con2
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -306,7 +306,7 @@ spec:
       imagePullSecrets:
       - name: con3-pull-1234567890ab
       serviceAccountName: con3
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.golden
@@ -69,7 +69,7 @@ spec:
       imagePullSecrets:
       - name: buildimage-pull-1234567890ab
       serviceAccountName: buildimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---
@@ -181,7 +181,7 @@ spec:
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       serviceAccountName: oneimage
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/template/expected.golden
+++ b/pkg/controller/appdefinition/testdata/template/expected.golden
@@ -61,7 +61,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.golden
@@ -68,7 +68,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: bar
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.golden
@@ -62,7 +62,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
 status: {}
 
 ---

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.golden
@@ -64,7 +64,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.golden
@@ -64,7 +64,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - emptyDir:
           sizeLimit: 10G

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/controller/appdefinition/testdata/volumes/reuse-existing/expected.golden
+++ b/pkg/controller/appdefinition/testdata/volumes/reuse-existing/expected.golden
@@ -66,7 +66,7 @@ spec:
       imagePullSecrets:
       - name: container-name-pull-1234567890ab
       serviceAccountName: container-name
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 10
       volumes:
       - name: foo
         persistentVolumeClaim:

--- a/pkg/imagesystem/buildertemplate.go
+++ b/pkg/imagesystem/buildertemplate.go
@@ -46,9 +46,10 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 					Labels: labels.ManagedByApp(namespace, name, "app", name),
 				},
 				Spec: corev1.PodSpec{
-					PriorityClassName:  system.AcornPriorityClass,
-					ServiceAccountName: "acorn-builder",
-					EnableServiceLinks: new(bool),
+					PriorityClassName:             system.AcornPriorityClass,
+					ServiceAccountName:            "acorn-builder",
+					EnableServiceLinks:            new(bool),
+					TerminationGracePeriodSeconds: z.Pointer[int64](10),
 					Containers: []corev1.Container{
 						{
 							Name:    "buildkitd",
@@ -164,6 +165,13 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							},
 							Args: []string{
 								"build-server",
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"sh", "-c", "sleep 5"},
+									},
+								},
 							},
 							Resources: system.ResourceRequirementsFor(*cfg.BuildkitdServiceMemory, *cfg.BuildkitdServiceCPU),
 							ReadinessProbe: &corev1.Probe{

--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -68,8 +68,9 @@ func registryDeployment(namespace, serviceAccountName, registryImage string, req
 					},
 				},
 				Spec: corev1.PodSpec{
-					PriorityClassName:  system.AcornPriorityClass,
-					EnableServiceLinks: new(bool),
+					TerminationGracePeriodSeconds: z.Pointer[int64](10),
+					PriorityClassName:             system.AcornPriorityClass,
+					EnableServiceLinks:            new(bool),
 					Containers: []corev1.Container{
 						{
 							Name: "registry",
@@ -120,6 +121,17 @@ func registryDeployment(namespace, serviceAccountName, registryImage string, req
 								{
 									Name:      "registry",
 									MountPath: "/var/lib/registry",
+								},
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh",
+											"-c",
+											"sleep 5",
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
This pre-stop hook will simply wait for 5 seconds. In order to achieve this in the most general way, a configmap is mounted as a volume that has a very simply binary that sleeps for 5 seconds. It is done this way because this should work for any container images, including scratch.

