### PR TITLE
Ignore auth failures when trying to pull apps during cli login

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -54,7 +54,7 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 			app, err := c.AppGet(cmd.Context(), args[0])
 			if err == nil {
 				return login.Secrets(cmd.Context(), c, app)
-			} else if !apierrors.IsNotFound(err) {
+			} else if !(apierrors.IsNotFound(err) || apierrors.IsForbidden(err)) {
 				return err
 			}
 		}


### PR DESCRIPTION
This has been causing failures in e2e

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

