### PR TITLE
fix: credential secrets: avoid the race condition better (#2410)

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -53,7 +53,8 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		if c, err := a.client.CreateDefault(); err == nil {
 			app, err := c.AppGet(cmd.Context(), args[0])
 			if err == nil {
-				return login.Secrets(cmd.Context(), c, app)
+				_, err = login.Secrets(cmd.Context(), c, app)
+				return err
 			} else if !(apierrors.IsNotFound(err) || apierrors.IsForbidden(err)) {
 				return err
 			}

--- a/pkg/log/default_log.go
+++ b/pkg/log/default_log.go
@@ -60,7 +60,6 @@ func (d *DefaultLoggerImpl) AppStatus(ready bool, msg string, app *apiv1.App) {
 			app.Status.ObservedGeneration > d.lastLoginGeneration &&
 			(app.Status.ResolvedOfferings.Region == apiv1.LocalRegion ||
 				time.Since(d.lastLoginTime) > 5*time.Second) {
-
 			if err := login.Secrets(d.ctx, d.client, app); err != nil {
 				go d.Errorf(err.Error())
 			} else {

--- a/pkg/log/default_log.go
+++ b/pkg/log/default_log.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 	"sync"
-	"time"
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/client"
@@ -27,7 +26,6 @@ type DefaultLoggerImpl struct {
 	client              client.Client
 	containerColors     map[string]pterm.Color
 	lastLoginGeneration int64
-	lastLoginTime       time.Time
 }
 
 func (d *DefaultLoggerImpl) Errorf(format string, args ...interface{}) {
@@ -48,26 +46,14 @@ func (d *DefaultLoggerImpl) AppStatus(ready bool, msg string, app *apiv1.App) {
 	} else {
 		d.lock.Lock()
 		defer d.lock.Unlock()
-
-		// Prompt the user to fill in a credential secret if:
-		// - The app status indicates a login is needed, AND
-		// - The app has been updated since the last time the user logged in, AND
-		// - (The app is running locally OR the last login was more than 5 seconds ago)
-		// The last condition is needed to avoid a race condition in the SaaS where the user is prompted multiple
-		// times in a row to fill in a credential secret. We don't want to prompt a user more than once within
-		// five seconds in order to avoid the double prompt.
-		if app.Status.AppStatus.LoginRequired &&
-			app.Status.ObservedGeneration > d.lastLoginGeneration &&
-			(app.Status.ResolvedOfferings.Region == apiv1.LocalRegion ||
-				time.Since(d.lastLoginTime) > 5*time.Second) {
-			if err := login.Secrets(d.ctx, d.client, app); err != nil {
+		if app.Status.AppStatus.LoginRequired && app.Status.ObservedGeneration > d.lastLoginGeneration {
+			updatedApp, err := login.Secrets(d.ctx, d.client, app)
+			if err != nil {
 				go d.Errorf(err.Error())
 			} else {
-				d.lastLoginGeneration = app.Generation
-				d.lastLoginTime = time.Now()
+				d.lastLoginGeneration = updatedApp.Generation
 			}
 		}
-
 		pterm.Println(pterm.LightYellow(msg))
 	}
 }


### PR DESCRIPTION
for #2410

Turns out my previous PR to fix this race condition introduced another problem. I was previously waiting until all containers in the app were marked as Defined in their status before prompting the user to fill in the credential secret, but the containers will never be Defined if their `env` references anything inside of the secret, since the secret needs to be created first.

This new approach is much better (shoutout to Mr. Thedadams for the solution). We bubble up the app that is returned from our Update and use that as the basis for the generation, and the user is prompted only one time as a result.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

