### PR TITLE
add alias for acorn project cli

### DIFF
--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -18,7 +18,7 @@ import (
 func NewProject(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Project{client: c.ClientFactory}, cobra.Command{
 		Use:     "project [flags]",
-		Aliases: []string{"projects"},
+		Aliases: []string{"projects", "proj"},
 		Example: `
 acorn project`,
 		SilenceUsage:      true,


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

