### PR TITLE
fix: unescape dots in env names (#2442)

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -177,7 +177,7 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 			if appEnvNames.Has(env.Name) {
 				continue
 			}
-			if strings.Contains(env.Secret.Name, ".") {
+			if secrets.HasUnescapedDot(env.Secret.Name) {
 				interpolated, noDotInKey := interpolator.ToEnv(env.Name, fmt.Sprintf("@{secrets.%s.%s}", env.Secret.Name, env.Secret.Key))
 				if noDotInKey {
 					interpolated.Name = strings.ReplaceAll(interpolated.Name, "\\.", ".") // restore dots that were escaped during unmarshalling
@@ -185,7 +185,7 @@ func toEnv(envs []v1.EnvVar, appEnvs []v1.NameValue, interpolator *secrets.Inter
 				}
 			} else {
 				result = append(result, corev1.EnvVar{
-					Name: env.Name,
+					Name: strings.ReplaceAll(env.Name, "\\.", "."), // restore dots that were escaped during unmarshalling
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -131,6 +131,13 @@ func TestEnvironment(t *testing.T) {
 								Name:  "foo\\.bar",
 								Value: "baz",
 							},
+							{
+								Name: "foo\\.bar\\.baz",
+								Secret: v1.SecretReference{
+									Name: "somesecret",
+									Key:  "somesecretkey",
+								},
+							},
 						},
 					},
 				},
@@ -149,6 +156,17 @@ func TestEnvironment(t *testing.T) {
 		{
 			Name:  "foo.bar",
 			Value: "baz",
+		},
+		{
+			Name: "foo.bar.baz",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "somesecretkey",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "somesecret",
+					},
+				},
+			},
 		},
 	}, dep.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -561,8 +561,8 @@ func (i *Interpolator) getContainerOrJobName() string {
 	return i.jobName
 }
 
-// hasUnescapedDot checks if a string contains an unescaped dot (i.e., a dot not escaped by a backslash).
-func hasUnescapedDot(s string) bool {
+// HasUnescapedDot checks if a string contains an unescaped dot (i.e., a dot not escaped by a backslash).
+func HasUnescapedDot(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if s[i] == '.' {
 			// Match if it's the first character or not escaped by a backslash
@@ -584,7 +584,7 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 		return corev1.EnvVar{
 			Name:  key,
 			Value: value,
-		}, !hasUnescapedDot(key)
+		}, !HasUnescapedDot(key)
 	}
 
 	newValue, err := i.Replace(value)
@@ -593,13 +593,13 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 		return corev1.EnvVar{
 			Name:  newKey,
 			Value: value,
-		}, !hasUnescapedDot(key)
+		}, !HasUnescapedDot(key)
 	}
 	if value == newValue {
 		return corev1.EnvVar{
 			Name:  newKey,
 			Value: value,
-		}, !hasUnescapedDot(newKey)
+		}, !HasUnescapedDot(newKey)
 	}
 
 	return corev1.EnvVar{
@@ -612,7 +612,7 @@ func (i *Interpolator) ToEnv(key, value string) (corev1.EnvVar, bool) {
 				Key: i.addContent(newValue),
 			},
 		},
-	}, !hasUnescapedDot(newKey)
+	}, !HasUnescapedDot(newKey)
 }
 
 func (i *Interpolator) Objects() []kclient.Object {


### PR DESCRIPTION
Missed a few spots to unescape dots in env var keys again after they've been escaped during unmarshalling.

Previous PR: https://github.com/acorn-io/runtime/pull/2428

Ref #2442

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

