### PR TITLE
Stop rerunning create jobs on non-generation bumping updates

### DIFF
--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/existing.yaml
@@ -1,0 +1,69 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: create-only
+  namespace: app-created-namespace
+  annotations:
+    acorn.io/app-generation: "1"
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-public-name: "app-name"
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/job-name: "create-only"
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: create-only
+  namespace: app-created-namespace
+  annotations:
+    acorn.io/app-generation: "1"
+    apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    acorn.io/app-public-name: "app-name"
+    "acorn.io/job-name": "create-only"
+    "acorn.io/managed": "true"
+spec:
+  backoffLimit: 1000
+  template:
+    metadata:
+      labels:
+        "acorn.io/app-namespace": "app-namespace"
+        "acorn.io/app-name": "app-name"
+        acorn.io/app-public-name: "app-name"
+        "acorn.io/job-name": "create-only"
+        "acorn.io/managed": "true"
+      annotations:
+        acorn.io/app-generation: "1"
+        acorn.io/container-spec: '{"events":["create"],"image":"create-only-image","probes":null}'
+    spec:
+      imagePullSecrets:
+        - name: create-only-pull-1234567890ab
+      restartPolicy: Never
+      serviceAccountName: create-only
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: create-only
+          image: "create-only-image"
+          terminationMessagePath: "/run/secrets/output"
+          env:
+            - name: ACORN_EVENT
+              value: "create"
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: create-only-pull-1234567890ab
+  namespace: app-created-namespace
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+type: "kubernetes.io/dockerconfigjson"
+data:
+  ".dockerconfigjson": eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/expected.golden
@@ -1,0 +1,69 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  generation: 1
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    jobs:
+      create-only:
+        events:
+        - create
+        image: create-only-image
+        metrics: {}
+        probes: null
+      delete-only:
+        events:
+        - delete
+        image: delete-only-image
+        metrics: {}
+        probes: null
+      stop-only:
+        events:
+        - stop
+        image: stop-only-image
+        metrics: {}
+        probes: null
+      update-only:
+        events:
+        - update
+        image: update-only-image
+        metrics: {}
+        probes: null
+  appStatus:
+    jobs:
+      create-only:
+        createEventSucceeded: true
+        skipped: true
+      delete-only:
+        skipped: true
+      stop-only:
+        skipped: true
+      update-only:
+        skipped: true
+  columns: {}
+  conditions:
+    observedGeneration: 1
+    reason: Success
+    status: "True"
+    success: true
+    type: defined
+  defaults: {}
+  namespace: app-created-namespace
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-generation-one/input.yaml
@@ -1,0 +1,32 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  generation: 1
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    jobs:
+      delete-only:
+        events: ["delete"]
+        image: "delete-only-image"
+      create-only:
+        events: ["create"]
+        image: "create-only-image"
+      update-only:
+        events: ["update"]
+        image: "update-only-image"
+      stop-only:
+        events: ["stop"]
+        image: "stop-only-image"
+  appStatus:
+    jobs:
+      create-only:
+        createEventSucceeded: true
+        succeeded: true

--- a/pkg/controller/appstatus/jobs.go
+++ b/pkg/controller/appstatus/jobs.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/acorn-io/baaah/pkg/router"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
-	"github.com/acorn-io/runtime/pkg/jobs"
 	"github.com/acorn-io/runtime/pkg/labels"
 	"github.com/acorn-io/runtime/pkg/ports"
 	"github.com/acorn-io/z"
@@ -35,7 +34,7 @@ func (a *appStatusRenderer) readJobs() error {
 
 		c := v1.JobStatus{
 			CreateEventSucceeded: existingStatus[jobName].CreateEventSucceeded,
-			Skipped:              !jobs.ShouldRun(jobName, a.app),
+			Skipped:              existingStatus[jobName].Skipped,
 			ExpressionErrors:     existingStatus[jobName].ExpressionErrors,
 			Dependencies:         existingStatus[jobName].Dependencies,
 			CommonStatus: v1.CommonStatus{

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -141,7 +141,7 @@ func GetEvent(jobName string, appInstance *v1.AppInstance) string {
 	if appInstance.Spec.Stop != nil && *appInstance.Spec.Stop {
 		return "stop"
 	}
-	if appInstance.Generation <= 1 || slices.Contains(appInstance.Status.AppSpec.Jobs[jobName].Events, "create") && !appInstance.Status.AppStatus.Jobs[jobName].CreateEventSucceeded {
+	if (appInstance.Generation <= 1 || slices.Contains(appInstance.Status.AppSpec.Jobs[jobName].Events, "create")) && !appInstance.Status.AppStatus.Jobs[jobName].CreateEventSucceeded {
 		// Create event jobs run at least once. So, if it hasn't succeeded, run it.
 		return "create"
 	}


### PR DESCRIPTION
If an app is updated in such a way that the generation is not bumped (e.g. an annotation or label is add/removed/modified), then any job that is create-only would rerun if the generation of the app is 1. This change ensures that create-only jobs will not be rerun in this instance.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)
