### PR TITLE
Stop trying to parse empty image names

### DIFF
--- a/pkg/controller/permissions/permissions_check.go
+++ b/pkg/controller/permissions/permissions_check.go
@@ -27,13 +27,13 @@ import (
 // - there are no missing permissions
 // - there are no image permissions denied (if ImageRoleAuthorizations are enabled)
 // - the image is allowed by the image allow rules (if enabled)
-func CopyPromoteStagedAppImage(req router.Request, resp router.Response) error {
+func CopyPromoteStagedAppImage(req router.Request, _ router.Response) error {
 	app := req.Object.(*v1.AppInstance)
 	if app.Status.Staged.AppImage.ID != "" &&
 		app.Status.Staged.PermissionsChecked &&
 		len(app.Status.Staged.PermissionsMissing) == 0 &&
 		len(app.Status.Staged.ImagePermissionsDenied) == 0 &&
-		z.Dereference[bool](app.Status.Staged.ImageAllowed) {
+		z.Dereference(app.Status.Staged.ImageAllowed) {
 		app.Status.AppImage = app.Status.Staged.AppImage
 		app.Status.Permissions = app.Status.Staged.AppScopedPermissions
 	}
@@ -63,9 +63,8 @@ func CheckPermissions(req router.Request, _ router.Response) error {
 	}
 
 	// Early exit
-	if (app.Status.Staged.AppImage.ID == "" ||
-		app.Status.Staged.AppImage.Digest == app.Status.AppImage.Digest) &&
-		app.Status.Staged.PermissionsObservedGeneration == app.Generation {
+	if app.Status.Staged.AppImage.ID == "" ||
+		app.Status.Staged.AppImage.Digest == app.Status.AppImage.Digest && app.Status.Staged.PermissionsObservedGeneration == app.Generation {
 		// IAR disabled? Allow the Image if we're not re-checking permissions
 		if enabled, err := config.GetFeature(req.Ctx, req.Client, profiles.FeatureImageAllowRules); err != nil {
 			return err


### PR DESCRIPTION
When determining image permissions for apps with auto-upgrade pattern, the handler would mistakenly try to parse a blank image name. This change will ignore empty image names.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/manager/issues/1556