### PR TITLE
add: 'acorn project use -' to switch to last used project (#1319)

### DIFF
--- a/pkg/config/cliconfig.go
+++ b/pkg/config/cliconfig.go
@@ -56,6 +56,7 @@ type CLIConfig struct {
 	ProjectAliases     map[string]string     `json:"projectAliases,omitempty"`
 	DefaultContext     string                `json:"defaultContext,omitempty"`
 	CurrentProject     string                `json:"currentProject,omitempty"`
+	LastProject        string                `json:"lastProject,omitempty"`
 	AcornConfigFile    string                `json:"acornConfig,omitempty"`
 
 	// ProjectURLs is used for testing to return EndpointURLs for remote projects
@@ -157,6 +158,7 @@ func ReadCLIConfig(acornConfigFile string, kubeconfigOnly bool) (*CLIConfig, err
 	if kubeconfigOnly {
 		result.DefaultContext = ""
 		result.CurrentProject = ""
+		result.LastProject = ""
 	}
 
 	return result, nil
@@ -177,6 +179,11 @@ func RemoveServer(cfg *CLIConfig, serverAddress string) error {
 	var modified bool
 	if strings.HasPrefix(cfg.CurrentProject, serverAddress) {
 		cfg.CurrentProject = ""
+		modified = true
+	}
+
+	if strings.HasPrefix(cfg.LastProject, serverAddress) {
+		cfg.LastProject = ""
 		modified = true
 	}
 


### PR DESCRIPTION
New Acorn CLI config field `lastProject` -> Switch back and forth via `acorn project use -`

Ref #1319

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

