### PR TITLE
Adjust status calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 /vendor
 apiserver.local.config
 /.envrc
+/depot.json
 **/.DS_Store

--- a/pkg/controller/appdefinition/depends.go
+++ b/pkg/controller/appdefinition/depends.go
@@ -1,16 +1,11 @@
 package appdefinition
 
 import (
-	"fmt"
-	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/acorn-io/baaah/pkg/apply"
-	"github.com/acorn-io/baaah/pkg/typed"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func getDependencyAnnotations(app *v1.AppInstance, containerOrJobName string, deps []v1.Dependency) map[string]string {
@@ -72,14 +67,6 @@ func getDependencyAnnotations(app *v1.AppInstance, containerOrJobName string, de
 		s := app.Status.AppStatus.Containers[containerOrJobName]
 		s.Dependencies = depStatus
 
-		if !s.Ready {
-			msg, blocked := isBlocked(s.Dependencies, s.ExpressionErrors)
-			if blocked {
-				s.State = "waiting"
-			}
-			s.TransitioningMessages = append(s.TransitioningMessages, msg...)
-		}
-
 		if app.Status.AppStatus.Containers == nil {
 			app.Status.AppStatus.Containers = map[string]v1.ContainerStatus{}
 		}
@@ -88,14 +75,6 @@ func getDependencyAnnotations(app *v1.AppInstance, containerOrJobName string, de
 		s := app.Status.AppStatus.Jobs[containerOrJobName]
 		s.Dependencies = depStatus
 
-		if !s.Ready {
-			msg, blocked := isBlocked(s.Dependencies, s.ExpressionErrors)
-			if blocked {
-				s.State = "waiting"
-			}
-			s.TransitioningMessages = append(s.TransitioningMessages, msg...)
-		}
-
 		if app.Status.AppStatus.Jobs == nil {
 			app.Status.AppStatus.Jobs = map[string]v1.JobStatus{}
 		}
@@ -103,36 +82,4 @@ func getDependencyAnnotations(app *v1.AppInstance, containerOrJobName string, de
 	}
 
 	return result
-}
-
-func isBlocked(dependencies map[string]v1.DependencyStatus, expressionErrors []v1.ExpressionError) (result []string, _ bool) {
-	groupedByTypeName := map[string][]string{}
-
-	for depName, dep := range dependencies {
-		var key string
-		if dep.Missing {
-			key = string(dep.DependencyType) + " to be created"
-		} else if !dep.Ready {
-			key = string(dep.DependencyType) + " to be ready"
-		} else {
-			continue
-		}
-		groupedByTypeName[key] = append(groupedByTypeName[key], depName)
-	}
-
-	for _, exprError := range expressionErrors {
-		if exprError.DependencyNotFound != nil && exprError.DependencyNotFound.SubKey == "" {
-			key := string(exprError.DependencyNotFound.DependencyType) + " to be created"
-			groupedByTypeName[key] = append(groupedByTypeName[key], exprError.DependencyNotFound.Name)
-		}
-	}
-
-	for _, key := range typed.SortedKeys(groupedByTypeName) {
-		values := sets.New(groupedByTypeName[key]...).UnsortedList()
-		slices.Sort(values)
-		msg := fmt.Sprintf("waiting for %s [%s]", key, strings.Join(values, ", "))
-		result = append(result, msg)
-	}
-
-	return result, len(result) > 0
 }

--- a/pkg/controller/appdefinition/testdata/depends/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends/expected.golden
@@ -303,9 +303,6 @@ status:
         dependencies:
           container-name:
             serviceType: container
-        state: waiting
-        transitioningMessages:
-        - waiting for container to be ready [container-name]
   columns: {}
   conditions:
     reason: Success

--- a/pkg/controller/appstatus/blocked.go
+++ b/pkg/controller/appstatus/blocked.go
@@ -1,0 +1,41 @@
+package appstatus
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/acorn-io/baaah/pkg/typed"
+	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func isBlocked(dependencies map[string]v1.DependencyStatus, expressionErrors []v1.ExpressionError) (result []string, _ bool) {
+	groupedByTypeName := map[string][]string{}
+
+	for depName, dep := range dependencies {
+		var key string
+		if dep.Missing {
+			key = string(dep.DependencyType) + " to be created"
+		} else if !dep.Ready {
+			key = string(dep.DependencyType) + " to be ready"
+		} else {
+			continue
+		}
+		groupedByTypeName[key] = append(groupedByTypeName[key], depName)
+	}
+
+	for _, exprError := range expressionErrors {
+		if exprError.DependencyNotFound != nil && exprError.DependencyNotFound.SubKey == "" {
+			key := string(exprError.DependencyNotFound.DependencyType) + " to be created"
+			groupedByTypeName[key] = append(groupedByTypeName[key], exprError.DependencyNotFound.Name)
+		}
+	}
+
+	for _, key := range typed.SortedKeys(groupedByTypeName) {
+		values := sets.NewString(groupedByTypeName[key]...).List()
+		msg := fmt.Sprintf("waiting for %s [%s]", key, strings.Join(values, ", "))
+		result = append(result, msg)
+	}
+
+	return result, len(result) > 0
+}

--- a/pkg/controller/appstatus/containers.go
+++ b/pkg/controller/appstatus/containers.go
@@ -137,6 +137,14 @@ func setContainerMessages(app *v1.AppInstance) {
 			}
 		}
 
+		if !cs.Ready {
+			msg, blocked := isBlocked(cs.Dependencies, cs.ExpressionErrors)
+			if blocked {
+				cs.State = "waiting"
+			}
+			cs.TransitioningMessages = append(cs.TransitioningMessages, msg...)
+		}
+
 		// Add informative messages if all else is healthy
 		if len(cs.TransitioningMessages) == 0 && len(cs.ErrorMessages) == 0 {
 			if cs.RunningReplicaCount > 1 {

--- a/pkg/controller/appstatus/jobs.go
+++ b/pkg/controller/appstatus/jobs.go
@@ -184,6 +184,14 @@ func setJobMessages(app *v1.AppInstance) {
 			}
 		}
 
+		if !c.Ready {
+			msg, blocked := isBlocked(c.Dependencies, c.ExpressionErrors)
+			if blocked {
+				c.State = "waiting"
+			}
+			c.TransitioningMessages = append(c.TransitioningMessages, msg...)
+		}
+
 		app.Status.AppStatus.Jobs[jobName] = c
 	}
 }

--- a/pkg/controller/appstatus/secrets.go
+++ b/pkg/controller/appstatus/secrets.go
@@ -91,9 +91,6 @@ func (a *appStatusRenderer) readSecrets() error {
 
 func setSecretMessages(app *v1.AppInstance) {
 	for secretName, s := range app.Status.AppStatus.Secrets {
-		s.ErrorMessages = s.LookupErrors
-		s.TransitioningMessages = s.LookupTransitioning
-
 		// Not ready if we have any error messages
 		if len(s.ErrorMessages) > 0 {
 			s.Ready = false


### PR DESCRIPTION
There was an issue where app status was being used to process deployments, jobs, etc but the app status wasn't being persisted. This change should give us the status updates we are looking forward without the "act before persist" issues.

