### PR TITLE
Enable generating endpoints with paths and exposing job ports.

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -255,6 +255,7 @@ type Endpoint struct {
 	Address         string          `json:"address,omitempty"`
 	Protocol        Protocol        `json:"protocol,omitempty"`
 	PublishProtocol PublishProtocol `json:"publishProtocol,omitempty"`
+	Path            string          `json:"path,omitempty"`
 	Pending         bool            `json:"pending,omitempty"`
 }
 

--- a/pkg/apis/internal.acorn.io/v1/appspec.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec.go
@@ -129,6 +129,7 @@ func (in PortDef) FormatString(serviceName string) string {
 
 type PortDef struct {
 	Hostname   string   `json:"hostname,omitempty"`
+	Path       string   `json:"path,omitempty"`
 	Protocol   Protocol `json:"protocol,omitempty"`
 	Publish    bool     `json:"publish,omitempty"`
 	Dev        bool     `json:"dev,omitempty"`

--- a/pkg/apis/internal.acorn.io/v1/service.go
+++ b/pkg/apis/internal.acorn.io/v1/service.go
@@ -72,6 +72,7 @@ type PortPublish struct {
 	Port       int32    `json:"port,omitempty"`
 	Protocol   Protocol `json:"protocol,omitempty"`
 	Hostname   string   `json:"hostname,omitempty"`
+	Path       string   `json:"path,omitempty"`
 	TargetPort int32    `json:"targetPort,omitempty"`
 }
 

--- a/pkg/appdefinition/app.acorn
+++ b/pkg/appdefinition/app.acorn
@@ -240,6 +240,7 @@
 		port?:       int
 		targetPort?: int
 		protocol?:   enum("tcp", "udp", "http", "http2")
+		path?: string =~ "^/.*"
 	}
 
 	Metrics: {

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
@@ -141,6 +141,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -290,6 +290,47 @@ spec:
 status: {}
 
 ---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.job-name
+  name: job-name-job
+  namespace: app-created-namespace
+spec:
+  annotations:
+    admit-job.io: test-admit-job-ann
+    admit.io: test-admit-app-spec-ann
+    allowed-global.io: test-global
+    allowed.io: test-allowed-app-spec-ann
+  appName: app-name
+  appNamespace: app-namespace
+  container: job-name
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+    allowed-global.io: test-global
+    allowed-job.io: test-allowed-job-label
+    allowed.io: test-allowed-app-spec-label
+    permit.io: test-permit-app-spec-label
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+status: {}
+
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -284,6 +284,45 @@ spec:
 status: {}
 
 ---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.job-name
+  name: job-name-job
+  namespace: app-created-namespace
+spec:
+  annotations:
+    appSpecAnn: test-app-spec-ann
+    global-scoped-ann: test-global
+    jobAnn: test-job-ann
+  appName: app-name
+  appNamespace: app-namespace
+  container: job-name
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+    appSpecLabel: test-app-spec-label
+    global-scoped-label: test-global
+    jobLabel: test-job-label
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+status: {}
+
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -226,6 +226,38 @@ spec:
 status: {}
 
 ---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.job-name
+  name: job-name-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: job-name
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job-name
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+status: {}
+
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
@@ -122,6 +122,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.golden
@@ -122,6 +122,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.golden
@@ -137,6 +137,49 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job1
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.job1
+  name: job1-job
+  namespace: app-created-namespace
+spec:
+  annotations:
+    alljobsa: value
+    global2a: value
+    globala: value
+    job1a: value
+    job3a: value
+  appName: app-name
+  appNamespace: app-namespace
+  container: job1
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: job1
+    acorn.io/managed: "true"
+    alljobs: value
+    global: value
+    global2: value
+    job1: value
+    job3: value
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.golden
@@ -126,6 +126,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -481,6 +481,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -283,6 +283,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
@@ -223,6 +223,41 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
@@ -447,6 +447,76 @@ status: {}
 
 ---
 apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.oneimage
+  name: oneimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: oneimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: oneimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/config-hash: ""
+  creationTimestamp: null
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: twoimage
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.twoimage
+  name: twoimage-job
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  container: twoimage
+  default: false
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/job-name: twoimage
+    acorn.io/managed: "true"
+  ports:
+  - port: 80
+    protocol: http
+    targetPort: 81
+  - port: 90
+    protocol: tcp
+    targetPort: 91
+status: {}
+
+---
+apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appstatus/cli_status.go
+++ b/pkg/controller/appstatus/cli_status.go
@@ -162,22 +162,25 @@ func endpoints(req router.Request, app *v1.AppInstance) (string, error) {
 						buf.WriteString("http://")
 					}
 				}
+
+				if endpoint.Pending {
+					buf.WriteString("<Pending Ingress>")
+				} else {
+					buf.WriteString(endpoint.Address)
+
+					// Append the path if provided
+					if len(endpoint.Path) > 0 {
+						buf.WriteString(endpoint.Path)
+					}
+				}
 			default:
 				buf.WriteString(strings.ToLower(string(endpoint.Protocol)))
 				buf.WriteString("://")
-			}
 
