### PR TITLE
enhance: allow dots in env vars

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -1396,7 +1396,7 @@ func parseEnvVar(key, value string) (result EnvVar, _ error) {
 		return result, nil
 	}
 
-	result.Name = key
+	result.Name = strings.ReplaceAll(key, ".", "\\.") // escape dots so they don't interfere with name separator '.' during interpolation
 
 	sec, ok, err = parseSecretReference(value)
 	if err != nil {

--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -1156,7 +1156,7 @@ func (in *EnvVars) UnmarshalJSON(data []byte) error {
 			if ok {
 				v.Secret = sec.SecretReference
 			} else {
-				v.Name = k
+				v.Name = strings.ReplaceAll(k, ".", "\\.") // escape dots so they don't interfere with name separator '.' during interpolation
 			}
 			*in = append(*in, (EnvVar)(v))
 		}

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -178,8 +178,8 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 				continue
 			}
 			if strings.Contains(env.Secret.Name, ".") {
-				interpolated, ok := interpolator.ToEnv(env.Name, fmt.Sprintf("@{secrets.%s.%s}", env.Secret.Name, env.Secret.Key))
-				if ok {
+				interpolated, noDotInKey := interpolator.ToEnv(env.Name, fmt.Sprintf("@{secrets.%s.%s}", env.Secret.Name, env.Secret.Key))
+				if noDotInKey {
 					interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
 					result = append(result, interpolated)
 				}
@@ -199,8 +199,8 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 		}
 	}
 	for _, appEnv := range appEnvs {
-		interpolated, ok := interpolator.ToEnv(appEnv.Name, appEnv.Value)
-		if ok {
+		interpolated, noDotInKey := interpolator.ToEnv(appEnv.Name, appEnv.Value)
+		if noDotInKey {
 			interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
 			result = append(result, interpolated)
 		}

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -165,8 +165,9 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 			if appEnvNames.Has(env.Name) {
 				continue
 			}
-			interpolated, ok := interpolator.ToEnv(env.Name, env.Value)
-			if ok {
+			interpolated, noDotInKey := interpolator.ToEnv(env.Name, env.Value)
+			if noDotInKey {
+				interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
 				result = append(result, interpolated)
 			}
 		} else {
@@ -179,6 +180,7 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 			if strings.Contains(env.Secret.Name, ".") {
 				interpolated, ok := interpolator.ToEnv(env.Name, fmt.Sprintf("@{secrets.%s.%s}", env.Secret.Name, env.Secret.Key))
 				if ok {
+					interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
 					result = append(result, interpolated)
 				}
 			} else {
@@ -199,6 +201,7 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 	for _, appEnv := range appEnvs {
 		interpolated, ok := interpolator.ToEnv(appEnv.Name, appEnv.Value)
 		if ok {
+			interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
 			result = append(result, interpolated)
 		}
 	}

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -127,6 +127,10 @@ func TestEnvironment(t *testing.T) {
 							{
 								Name: "foo",
 							},
+							{
+								Name:  "foo\\.bar",
+								Value: "baz",
+							},
 						},
 					},
 				},
@@ -141,6 +145,10 @@ func TestEnvironment(t *testing.T) {
 		{
 			Name:  "foo",
 			Value: "",
+		},
+		{
+			Name:  "foo.bar",
+			Value: "baz",
 		},
 	}, dep.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -561,6 +561,19 @@ func (i *Interpolator) getContainerOrJobName() string {
 	return i.jobName
 }
 
+// hasUnescapedDot checks if a string contains an unescaped dot (i.e., a dot not escaped by a backslash).
+func hasUnescapedDot(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			// Match if it's the first character or not escaped by a backslash
+			if i == 0 || s[i-1] != '\\' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 	prefix := i.getContainerOrJobName()
 	key = strings.TrimPrefix(key, prefix+".")
@@ -571,7 +584,7 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 		return corev1.EnvVar{
 			Name:  key,
 			Value: value,
-		}, !strings.Contains(key, ".")
+		}, !hasUnescapedDot(key)
 	}
 
 	newValue, err := i.Replace(value)
@@ -580,13 +593,13 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 		return corev1.EnvVar{
 			Name:  newKey,
 			Value: value,
-		}, !strings.Contains(key, ".")
+		}, !hasUnescapedDot(key)
 	}
 	if value == newValue {
 		return corev1.EnvVar{
 			Name:  newKey,
 			Value: value,
-		}, !strings.Contains(newKey, ".")
+		}, !hasUnescapedDot(newKey)
 	}
 
 	return corev1.EnvVar{
@@ -599,7 +612,7 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 				Key: i.addContent(newValue),
 			},
 		},
-	}, !strings.Contains(newKey, ".")
+	}, !hasUnescapedDot(newKey)
 }
 
 func (i *Interpolator) Objects() []kclient.Object {


### PR DESCRIPTION
Before, one couldn't have dots `.` in env var keys, but services like OpenSearch use them quite a bit.
We're using `.` as hierarchy separators during interpolation, which caused dotted env var keys to be ignored silently.
Now we're escaping dotted keys first and restoring the original later.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

