### PR TITLE
Remove -job suffix from generated service names 

### DIFF
--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
@@ -153,7 +153,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -303,7 +303,7 @@ metadata:
     acorn.io/job-name: job-name
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.job-name
-  name: job-name-job
+  name: job-name
   namespace: app-created-namespace
 spec:
   annotations:

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -297,7 +297,7 @@ metadata:
     acorn.io/job-name: job-name
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.job-name
-  name: job-name-job
+  name: job-name
   namespace: app-created-namespace
 spec:
   annotations:

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -239,7 +239,7 @@ metadata:
     acorn.io/job-name: job-name
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.job-name
-  name: job-name-job
+  name: job-name
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/pre-stop/job/expected.golden
@@ -134,7 +134,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.golden
@@ -134,7 +134,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.golden
@@ -149,7 +149,7 @@ metadata:
     acorn.io/job-name: job1
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.job1
-  name: job1-job
+  name: job1
   namespace: app-created-namespace
 spec:
   annotations:

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.golden
@@ -138,7 +138,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -493,7 +493,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -295,7 +295,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
@@ -235,7 +235,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
@@ -459,7 +459,7 @@ metadata:
     acorn.io/job-name: oneimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.oneimage
-  name: oneimage-job
+  name: oneimage
   namespace: app-created-namespace
 spec:
   appName: app-name
@@ -494,7 +494,7 @@ metadata:
     acorn.io/job-name: twoimage
     acorn.io/managed: "true"
     acorn.io/public-name: app-name.twoimage
-  name: twoimage-job
+  name: twoimage
   namespace: app-created-namespace
 spec:
   appName: app-name

--- a/pkg/services/acorn.go
+++ b/pkg/services/acorn.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/acorn-io/baaah/pkg/apply"
-	"github.com/acorn-io/baaah/pkg/name"
 	"github.com/acorn-io/baaah/pkg/typed"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/jobs"
@@ -125,7 +124,7 @@ func serviceNames(appInstance *v1.AppInstance) sets.Set[string] {
 		result.Insert(k)
 	}
 	for k := range appInstance.Status.AppSpec.Jobs {
-		result.Insert(jobServiceName(k))
+		result.Insert(k)
 	}
 	for k := range appInstance.Status.AppSpec.Routers {
 		result.Insert(k)
@@ -340,7 +339,7 @@ func forJobs(interpolator *secrets.Interpolator, appInstance *v1.AppInstance) (r
 
 		result = append(result, &v1.ServiceInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      jobServiceName(jobName),
+				Name:      jobName,
 				Namespace: appInstance.Status.Namespace,
 				Labels: labels.Managed(appInstance,
 					labels.AcornPublicName, publicname.ForChild(appInstance, jobName),
@@ -540,8 +539,4 @@ func getUngranted(appInstance *v1.AppInstance, service *v1.ServiceInstance) []v1
 	}
 
 	return ungranted
-}
-
-func jobServiceName(jobName string) string {
-	return name.SafeConcatName(jobName, "job")
 }


### PR DESCRIPTION
The names of jobs and containers already form a set; that is, the name
of a job or container must be unique across all jobs and containers.
Drop the -job suffix from the names of ServiceInstances generated for jobs
so that the DNS name matches the resource name.