### PR TITLE
Fix internal registry not working on some storage classes

### DIFF
--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -68,6 +68,9 @@ func registryDeployment(namespace, serviceAccountName, registryImage string, req
 					},
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: z.Pointer[int64](1000),
+					},
 					TerminationGracePeriodSeconds: z.Pointer[int64](10),
 					PriorityClassName:             system.AcornPriorityClass,
 					EnableServiceLinks:            new(bool),


### PR DESCRIPTION
Depending on the storage class the PV may not be writeble by
non-root users. We need to set the fsGroup to address this.

Signed-off-by: Darren Shepherd <darren@acorn.io>
