### PR TITLE
Add ability to read port from svc.status.loadbalancer.port

### DIFF
--- a/pkg/controller/appstatus/endpoints.go
+++ b/pkg/controller/appstatus/endpoints.go
@@ -50,12 +50,24 @@ func serviceEndpoints(ctx context.Context, c kclient.Client, app *v1.AppInstance
 
 			for _, ingress := range service.Status.LoadBalancer.Ingress {
 				if ingress.Hostname != "" {
-					endpoints = append(endpoints, v1.Endpoint{
-						Target:     containerName,
-						TargetPort: port.TargetPort.IntVal,
-						Address:    fmt.Sprintf("%s:%d", ingress.Hostname, port.Port),
-						Protocol:   protocol,
-					})
+					portNum := port.Port
+					if len(ingress.Ports) > 0 {
+						for _, ingressPort := range ingress.Ports {
+							endpoints = append(endpoints, v1.Endpoint{
+								Target:     containerName,
+								TargetPort: port.TargetPort.IntVal,
+								Address:    fmt.Sprintf("%s:%d", ingress.Hostname, ingressPort.Port),
+								Protocol:   protocol,
+							})
+						}
+					} else {
+						endpoints = append(endpoints, v1.Endpoint{
+							Target:     containerName,
+							TargetPort: port.TargetPort.IntVal,
+							Address:    fmt.Sprintf("%s:%d", ingress.Hostname, portNum),
+							Protocol:   protocol,
+						})
+					}
 				} else if ingress.IP != "" {
 					endpoints = append(endpoints, v1.Endpoint{
 						Target:     containerName,


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)


This PR adds ability to read port from svc.status.loadbalancer.ingress.port. Currently it is primarily used by aws-lb-controller in order to allocate random port.
