### PR TITLE
fix: handle multiple default compute classes

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1132,7 +1132,7 @@ func TestUsingComputeClasses(t *testing.T) {
 		},
 		{
 			name:              "unsupported-region",
-			testDataDirectory: "./testdata/simple",
+			testDataDirectory: "./testdata/computeclass",
 			computeClass: adminv1.ProjectComputeClassInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "acorn-test-custom",


### PR DESCRIPTION
acorn-io/manager#1819

This code is used to validate apps in manager and is invoked directly by the manager side validator so we will be making the change in runtime code.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

