### PR TITLE
fix: handle multiple compute classes in a project

### DIFF
--- a/integration/helper/project.go
+++ b/integration/helper/project.go
@@ -68,7 +68,6 @@ func TempProjectWithRegions(t *testing.T, client client.WithWatch, regions []str
 	})
 
 	return project
-
 }
 
 func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {

--- a/integration/helper/project.go
+++ b/integration/helper/project.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {
+func TempProjectWithRegions(t *testing.T, client client.WithWatch, regions []string) *v1.ProjectInstance {
 	t.Helper()
 	project := &v1.ProjectInstance{
 		ObjectMeta: metav1.ObjectMeta{
@@ -26,7 +26,7 @@ func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {
 		},
 		Spec: v1.ProjectInstanceSpec{
 			DefaultRegion:    apiv1.LocalRegion,
-			SupportedRegions: []string{apiv1.LocalRegion},
+			SupportedRegions: regions,
 		},
 	}
 
@@ -68,6 +68,12 @@ func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {
 	})
 
 	return project
+
+}
+
+func TempProject(t *testing.T, client client.WithWatch) *v1.ProjectInstance {
+	t.Helper()
+	return TempProjectWithRegions(t, client, []string{apiv1.LocalRegion})
 }
 
 // createAllowAllIAR creates an ImageAllowRule that allows all images and has no extra rules

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -931,6 +931,310 @@ func TestDeployParam(t *testing.T) {
 	assert.Equal(t, "5", appInstance.Status.AppSpec.Containers["foo"].Environment[0].Value)
 }
 
+func TestMultipleDefaultComputeClass(t *testing.T) {
+	helper.StartController(t)
+	cfg := helper.StartAPI(t)
+	project := helper.TempProjectWithRegions(t, helper.MustReturn(kclient.Default), []string{apiv1.LocalRegion, "local2"})
+	kclient := helper.MustReturn(kclient.Default)
+	c, err := client.New(cfg, "", project.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := helper.GetCTX(t)
+
+	checks := []struct {
+		name              string
+		noComputeClass    bool
+		testDataDirectory string
+		region            string
+		computeClasses    []adminv1.ProjectComputeClassInstance
+		expected          map[string]v1.Scheduling
+		waitFor           func(obj *v1.AppInstance) bool
+		fail              bool
+	}{
+		{
+			name:              "local-default",
+			testDataDirectory: "./testdata/simple",
+			region:            apiv1.LocalRegion,
+			computeClasses: []adminv1.ProjectComputeClassInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "512Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{apiv1.LocalRegion},
+				},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "acorn-test-custom-2",
+					Namespace: c.GetNamespace(),
+				},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "513Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{"local2"},
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
+					},
+				}},
+			},
+			waitFor: func(obj *v1.AppInstance) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "local2-default",
+			testDataDirectory: "./testdata/simple",
+			region:            "local2",
+			computeClasses: []adminv1.ProjectComputeClassInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "512Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{apiv1.LocalRegion},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom-2",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "513Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{"local2"},
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("513Mi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("513Mi"),
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
+					},
+				}},
+			},
+			waitFor: func(obj *v1.AppInstance) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "acornfile-computeclass",
+			testDataDirectory: "./testdata/computeclass",
+			region:            apiv1.LocalRegion,
+			computeClasses: []adminv1.ProjectComputeClassInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "512Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{apiv1.LocalRegion},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom-2",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "513Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{"local2"},
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
+					},
+				}},
+			},
+			waitFor: func(obj *v1.AppInstance) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "acornfile-computeclass-wrong-region",
+			testDataDirectory: "./testdata/computeclass",
+			region:            apiv1.LocalRegion,
+			computeClasses: []adminv1.ProjectComputeClassInstance{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom-2",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "512Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{apiv1.LocalRegion},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom",
+						Namespace: c.GetNamespace(),
+					},
+					Default: true,
+					Memory: adminv1.ComputeClassMemory{
+						Default: "513Mi",
+						Max:     "1Gi",
+						Min:     "512Mi",
+					},
+					SupportedRegions: []string{"local2"},
+				},
+			},
+			fail: true,
+		},
+	}
+
+	for _, tt := range checks {
+		clusterObjects := make([]crClient.Object, 0, len(tt.computeClasses))
+		for _, pcc := range tt.computeClasses {
+			cc := adminv1.ClusterComputeClassInstance(pcc)
+			clusterObjects = append(clusterObjects, cc.DeepCopy())
+		}
+		projectObjects := make([]crClient.Object, 0, len(tt.computeClasses))
+		for _, cc := range tt.computeClasses {
+			projectObjects = append(projectObjects, cc.DeepCopy())
+		}
+		// Perform the same test cases on both Project and Cluster ComputeClasses
+		for kind, computeClasses := range map[string][]crClient.Object{"projectcomputeclass": projectObjects, "clustercomputeclass": clusterObjects} {
+			testcase := fmt.Sprintf("%v-%v", kind, tt.name)
+			t.Run(testcase, func(t *testing.T) {
+				if !tt.noComputeClass {
+					for _, computeClass := range computeClasses {
+						if err := kclient.Create(ctx, computeClass); err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					// Clean-up and guarantee the computeclass doesn't exist after this test run
+					t.Cleanup(func() {
+						for _, computeClass := range computeClasses {
+							if err = kclient.Delete(context.Background(), computeClass); err != nil && !apierrors.IsNotFound(err) {
+								t.Fatal(err)
+							}
+							err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+								lookingFor := computeClass
+								err := kclient.Get(ctx, router.Key(computeClass.GetNamespace(), computeClass.GetName()), lookingFor)
+								return lookingFor, err
+							})
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+					})
+				}
+
+				image, err := c.AcornImageBuild(ctx, tt.testDataDirectory+"/Acornfile", &client.AcornImageBuildOptions{
+					Cwd: tt.testDataDirectory,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Assign a name for the test case so no collisions occur
+				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{
+					Name:   testcase,
+					Region: tt.region,
+				})
+				if err == nil && tt.fail {
+					t.Fatal("expected error, got nil")
+				} else if err != nil {
+					if !tt.fail {
+						t.Fatal(err)
+					}
+				}
+
+				// Clean-up and gurantee the app doesn't exist after this test run
+				if app != nil {
+					t.Cleanup(func() {
+						if err = kclient.Delete(context.Background(), app); err != nil && !apierrors.IsNotFound(err) {
+							t.Fatal(err)
+						}
+						err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+							lookingFor := app
+							err := kclient.Get(ctx, router.Key(app.GetName(), app.GetNamespace()), lookingFor)
+							return lookingFor, err
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+					})
+				}
+
+				if tt.waitFor != nil {
+					appInstance := &v1.AppInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      app.Name,
+							Namespace: app.Namespace,
+						},
+					}
+					appInstance = helper.WaitForObject(t, kclient.Watch, new(v1.AppInstanceList), appInstance, tt.waitFor)
+					assert.EqualValues(t, appInstance.Status.Scheduling, tt.expected, "generated scheduling rules are incorrect")
+				}
+			})
+		}
+	}
+}
+
 func TestUsingComputeClasses(t *testing.T) {
 	helper.StartController(t)
 	c, _ := helper.ClientAndProject(t)
@@ -1160,7 +1464,7 @@ func TestUsingComputeClasses(t *testing.T) {
 	for _, tt := range checks {
 		asClusterComputeClass := adminv1.ClusterComputeClassInstance(tt.computeClass)
 		// Perform the same test cases on both Project and Cluster ComputeClasses
-		for kind, computeClass := range map[string]crClient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
+		for kind, computeClass := range map[string]crClient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": asClusterComputeClass.DeepCopy()} {
 			testcase := fmt.Sprintf("%v-%v", kind, tt.name)
 			t.Run(testcase, func(t *testing.T) {
 				if !tt.noComputeClass {
@@ -1192,7 +1496,10 @@ func TestUsingComputeClasses(t *testing.T) {
 				}
 
 				// Assign a name for the test case so no collisions occur
-				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{Name: testcase})
+				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{
+					Name:   testcase,
+					Region: apiv1.LocalRegion,
+				})
 				if err == nil && tt.fail {
 					t.Fatal("expected error, got nil")
 				} else if err != nil {

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1497,10 +1497,7 @@ func TestUsingComputeClasses(t *testing.T) {
 				}
 
 				// Assign a name for the test case so no collisions occur
-				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{
-					Name:   testcase,
-					Region: apiv1.LocalRegion,
-				})
+				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{Name: testcase})
 				if err == nil && tt.fail {
 					t.Fatal("expected error, got nil")
 				} else if err != nil {

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1132,7 +1132,7 @@ func TestUsingComputeClasses(t *testing.T) {
 		},
 		{
 			name:              "unsupported-region",
-			testDataDirectory: "./testdata/simple",
+			testDataDirectory: "./testdata/computeclass",
 			computeClass: adminv1.ProjectComputeClassInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "acorn-test-custom",

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -971,10 +971,11 @@ func TestMultipleDefaultComputeClass(t *testing.T) {
 					},
 					SupportedRegions: []string{apiv1.LocalRegion},
 				},
-				{ObjectMeta: metav1.ObjectMeta{
-					Name:      "acorn-test-custom-2",
-					Namespace: c.GetNamespace(),
-				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "acorn-test-custom-2",
+						Namespace: c.GetNamespace(),
+					},
 					Default: true,
 					Memory: adminv1.ComputeClassMemory{
 						Default: "513Mi",

--- a/pkg/apis/internal.admin.acorn.io/v1/default.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"sort"
 
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) (*ClusterComputeClassInstance, error) {
+func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, region string) (*ClusterComputeClassInstance, error) {
 	clusterComputeClasses := ClusterComputeClassInstanceList{}
 	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
 		return nil, err
@@ -20,6 +21,9 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) 
 
 	var defaultCCC *ClusterComputeClassInstance
 	for _, clusterComputeClass := range clusterComputeClasses.Items {
+		if !slices.Contains(clusterComputeClass.SupportedRegions, region) {
+			continue
+		}
 		if clusterComputeClass.Default {
 			if defaultCCC != nil {
 				return nil, fmt.Errorf(
@@ -34,7 +38,7 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) 
 	return defaultCCC, nil
 }
 
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, namespace string) (*ProjectComputeClassInstance, error) {
+func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, namespace, region string) (*ProjectComputeClassInstance, error) {
 	projectComputeClasses := ProjectComputeClassInstanceList{}
 	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
 		return nil, err
@@ -46,6 +50,9 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 
 	var defaultPCC *ProjectComputeClassInstance
 	for _, projectComputeClass := range projectComputeClasses.Items {
+		if !slices.Contains(projectComputeClass.SupportedRegions, region) {
+			continue
+		}
 		if projectComputeClass.Default {
 			if defaultPCC != nil {
 				return nil, fmt.Errorf(
@@ -60,15 +67,15 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 	return defaultPCC, nil
 }
 
-func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace string) (string, error) {
-	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace)
+func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace, region string) (string, error) {
+	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace, region)
 	if err != nil {
 		return "", err
 	} else if pcc != nil {
 		return pcc.Name, nil
 	}
 
-	ccc, err := getCurrentClusterComputeClassDefault(ctx, c)
+	ccc, err := getCurrentClusterComputeClassDefault(ctx, c, region)
 	if err != nil {
 		return "", err
 	} else if ccc != nil {

--- a/pkg/computeclasses/computeclasses.go
+++ b/pkg/computeclasses/computeclasses.go
@@ -146,11 +146,11 @@ func GetComputeClassNameForWorkload(workload string, container internalv1.Contai
 
 // GetClassForWorkload determines what ComputeClass should be used for the given appInstance, container and
 // workload.
-func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses internalv1.ComputeClassMap, container internalv1.Container, workload, namespace string) (*internaladminv1.ProjectComputeClassInstance, error) {
+func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses internalv1.ComputeClassMap, container internalv1.Container, workload, namespace, region string) (*internaladminv1.ProjectComputeClassInstance, error) {
 	var err error
 	ccName := GetComputeClassNameForWorkload(workload, container, computeClasses)
 	if ccName == "" {
-		ccName, err = internaladminv1.GetDefaultComputeClass(ctx, c, namespace)
+		ccName, err = internaladminv1.GetDefaultComputeClass(ctx, c, namespace, region)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/defaults/memory.go
+++ b/pkg/controller/defaults/memory.go
@@ -22,13 +22,8 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 	)
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
-	} else if appInstance.Spec.Region != "" {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Spec.Region)
-		if err != nil {
-			return err
-		}
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.Defaults.Region)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}
@@ -65,7 +60,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 func addWorkloadMemoryDefault(req router.Request, appInstance *v1.AppInstance, configDefault *int64, containers map[string]v1.Container) error {
 	for name, container := range containers {
 		memory := configDefault
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.Spec.Region)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/defaults/memory.go
+++ b/pkg/controller/defaults/memory.go
@@ -23,7 +23,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Spec.Region)
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 func addWorkloadMemoryDefault(req router.Request, appInstance *v1.AppInstance, configDefault *int64, containers map[string]v1.Container) error {
 	for name, container := range containers {
 		memory := configDefault
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.Spec.Region)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/existing.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/existing.yaml
@@ -6,6 +6,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -27,6 +28,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/existing.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/existing.yaml
@@ -7,6 +7,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -29,6 +30,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -21,8 +21,13 @@ func resolveComputeClasses(req router.Request, cfg *apiv1.Config, appInstance *v
 	)
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
-	} else {
+	} else if appInstance.GetRegion() != "" {
 		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.GetRegion())
+		if err != nil {
+			return err
+		}
+	} else {
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.ResolvedOfferings.Region)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -22,7 +22,7 @@ func resolveComputeClasses(req router.Request, cfg *apiv1.Config, appInstance *v
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Spec.Region)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func resolveComputeClassForContainer(req router.Request, appInstance *v1.AppInst
 	)
 
 	// First, get the compute class for the workload
-	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace)
+	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace, appInstance.Spec.Region)
 	if err != nil {
 		return v1.ContainerResolvedOffering{}, err
 	}

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -21,13 +21,8 @@ func resolveComputeClasses(req router.Request, cfg *apiv1.Config, appInstance *v
 	)
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
-	} else if appInstance.Spec.Region != "" {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Spec.Region)
-		if err != nil {
-			return err
-		}
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.ResolvedOfferings.Region)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}
@@ -104,7 +99,7 @@ func resolveComputeClassForContainer(req router.Request, appInstance *v1.AppInst
 	)
 
 	// First, get the compute class for the workload
-	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace, appInstance.Spec.Region)
+	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace, appInstance.GetRegion())
 	if err != nil {
 		return v1.ContainerResolvedOffering{}, err
 	}

