### PR TITLE
More reliably determine when linked/aliased services are ready

### DIFF
--- a/pkg/controller/appstatus/endpoints.go
+++ b/pkg/controller/appstatus/endpoints.go
@@ -204,7 +204,7 @@ func (a *appStatusRenderer) readEndpoints() error {
 	return nil
 }
 
-func ingressTLSHosts(ctx context.Context, client kclient.Client, app *v1.AppInstance) (map[string]interface{}, error) {
+func ingressTLSHosts(ctx context.Context, client kclient.Client, app *v1.AppInstance) (map[string]struct{}, error) {
 	ingresses := &networkingv1.IngressList{}
 	err := client.List(ctx, ingresses, &kclient.ListOptions{
 		Namespace: app.Status.Namespace,
@@ -217,12 +217,12 @@ func ingressTLSHosts(ctx context.Context, client kclient.Client, app *v1.AppInst
 		return nil, err
 	}
 
-	ingressTLSHosts := map[string]interface{}{}
+	ingressTLSHosts := map[string]struct{}{}
 	for _, ingress := range ingresses.Items {
 		if ingress.Spec.TLS != nil {
 			for _, tls := range ingress.Spec.TLS {
 				for _, host := range tls.Hosts {
-					ingressTLSHosts[host] = nil
+					ingressTLSHosts[host] = struct{}{}
 				}
 			}
 		}

--- a/pkg/controller/appstatus/services.go
+++ b/pkg/controller/appstatus/services.go
@@ -2,7 +2,6 @@ package appstatus
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	name2 "github.com/acorn-io/baaah/pkg/name"
@@ -81,9 +80,7 @@ func (a *appStatusRenderer) readServices() error {
 			return err
 		} else {
 			s.Defined = s.Defined || !service.Status.HasService
-			s.UpToDate = service.Namespace != a.app.Status.Namespace ||
-				service.Annotations[labels.AcornAppGeneration] == strconv.Itoa(int(a.app.Generation))
-			s.UpToDate = s.Defined && s.UpToDate && (s.ServiceAcornReady || s.LinkOverride != "" || serviceDef.External != "" || service.Annotations[labels.AcornConfigHashAnnotation] == hash)
+			s.UpToDate = s.Defined && (service.Namespace != a.app.Status.Namespace || s.ServiceAcornReady || s.LinkOverride != "" || serviceDef.External != "" || service.Annotations[labels.AcornConfigHashAnnotation] == hash)
 			s.Ready = (s.Ready || !service.Status.HasService) && s.UpToDate
 			if s.ServiceAcornName != "" {
 				s.Ready = s.Ready && s.ServiceAcornReady

--- a/pkg/publish/ingress.go
+++ b/pkg/publish/ingress.go
@@ -286,7 +286,6 @@ func Ingress(req router.Request, svc *v1.ServiceInstance) (result []kclient.Obje
 		}
 
 		ingress := &networkingv1.Ingress{
-			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name.SafeConcatName(svc.Name, rules.name),
 				Namespace: svc.Namespace,


### PR DESCRIPTION
A linked or aliased service could be in a different namespace than the running app. This means that the hash check that is done is erroneous because the service instance that is inspected could be from an entirely different app. This change better detects with by moving the namespace check.

Additionally, a few small cleanup changes are included here.

