### PR TITLE
fix: login: eliminate possible nil dereference

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -21,7 +21,9 @@ func Secrets(ctx context.Context, c client.Client, app *apiv1.App) (*apiv1.App, 
 			if err != nil {
 				return nil, err
 			}
-			app = updatedApp
+			if updatedApp != nil {
+				app = updatedApp
+			}
 		}
 	}
 
@@ -88,7 +90,7 @@ func bindSecret(ctx context.Context, c client.Client, app *apiv1.App, targetSecr
 	appName := parts[0]
 	targetSecretName = strings.Join(parts[1:], ".")
 
-	updatedApp, err := c.AppUpdate(ctx, appName, &client.AppUpdateOptions{
+	return c.AppUpdate(ctx, appName, &client.AppUpdateOptions{
 		Secrets: []v1.SecretBinding{
 			{
 				Secret: overrideSecretName,
@@ -96,7 +98,6 @@ func bindSecret(ctx context.Context, c client.Client, app *apiv1.App, targetSecr
 			},
 		},
 	})
-	return updatedApp, err
 }
 
 func createSecret(ctx context.Context, c client.Client, app *apiv1.App, secretName string) (*apiv1.App, error) {


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