--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/existing.yaml
@@ -16,6 +16,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
@@ -50,7 +50,8 @@ status:
     containers:
       "":
         class: sample-compute-class
-        memory: 0
+        cpuScaler: 0.25
+        memory: 1048576
       left:
         class: sample-compute-class
         cpuScaler: 0.25

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/existing.yaml
@@ -16,6 +16,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
@@ -49,7 +49,8 @@ status:
     containers:
       "":
         class: sample-compute-class
-        memory: 0
+        cpuScaler: 0.25
+        memory: 1048576
       left:
         class: sample-compute-class
         cpuScaler: 0.25

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
@@ -6,6 +6,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -27,6 +28,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-should-error/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-should-error/existing.yaml
@@ -7,6 +7,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -29,6 +30,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/existing.yaml
@@ -16,9 +16,10 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
-  max: 3Mi # 2Mi
+  max: 2Mi # 2Mi
   default: 1Mi # 1Mi
 affinity:
   nodeAffinity:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
@@ -52,7 +52,8 @@ status:
     containers:
       "":
         class: sample-compute-class
-        memory: 0
+        cpuScaler: 0.25
+        memory: 1048576
       left:
         class: sample-compute-class
         cpuScaler: 0.25

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -59,7 +59,7 @@ func addScheduling(req router.Request, appInstance *v1.AppInstance, workloads ma
 			tolerations []corev1.Toleration
 		)
 
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.Spec.Region)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -59,7 +59,7 @@ func addScheduling(req router.Request, appInstance *v1.AppInstance, workloads ma
 			tolerations []corev1.Toleration
 		)
 
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.Spec.Region)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/existing.yaml
@@ -6,4 +6,5 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 priorityClassName: does-not-exist

