### PR TITLE
Update goreleaser for tap deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,7 +96,7 @@ brews:
     homepage: "https://acorn.io"
     license: "Apache 2.0"
     skip_upload: false
-    tap:
+    repository:
       owner: acorn-io
       name: homebrew-cli
       token: "{{ .Env.GH_PROJECT_TOKEN }}"


### PR DESCRIPTION
More info https://goreleaser.com/deprecations#brewstap

Signed-off-by: Darren Shepherd <darren@acorn.io>
