### PR TITLE
Remove algolia for docs.

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -106,11 +106,6 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ['cue', 'docker'],
       },
-      algolia: {
-        appId: '7QCEFR54LA',
-        apiKey: '0091e059262804a95d3253d28bc90eeb',
-        indexName: 'acorn-io',
-      }
     })
 };
 


### PR DESCRIPTION
Removing algolia fro this site. It's been moved to the new docs.acorn.io. We will add back, when we have a new one.

