### PR TITLE
Quota memory limit

### DIFF
--- a/pkg/controller/quota/quota.go
+++ b/pkg/controller/quota/quota.go
@@ -142,7 +142,7 @@ func addCompute(containers map[string]v1.Container, appInstance *v1.AppInstance,
 		// Add the memory/cpu requests to the quota request for each container at the scale specified
 		for i := 0; i < replicas(container.Scale); i++ {
 			quotaRequest.Spec.Resources.CPU.Add(requirements.Requests["cpu"])
-			quotaRequest.Spec.Resources.Memory.Add(requirements.Requests["memory"])
+			quotaRequest.Spec.Resources.Memory.Add(requirements.Limits["memory"])
 		}
 
 		// Recurse over any sidecars. Since sidecars can't have sidecars, this is safe.

--- a/pkg/controller/quota/quota_test.go
+++ b/pkg/controller/quota/quota_test.go
@@ -22,3 +22,7 @@ func TestDefaultStatusVolumeSize(t *testing.T) {
 func TestImplicitPVBind(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/implicit-pv-bind", EnsureQuotaRequest)
 }
+
+func TestOverProvisioned(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/over-provisioned", EnsureQuotaRequest)
+}

--- a/pkg/controller/quota/testdata/over-provisioned/existing.yaml
+++ b/pkg/controller/quota/testdata/over-provisioned/existing.yaml
@@ -1,0 +1,11 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+  annotations:
+    acorn.io/enforced-quota: "true"
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/quota/testdata/over-provisioned/expected.golden
+++ b/pkg/controller/quota/testdata/over-provisioned/expected.golden
@@ -1,0 +1,31 @@
+`apiVersion: internal.admin.acorn.io/v1
+kind: QuotaRequestInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+spec:
+  resources:
+    apps: 0
+    containers: 1
+    cpu: 250m
+    images: 0
+    jobs: 1
+    memory: 2Gi
+    secrets: 1
+    volumeStorage: 10G
+    volumes: 1
+status:
+  allocatedResources:
+    apps: 0
+    containers: 0
+    cpu: "0"
+    images: 0
+    jobs: 0
+    memory: "0"
+    secrets: 0
+    volumeStorage: "0"
+    volumes: 0
+`

--- a/pkg/controller/quota/testdata/over-provisioned/input.yaml
+++ b/pkg/controller/quota/testdata/over-provisioned/input.yaml
@@ -1,0 +1,68 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: image-name
+  computeClass:
+    "": sample-compute-class
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      container-name:
+        sidecars:
+          sidecar-name:
+            image: "image-name"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+    jobs:
+      job-name:
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+    secrets:
+      test:
+        params:
+          characters: bcdfghjklmnpqrstvwxz2456789
+          length: 54
+        type: token
+    volumes:
+      test:
+        accessModes:
+        - readWriteOnce
+  scheduling:
+    container-name:
+      requirements:
+        limits:
+          memory: 1Gi # over-provisioned, notice the 512Mi request
+        requests:
+          cpu: 125m
+          memory: 512Mi
+    sidecar-name:
+      requirements:
+        limits:
+          memory: 1Gi # over-provisioned, notice the 512Mi request
+        requests:
+          cpu: 125m
+          memory: 512Mi


### PR DESCRIPTION
This PR switches quota requests to calculate memory usage based on the limit as opposed to the request. This allows for apps using a compute-classes with the `requestScaler` field to get quota'd for what they asked for instead of what they actually get.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

