### PR TITLE
Ignore external services when comparing hashes

### DIFF
--- a/pkg/controller/appstatus/services.go
+++ b/pkg/controller/appstatus/services.go
@@ -80,7 +80,7 @@ func (a *appStatusRenderer) readServices() error {
 			s.Defined = s.Defined || !service.Status.HasService
 			s.UpToDate = service.Namespace != a.app.Status.Namespace ||
 				service.Annotations[labels.AcornAppGeneration] == strconv.Itoa(int(a.app.Generation))
-			s.UpToDate = s.Defined && s.UpToDate && (s.ServiceAcornReady || s.LinkOverride != "" || service.Annotations[labels.AcornConfigHashAnnotation] == hash)
+			s.UpToDate = s.Defined && s.UpToDate && (s.ServiceAcornReady || s.LinkOverride != "" || serviceDef.External != "" || service.Annotations[labels.AcornConfigHashAnnotation] == hash)
 			s.Ready = (s.Ready || !service.Status.HasService) && s.UpToDate
 			if s.ServiceAcornName != "" {
 				s.Ready = s.Ready && s.ServiceAcornReady


### PR DESCRIPTION
An external service is defined outside the app that consumes it. Thus, the config has on the service will be different from the config hash of the external service, so it doesn't make sense to compare them to determine if the service should be updated.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/manager/issues/1531