### PR TITLE
fix: add CPU field to resolvedOfferings and change QuotaRequests to use resolvedOfferings

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -282,9 +282,9 @@ type VolumeResolvedOffering struct {
 }
 
 type ContainerResolvedOffering struct {
-	Class     string   `json:"class,omitempty"`
-	Memory    *int64   `json:"memory,omitempty"`
-	CPUScaler *float64 `json:"cpuScaler,omitempty"`
+	Class  string `json:"class,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
+	CPU    *int64 `json:"cpu,omitempty"`
 }
 
 type Scheduling struct {

--- a/pkg/apis/internal.acorn.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/internal.acorn.io/v1/zz_generated.deepcopy.go
@@ -1408,9 +1408,9 @@ func (in *ContainerResolvedOffering) DeepCopyInto(out *ContainerResolvedOffering
 		*out = new(int64)
 		**out = **in
 	}
-	if in.CPUScaler != nil {
-		in, out := &in.CPUScaler, &out.CPUScaler
-		*out = new(float64)
+	if in.CPU != nil {
+		in, out := &in.CPU, &out.CPU
+		*out = new(int64)
 		**out = **in
 	}
 }

--- a/pkg/computeclasses/computeclasses.go
+++ b/pkg/computeclasses/computeclasses.go
@@ -123,13 +123,13 @@ func Validate(cc apiv1.ComputeClass, memory resource.Quantity, memDefault *int64
 	return nil
 }
 
-func CalculateCPU(cc internaladminv1.ProjectComputeClassInstance, memory resource.Quantity) (resource.Quantity, error) {
+func CalculateCPU(cc internaladminv1.ProjectComputeClassInstance, memory resource.Quantity) resource.Quantity {
 	// The CPU scaler calculates the CPUs per Gi of memory so get the memory in a ratio of Gi
 	memoryInGi := memory.AsApproximateFloat64() / gi
 	// Since we're putting this in to mili-cpu's, multiply memoryInGi by the scaler and by 1000
 	value := cc.CPUScaler * memoryInGi * 1000
 
-	return *resource.NewMilliQuantity(int64(math.Ceil(value)), resource.DecimalSI), nil
+	return *resource.NewMilliQuantity(int64(math.Ceil(value)), resource.DecimalSI)
 }
 
 func GetComputeClassNameForWorkload(workload string, container internalv1.Container, computeClasses internalv1.ComputeClassMap) string {

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/existing.yaml
@@ -6,9 +6,9 @@ metadata:
 description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 memory:
-  min: 1Mi
-  max: 2Mi
-  default: 1Mi
+  min: 50Mi
+  max: 200Mi
+  default: 100Mi
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/quota/testdata/basic/input.yaml
+++ b/pkg/controller/quota/testdata/basic/input.yaml
@@ -51,18 +51,32 @@ status:
       test:
         accessModes:
         - readWriteOnce
+  resolvedOfferings:
+    containers:
+      "":
+        class: sample-compute-class
+        cpu: 125
+        memory: 536870912
+      container-name:
+        class: sample-compute-class
+        cpu: 125
+        memory: 536870912
+      sidecar-name:
+        class: sample-compute-class
+        cpu: 125
+        memory: 536870912
   scheduling:
     container-name:
       requirements:
         limits:
           memory: 512Mi
         requests:
-          cpu: 125m
-          memory: 512Mi
+          cpu: 75m
+          memory: 128Mi # simulate requestScaler
     sidecar-name:
       requirements:
         limits:
           memory: 512Mi
         requests:
-          cpu: 125m
-          memory: 512Mi
+          cpu: 75m
+          memory: 128Mi # simulate requestScaler

--- a/pkg/controller/quota/testdata/not-enforced/input.yaml
+++ b/pkg/controller/quota/testdata/not-enforced/input.yaml
@@ -51,18 +51,11 @@ status:
       test:
         accessModes:
         - readWriteOnce
-  scheduling:
-    container-name:
-      requirements:
-        limits:
-          memory: 512Mi
-        requests:
-          cpu: 125m
-          memory: 512Mi
-    sidecar-name:
-      requirements:
-        limits:
-          memory: 512Mi
-        requests:
-          cpu: 125m
-          memory: 512Mi
+  resolvedOfferings:
+    containers:
+      container-name:
+        cpu: 125
+        memory: 536870912 # 512Mi
+      sidecar-name:
+        memory: 536870912 # 512Mi
+        cpu: 125

--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
@@ -53,11 +53,11 @@ status:
         memory: 0
       left:
         class: sample-compute-class
-        cpuScaler: 0.25
+        cpu: 1
         memory: 1048576
       oneimage:
         class: sample-compute-class
-        cpuScaler: 0.25
+        cpu: 1
         memory: 2097152
     region: local
   staged:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/all-set-overwrite/expected.golden
@@ -51,6 +51,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        cpu: 0
         memory: 1048576
       left:
         memory: 1048576

--- a/pkg/controller/resolvedofferings/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/all-set/expected.golden
@@ -50,6 +50,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        cpu: 0
         memory: 1048576
       left:
         memory: 1048576

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/existing.yaml
@@ -17,9 +17,9 @@ description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
 memory:
-  min: 1Mi # 1Mi
-  max: 2Mi # 2Mi
-  default: 1Mi # 1Mi
+  min: 100Mi # 100Mi
+  max: 200Mi # 200Mi
+  default: 100Mi # 100Mi
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
@@ -52,12 +52,12 @@ status:
         memory: 0
       left:
         class: sample-compute-class
-        cpuScaler: 0.25
-        memory: 1048576
+        cpu: 25
+        memory: 104857600
       oneimage:
         class: sample-compute-class
-        cpuScaler: 0.25
-        memory: 1048576
+        cpu: 25
+        memory: 104857600
     region: local
   staged:
     appImage:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
@@ -55,11 +55,11 @@ status:
         memory: 0
       left:
         class: sample-compute-class
-        cpuScaler: 0.25
+        cpu: 1
         memory: 1048576
       oneimage:
         class: sample-compute-class
-        cpuScaler: 0.25
+        cpu: 1
         memory: 3145728
     region: local
   staged:

--- a/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/with-acornfile-memory-and-spec-override/expected.golden
@@ -51,6 +51,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        cpu: 0
         memory: 3145728
       left:
         memory: 3145728

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -219,10 +219,7 @@ func ResourceRequirements(req router.Request, app *v1.AppInstance, containerName
 	}
 
 	if computeClass != nil {
-		cpuQuantity, err := computeclasses.CalculateCPU(*computeClass, memoryRequest)
-		if err != nil {
-			return nil, err
-		}
+		cpuQuantity := computeclasses.CalculateCPU(*computeClass, memoryRequest)
 		if cpuQuantity.Value() != 0 {
 			requirements.Requests[corev1.ResourceCPU] = cpuQuantity
 		}

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -8852,10 +8852,10 @@ func schema_pkg_apis_internalacornio_v1_ContainerResolvedOffering(ref common.Ref
 							Format: "int64",
 						},
 					},
-					"cpuScaler": {
+					"cpu": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"number"},
-							Format: "double",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},


### PR DESCRIPTION
This PR adjusts two main things.
1. Removes the `cpuScaler` field from ResolvedOfferings in favor of a new `cpu` field.
2. Updates QuotaRequests to report against the ResolvedOfferings fields for container compute.

These two things are necessary for ComputeClasses that define a requestScaler on memory as we want to quota against the requested amount, not the incoming scaled down amount.

### Checklist
- [X]  The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

