### PR TITLE
fix: replace / with - in anonymous ephemeral volume names (manager-specific) (manager#1598)

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -1396,7 +1396,7 @@ func parseVolumeDefinition(anonName, s string) (VolumeBinding, error) {
 	if u.Scheme == "ephemeral" {
 		result.Class = u.Scheme
 		if result.Volume == "" {
-			result.Volume = anonName
+			result.Volume = strings.ReplaceAll(anonName, "/", "-") // While a path-style name is OK in runtime, it breaks as resource name in manager
 		}
 	}
 

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"cuelang.org/go/cue/errors"
@@ -1380,8 +1381,8 @@ volumes: {
 	assert.Equal(t, v1.AccessModes{"readWriteMany", "readWriteOnce"}, appSpec.Volumes["uri"].AccessModes)
 	assert.Equal(t, v1.Quantity(""), appSpec.Volumes["uri-sub"].Size)
 	assert.Nil(t, appSpec.Volumes["uri-sub"].AccessModes)
-	assert.Equal(t, "ephemeral", appSpec.Volumes["s/left/var/anon-ephemeral-vol"].Class)
-	assert.Equal(t, "ephemeral", appSpec.Volumes["s/left/var/anon-ephemeral2-vol"].Class)
+	assert.Equal(t, "ephemeral", appSpec.Volumes["s-left-var-anon-ephemeral-vol"].Class)
+	assert.Equal(t, "ephemeral", appSpec.Volumes["s-left-var-anon-ephemeral2-vol"].Class)
 	assert.Equal(t, "ephemeral", appSpec.Volumes["eph"].Class)
 	assert.Len(t, typed.SortedKeys(appSpec.Volumes), 11)
 
@@ -1396,9 +1397,9 @@ volumes: {
 	assert.Equal(t, "", sidecar.Dirs["/var/uri-vol"].SubPath)
 	assert.Equal(t, "uri-sub", sidecar.Dirs["/var/uri-sub-vol"].Volume)
 	assert.Equal(t, "sub", sidecar.Dirs["/var/uri-sub-vol"].SubPath)
-	assert.Equal(t, filepath.Join("s", "left", "var", "anon-ephemeral-vol"), sidecar.Dirs["/var/anon-ephemeral-vol"].Volume)
+	assert.Equal(t, strings.ReplaceAll(filepath.Join("s", "left", "var", "anon-ephemeral-vol"), "/", "-"), sidecar.Dirs["/var/anon-ephemeral-vol"].Volume)
 	assert.Equal(t, "", sidecar.Dirs["/var/anon-ephemeral-vol"].SubPath)
-	assert.Equal(t, filepath.Join("s", "left", "var", "anon-ephemeral2-vol"), sidecar.Dirs["/var/anon-ephemeral2-vol"].Volume)
+	assert.Equal(t, strings.ReplaceAll(filepath.Join("s", "left", "var", "anon-ephemeral2-vol"), "/", "-"), sidecar.Dirs["/var/anon-ephemeral2-vol"].Volume)
 	assert.Equal(t, "", sidecar.Dirs["/var/anon-ephemeral2-vol"].SubPath)
 	assert.Equal(t, "eph", sidecar.Dirs["/var/named-ephemeral-vol"].Volume)
 	assert.Equal(t, "", sidecar.Dirs["/var/named-ephemeral-vol"].SubPath)


### PR DESCRIPTION
`dirs: "/foo/bar": "ephemeral://"` stores a volume with name `/foo/bar`, which is OK in runtime, but is actually used as a resource name in Manager, which cannot contain `/`, so we're replacing this here (instead of adapting the store strategy in Manager)

I'm not sure if we'll need more sophisticated replaces here to make it a DNS name :thinking: 

Discovered as part of [ #1598](https://github.com/acorn-io/manager/issues/1598)

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

