### PR TITLE
fix: credential secrets: handle case where no default is set (#2411)

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -107,7 +107,11 @@ func createSecret(ctx context.Context, c client.Client, app *apiv1.App, secretNa
 	promptOrder, _ := app.Status.AppSpec.Secrets[secretName].Params.GetData()["promptOrder"].([]string)
 	for _, key := range promptOrder {
 		if def, ok := app.Status.AppSpec.Secrets[secretName].Data[key]; ok {
-			value, err := prompt.Password(fmt.Sprintf("%s (default: %s)", key, def))
+			message := key
+			if def != "" {
+				message += fmt.Sprintf(" (default: %s)", def)
+			}
+			value, err := prompt.Password(message)
 			if err != nil {
 				return err
 			}
@@ -123,7 +127,11 @@ func createSecret(ctx context.Context, c client.Client, app *apiv1.App, secretNa
 			continue
 		}
 		def := app.Status.AppSpec.Secrets[secretName].Data[key]
-		value, err := prompt.Password(fmt.Sprintf("%s (default: %s)", key, def))
+		message := key
+		if def != "" {
+			message += fmt.Sprintf(" (default: %s)", def)
+		}
+		value, err := prompt.Password(message)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
for #2411

This adds a check so that we do not print `(default: <default>)` for fields in the secret that have no default value set.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

