### PR TITLE
fix: resolved offerings: prioritize -m over Acornfile (#2415)

### DIFF
--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -102,10 +102,10 @@ func resolveComputeClass(req router.Request, appInstance *v1.AppInstance, config
 
 		if appInstance.Spec.Memory[name] != nil { // runtime-level overrides from the user
 			memory = appInstance.Spec.Memory[name]
-		} else if container.Memory != nil { // defaults in the acorn image
-			memory = container.Memory
 		} else if appInstance.Spec.Memory[""] != nil { // runtime-level overrides from the user for all containers in the app
 			memory = appInstance.Spec.Memory[""]
+		} else if container.Memory != nil { // defaults in the acorn image
+			memory = container.Memory
 		} else if cc != nil { // defaults from compute class
 			parsedMemory, err := computeclasses.ParseComputeClassMemory(cc.Memory)
 			if err != nil {

--- a/pkg/controller/resolvedofferings/computeclass_test.go
+++ b/pkg/controller/resolvedofferings/computeclass_test.go
@@ -84,3 +84,7 @@ func TestAcornfileOverrideComputeClass(t *testing.T) {
 func TestUserOverrideComputeClass(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/user-override-compute-class", Calculate)
 }
+
+func TestWithAcornfileMemoryAndSpecOverride(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/with-acornfile-memory-and-spec-override", Calculate)
+}

--- a/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/existing.yaml
@@ -1,0 +1,9 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/expected.golden
@@ -1,0 +1,66 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    "": 3145728
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        memory: 1048576
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: resolved-offerings
+  defaults: {}
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings:
+    containers:
+      "":
+        memory: 3145728
+      left:
+        memory: 3145728
+      oneimage:
+        memory: 3145728
+    region: local
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/input.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/input.yaml
@@ -1,0 +1,34 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    "": 3145728 # 3Mi - this will take precedence over the 1Mi specified below in the status.appSpec
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+        memory: 1048576 # 1Mi


### PR DESCRIPTION
for #2415

When a user does `-m <memory>` to override the memory for all containers in the app, this takes precedence over any specific values set in the Acornfile for a container. I previously had these in the wrong order of precedence, but this PR fixes that.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

