### PR TITLE
Expand * verbs when doing SAR checks on images

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -30,7 +30,7 @@ var (
 		},
 		ClusterEdit: {
 			{
-				Verbs: []string{"create", "update", "delete"},
+				Verbs: []string{"create", "update", "delete", "deletecollection"},
 				Resources: []string{
 					"projects",
 				},
@@ -91,7 +91,7 @@ var (
 		},
 		Edit: {
 			{
-				Verbs: []string{"create", "update", "delete", "patch"},
+				Verbs: []string{"create", "update", "delete", "deletecollection", "patch"},
 				Resources: []string{
 					"apps",
 					"devsessions",
@@ -100,7 +100,7 @@ var (
 				},
 			},
 			{
-				Verbs: []string{"update", "delete", "patch"},
+				Verbs: []string{"update", "delete", "deletecollection", "patch"},
 				Resources: []string{
 					"images",
 				},
@@ -117,7 +117,7 @@ var (
 				},
 			},
 			{
-				Verbs: []string{"delete"},
+				Verbs: []string{"delete", "deletecollection"},
 				Resources: []string{
 					"services",
 					"volumes",
@@ -136,7 +136,7 @@ var (
 		},
 		Build: {
 			{
-				Verbs: []string{"create", "delete"},
+				Verbs: []string{"create", "delete", "deletecollection"},
 				Resources: []string{
 					"builders",
 					"acornimagebuilds",
@@ -151,7 +151,7 @@ var (
 		},
 		Admin: {
 			{
-				Verbs: []string{"create", "update", "delete", "patch", "get", "list", "watch"},
+				Verbs: []string{"create", "update", "delete", "deletecollection", "patch", "get", "list", "watch"},
 				Resources: []string{
 					"projectvolumeclasses",
 					"clustervolumeclasses",
@@ -163,7 +163,7 @@ var (
 				APIGroups: []string{admin_acorn_io.Group},
 			},
 			{
-				Verbs: []string{"create", "update", "delete", "patch"},
+				Verbs: []string{"create", "update", "delete", "deletecollection", "patch"},
 				Resources: []string{
 					"imageallowrules",
 				},

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -439,6 +439,9 @@ func (s *RBACValidator) getSARResourceRole(sar *authv1.SubjectAccessReview, serv
 	if len(rule.Verbs) == 0 {
 		return nil, fmt.Errorf("can not deploy acorn due to requesting role with empty verbs")
 	}
+	if slices.Contains(rule.Verbs, "*") {
+		rule.Verbs = v1.DefaultVerbs
+	}
 	if len(rule.Resources) == 0 {
 		rule.Resources = []string{"*"}
 	}


### PR DESCRIPTION
None of our roles explicitly allow * verb in their permissions. Therefore, in order to check these permissions, * must be expanded. Implicit in the * verb is the deletecollection verb. Therefore, this verb is added to any rule that allows the delete verb.