--- a/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/expected.golden
+++ b/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/expected.golden
@@ -7,6 +7,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
 status:
   appImage:
     buildContext: {}

--- a/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/input.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
 status:
   defaults:
     memory:

--- a/pkg/controller/scheduling/testdata/computeclass/priority-class/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/priority-class/existing.yaml
@@ -12,4 +12,5 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 priorityClassName: exists

--- a/pkg/controller/scheduling/testdata/computeclass/priority-class/expected.golden
+++ b/pkg/controller/scheduling/testdata/computeclass/priority-class/expected.golden
@@ -7,6 +7,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
 status:
   appImage:
     buildContext: {}

--- a/pkg/controller/scheduling/testdata/computeclass/priority-class/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/priority-class/input.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
 status:
   defaults:
     memory:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
@@ -6,6 +6,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -27,6 +28,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
   memory:
     oneimage: 1048576 # 1Mi
 status:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
   memory:
     oneimage: 1048576 # 1Mi
 status:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/existing.yaml
@@ -7,6 +7,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -29,6 +30,7 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
+supportedRegions: [local]
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
   memory:
     oneimage: 1048576 # 1Mi
 status:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
@@ -6,6 +6,7 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
+  region: local
   memory:
     oneimage: 1048576 # 1Mi
 status:

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -584,13 +584,20 @@ func (s *Validator) checkScheduling(ctx context.Context, params *apiv1.App, proj
 		return append(validationErrors, field.Invalid(field.NewPath("spec", "image"), params.Spec.Image, fmt.Sprintf("error listing compute classes: %v", err)))
 	}
 
