### PR TITLE
Add pull secret information to debug build issues

### DIFF
--- a/pkg/pullsecret/pullsecrets.go
+++ b/pkg/pullsecret/pullsecrets.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,6 +72,13 @@ func Keychain(ctx context.Context, c client.Reader, namespace string) (authn.Key
 		}
 		keychainSecrets = append(keychainSecrets, secrets...)
 	}
+
+	var pullSecretNameAndNamespace []string
+	for _, secret := range keychainSecrets {
+		pullSecretNameAndNamespace = append(pullSecretNameAndNamespace, fmt.Sprintf("%s/%s", secret.Namespace, secret.Name))
+	}
+
+	logrus.Infof("Using pull secrets: %v for builder namespace %s", pullSecretNameAndNamespace, namespace)
 	return kubernetes.NewFromPullSecrets(ctx, keychainSecrets)
 }
 


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)


We used to see a lot of build issue regarding to push ECR registry with 403 errors, it turns out that it is extremely hard to troubleshoot ECR registry issue today. This PR prints out the pull secret it will pull out to push images to registry, so that we know which secret is pulled and used to push images and it will be easy to figure out which is going wrong.

It should only print out name and namespace so nothing sensetive will be printed out.


