### PR TITLE
fix: calculate resolvedOfferings for sidecars

### DIFF
--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
@@ -54,7 +54,7 @@ status:
       left:
         class: sample-compute-class
         cpuScaler: 0.25
-        memory: 2097152
+        memory: 1048576
       oneimage:
         class: sample-compute-class
         cpuScaler: 0.25

--- a/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
@@ -53,7 +53,7 @@ status:
       "":
         memory: 1048576
       left:
-        memory: 2097152
+        memory: 1048576
       oneimage:
         memory: 2097152
     region: local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/container/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/container/expected.golden
@@ -52,7 +52,7 @@ status:
       "":
         memory: 0
       left:
-        memory: 1048576
+        memory: 0
       oneimage:
         memory: 1048576
     region: local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/job/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/job/expected.golden
@@ -52,7 +52,7 @@ status:
       "":
         memory: 0
       left:
-        memory: 1048576
+        memory: 0
       oneimage:
         memory: 1048576
     region: local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/overwrite-acornfile-memory/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/overwrite-acornfile-memory/expected.golden
@@ -53,7 +53,7 @@ status:
       "":
         memory: 0
       left:
-        memory: 1048576
+        memory: 0
       oneimage:
         memory: 1048576
     region: local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/sidecar/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/sidecar/expected.golden
@@ -52,7 +52,7 @@ status:
       "":
         memory: 0
       left:
-        memory: 0
+        memory: 1048576
       oneimage:
         memory: 0
     region: local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
@@ -56,7 +56,7 @@ status:
       left:
         class: sample-compute-class
         cpuScaler: 0.25
-        memory: 3145728
+        memory: 1048576
       oneimage:
         class: sample-compute-class
         cpuScaler: 0.25

--- a/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory/expected.golden
@@ -51,7 +51,7 @@ status:
       "":
         memory: 0
       left:
-        memory: 1048576
+        memory: 0
       oneimage:
         memory: 1048576
     region: local


### PR DESCRIPTION
@tylerslaton reported this issue to me this morning. My previous implementation of this was taking the resolved offerings for a container and setting them for all sidecars on the container as well. Not sure what I was thinking, because that was very incorrect. With this PR, sidecars get their offerings resolved the same way that normal containers do.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