+	filteredComputeClasses := new(apiv1.ComputeClassList)
+	for _, cc := range computeClasses.Items {
+		if slices.Contains(cc.SupportedRegions, params.Spec.Region) || slices.Contains(cc.SupportedRegions, defaultRegion) {
+			filteredComputeClasses.Items = append(filteredComputeClasses.Items, cc)
+		}
+	}
+
 	err := validateMemoryRunFlags(memory, workloads)
 	if err != nil {
 		validationErrors = append(validationErrors, err...)
 	}
 
 	for workload, container := range workloads {
-		cc, err := getClassForWorkload(computeClasses, computeClass, container, workload)
+		cc, err := getClassForWorkload(filteredComputeClasses, computeClass, container, workload)
 		if err != nil {
 			validationErrors = append(validationErrors, field.NotFound(field.NewPath("computeclass"), err.Error()))
 		}

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -584,9 +584,11 @@ func (s *Validator) checkScheduling(ctx context.Context, params *apiv1.App, proj
 		return append(validationErrors, field.Invalid(field.NewPath("spec", "image"), params.Spec.Image, fmt.Sprintf("error listing compute classes: %v", err)))
 	}
 
+	// filter compute classes that don't match the relevant regions
 	filteredComputeClasses := new(apiv1.ComputeClassList)
 	for _, cc := range computeClasses.Items {
-		if slices.Contains(cc.SupportedRegions, params.Spec.Region) || slices.Contains(cc.SupportedRegions, defaultRegion) {
+		// if the region is set in the spec then we aren't concerned with the defaultRegion
+		if (params.Spec.Region != "" && slices.Contains(cc.SupportedRegions, params.Spec.Region)) || slices.Contains(cc.SupportedRegions, defaultRegion) {
 			filteredComputeClasses.Items = append(filteredComputeClasses.Items, cc)
 		}
 	}

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -588,7 +588,7 @@ func (s *Validator) checkScheduling(ctx context.Context, params *apiv1.App, proj
 	filteredComputeClasses := new(apiv1.ComputeClassList)
 	for _, cc := range computeClasses.Items {
 		// if the region is set in the spec then we aren't concerned with the defaultRegion
-		if (params.Spec.Region != "" && slices.Contains(cc.SupportedRegions, params.Spec.Region)) || slices.Contains(cc.SupportedRegions, defaultRegion) {
+		if (params.Spec.Region != "" && slices.Contains(cc.SupportedRegions, params.Spec.Region)) || (params.Spec.Region == "" && slices.Contains(cc.SupportedRegions, defaultRegion)) {
 			filteredComputeClasses.Items = append(filteredComputeClasses.Items, cc)
 		}
 	}


### PR DESCRIPTION
acorn-io/manager#1819

Handle the case of multiple compute classes being configured as default for a project spanning multiple regions.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

