### PR TITLE
Ensure that nginx does DNS lookups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=registry /bin/registry /usr/local/bin
 COPY --from=klipper-lb /usr/bin/entry /usr/local/bin/klipper-lb
 COPY ./scripts/ds-containerd-config-path-entry /usr/local/bin
 COPY ./scripts/setup-binfmt /usr/local/bin
+COPY ./scripts/40-copy-resolv-nameserver.sh /docker-entrypoint.d/
 COPY --from=helper /usr/local/bin/acorn-helper /usr/local/bin/
 COPY --from=loglevel /usr/local/bin/loglevel /usr/local/bin/
 VOLUME /var/lib/buildkit

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -98,7 +98,7 @@ func DeploySpec(req router.Request, resp router.Response) (err error) {
 	} else if len(objs) > 0 {
 		result = append(result, objs...)
 	}
-	if objs, err := toRouters(appInstance); err != nil {
+	if objs, err := toRouters(req.Ctx, req.Client, appInstance); err != nil {
 		return err
 	} else {
 		result = append(result, objs...)

--- a/pkg/controller/appdefinition/testdata/router/expected.golden
+++ b/pkg/controller/appdefinition/testdata/router/expected.golden
@@ -66,7 +66,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: router-name-e9cec3df
+          name: router-name-30019cec
         name: conf
 status: {}
 
@@ -77,22 +77,25 @@ data:
     server {
     listen 8080;
     location = /foo {
-      proxy_pass http://foo-target:80;
+      set $backend_servers foo-target.app-created-namespace.svc.cluster.local;
+      proxy_pass http://$backend_servers:80;
       proxy_set_header X-Forwarded-Host $http_host;
     }
     location = /zzzz {
-      proxy_pass http://zzz-target:80;
+      set $backend_servers zzz-target.app-created-namespace.svc.cluster.local;
+      proxy_pass http://$backend_servers:80;
       proxy_set_header X-Forwarded-Host $http_host;
     }
     location /zzzz/ {
-      proxy_pass http://zzz-target:80;
+      set $backend_servers zzz-target.app-created-namespace.svc.cluster.local;
+      proxy_pass http://$backend_servers:80;
       proxy_set_header X-Forwarded-Host $http_host;
     }
     }
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: router-name-e9cec3df
+  name: router-name-30019cec
   namespace: app-created-namespace
 
 ---

--- a/scripts/40-copy-resolv-nameserver.sh
+++ b/scripts/40-copy-resolv-nameserver.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eu
+
+ip=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')
+echo "resolver $ip valid=15s;" > /etc/nginx/conf.d/resolver.conf


### PR DESCRIPTION
When using static hostnames, nginx will lookup the DNS for these hostnames on startup/config reload and won't do it again until the container is restarted or the config is reloaded. This means that if the service IPs change, then nginx won't have the correct IPs until one of these things happen.

This change uses a hack to ensure that nginx will look up for the DNS for services at least every 15 seconds. This ensures that if the service IPs change for some reason, then nginx will get them.