-			if endpoint.Pending {
-				if endpoint.Protocol == "http" {
-					buf.WriteString("<Pending Ingress>")
-				} else {
+				if endpoint.Pending {
 					buf.WriteString("<Pending Load Balancer>")
-				}
-			} else {
-				buf.WriteString(endpoint.Address)
-				if len(endpoint.Path) > 0 {
-					// TODO(njhale): Sanitize address and path if necessary
-					buf.WriteString(endpoint.Path)
+				} else {
+					buf.WriteString(endpoint.Address)
 				}
 			}
 

--- a/pkg/controller/appstatus/cli_status.go
+++ b/pkg/controller/appstatus/cli_status.go
@@ -142,9 +142,7 @@ func endpoints(req router.Request, app *v1.AppInstance) (string, error) {
 	var endpointStrings []string
 
 	for _, endpoints := range typed.SortedValues(endpointTarget) {
-		var (
-			publicStrings []string
-		)
+		var publicStrings []string
 
 		for _, endpoint := range endpoints {
 			buf := &strings.Builder{}
@@ -177,7 +175,12 @@ func endpoints(req router.Request, app *v1.AppInstance) (string, error) {
 				}
 			} else {
 				buf.WriteString(endpoint.Address)
+				if len(endpoint.Path) > 0 {
+					// TODO(njhale): Sanitize address and path if necessary
+					buf.WriteString(endpoint.Path)
+				}
 			}
+
 			publicStrings = append(publicStrings, buf.String())
 		}
 

--- a/pkg/controller/appstatus/endpoints.go
+++ b/pkg/controller/appstatus/endpoints.go
@@ -126,6 +126,7 @@ func ingressEndpoints(ctx context.Context, c kclient.Client, app *v1.AppInstance
 			endpoints = append(endpoints, v1.Endpoint{
 				Target:     target.Service,
 				TargetPort: target.Port,
+				Path:       target.Path,
 				Address:    hostname,
 				Protocol:   v1.ProtocolHTTP,
 				Pending:    len(ingress.Status.LoadBalancer.Ingress) == 0,

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -9025,6 +9025,12 @@ func schema_pkg_apis_internalacornio_v1_Endpoint(ref common.ReferenceCallback) c
 							Format: "",
 						},
 					},
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"pending": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
@@ -10606,6 +10612,12 @@ func schema_pkg_apis_internalacornio_v1_PortDef(ref common.ReferenceCallback) co
 							Format: "",
 						},
 					},
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -10661,6 +10673,12 @@ func schema_pkg_apis_internalacornio_v1_PortPublish(ref common.ReferenceCallback
 						},
 					},
 					"hostname": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"path": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/publish/servicelb.go
+++ b/pkg/publish/servicelb.go
@@ -30,8 +30,14 @@ func ServiceLoadBalancer(req router.Request, svc *v1.ServiceInstance) (result []
 
 	selectorLabels := svc.Spec.ContainerLabels
 	if svc.Spec.Container != "" {
+		selectorLabel := labels.AcornContainerName
+		if svc.Labels[labels.AcornJobName] != "" {
+			// Service targets a job, so we need to selector for containers matching the job name.
+			// Which will be marked as the Container on the spec.
+			selectorLabel = labels.AcornJobName
+		}
 		selectorLabels = map[string]string{
-			labels.AcornContainerName: svc.Spec.Container,
+			selectorLabel: svc.Spec.Container,
 		}
 	}
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -250,6 +250,9 @@ func ToK8sService(req router.Request, service *v1.ServiceInstance) (result []kcl
 		return toAddressService(service), nil, nil
 	} else if service.Spec.Container != "" {
 		return toContainerService(service), nil, nil
+		// TODO(njhale): Flip this on when generating job services
+		//} else if service.Spec.Job != "" {
+		//	return toJobService(service), nil, nil
 	} else if len(service.Spec.ContainerLabels) > 0 {
 		return toContainerLabelsService(service), nil, nil
 	}


### PR DESCRIPTION
Add a path field to container ports so that users can specify an
optional path to append to container's endpoint URL. The path field
supports interpolation which, for example, enables the use of runtime
generated tokens.

Additionally, deploy ServiceInstances and Ingresses for job ports. This
allows jobs to serve traffic and expose things like temporary web pages
for collecting user credentials.

e.g. Adding a port with an interpolated path to a job:

```cue
jobs: ahoy: {
	build: "."
	ports: publish: [
		{
			targetPort: 9000
			protocol:   "http"
			path:       "/ahoy?token=@{secrets.token-ahoy.token}"
		},
	]
}


secrets: {
	"token-ahoy": type: "token"
}
```

Will result in an app endpoint that stays active until the job completed (or the app is stopped)

```
NAME        IMAGE          COMMIT         CREATED    ENDPOINTS                                                                                                                 MESSAGE
cupule-j5   b831b259b470   ffaa36e7e2a2   32s ago    http://ahoy-job-cupule-j5-0ce4c978.local.oss-acorn.io/ahoy?token=bsgqt4bv75wm9sj85rldnv69m7bjsh6qrttqv9h8vw7w9g8nr6k7zt   (job: ahoy): job running
```

```
NAME        IMAGE          COMMIT         CREATED     ENDPOINTS   MESSAGE
cupule-j5   b831b259b470   ffaa36e7e2a2   2m50s ago               OK
```