### PR TITLE
Fix memory values in resolved offerings (#2389)

### DIFF
--- a/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
@@ -51,7 +51,7 @@ status:
   resolvedOfferings:
     containers:
       "":
-        memory: 0
+        memory: 1048576
       left:
         memory: 2097152
       oneimage:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/all-set/expected.golden
@@ -50,11 +50,11 @@ status:
   resolvedOfferings:
     containers:
       "":
-        memory: 0
+        memory: 1048576
       left:
-        memory: 0
+        memory: 1048576
       oneimage:
-        memory: 0
+        memory: 1048576
     region: local
   staged:
     appImage:


### PR DESCRIPTION
for #2389

My initial implementation of resolved offerings did not account for cases where the user overrode the memory request for all container in the app using the `--memory` argument with `acorn run`. This fixes that.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

