### PR TITLE
Wait for server to acknowledge app deletion before trying ignore-cleanup

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
+++ b/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
@@ -59,7 +59,7 @@ func (s *ignoreCleanupStrategy) Create(ctx context.Context, obj types.Object) (t
 		}
 
 		if app.DeletionTimestamp.IsZero() {
-			return fmt.Errorf("cannot force delete app %s because it is not being deleted", app.Name)
+			return apierrors.NewBadRequest(fmt.Sprintf("cannot force delete app %s because it is not being deleted", app.Name))
 		}
 
 		// If the app has the destroy job finalizer, remove it to force delete


### PR DESCRIPTION
There are certain situations where the app delete succeeds and the call to ignore-cleanup fails because it thinks that the app is not being deleted. This change will retry on this error to avoid the necessity of having to delete the app and then ignore-cleanup.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/manager/issues/1585