### PR TITLE
fix: remove resolvedOfferings, defaults, and scheduling for containers not defined in app

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -5,6 +5,7 @@ package v1
 import (
 	"strings"
 
+	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,6 +121,18 @@ func (in *AppInstanceSpec) GetGrantedPermissions() []Permissions {
 
 func (in *AppInstance) GetStopped() bool {
 	return in.Spec.Stop != nil && *in.Spec.Stop && in.DeletionTimestamp.IsZero()
+}
+
+// GetAllContainerNames returns a string slice containing the name of every container, job, and sidecar defined in Status.AppSpec.
+func (in *AppInstance) GetAllContainerNames() []string {
+	allContainers := append(maps.Keys(in.Status.AppSpec.Containers), maps.Keys(in.Status.AppSpec.Jobs)...)
+	for _, container := range in.Status.AppSpec.Containers {
+		allContainers = append(allContainers, maps.Keys(container.Sidecars)...)
+	}
+	for _, job := range in.Status.AppSpec.Jobs {
+		allContainers = append(allContainers, maps.Keys(job.Sidecars)...)
+	}
+	return allContainers
 }
 
 func (in *AppInstanceSpec) GetAutoUpgrade() bool {

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,6 +133,7 @@ func (in *AppInstance) GetAllContainerNames() []string {
 	for _, job := range in.Status.AppSpec.Jobs {
 		allContainers = append(allContainers, maps.Keys(job.Sidecars)...)
 	}
+	slices.Sort[[]string](allContainers)
 	return allContainers
 }
 

--- a/pkg/controller/defaults/memory_test.go
+++ b/pkg/controller/defaults/memory_test.go
@@ -72,3 +72,7 @@ func TestTwoPCCDefaultsShouldError(t *testing.T) {
 
 	assert.True(t, resp.NoPrune, "NoPrune should be true when error occurs")
 }
+
+func TestRemovedContainer(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/removed-container", Calculate)
+}

--- a/pkg/controller/defaults/testdata/memory/removed-container/existing.yaml
+++ b/pkg/controller/defaults/testdata/memory/removed-container/existing.yaml
@@ -1,0 +1,9 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/defaults/testdata/memory/removed-container/expected.golden
+++ b/pkg/controller/defaults/testdata/memory/removed-container/expected.golden
@@ -1,0 +1,62 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defaults
+  defaults:
+    memory:
+      "": 0
+      left: 0
+      oneimage: 0
+    region: local
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/defaults/testdata/memory/removed-container/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/removed-container/input.yaml
@@ -1,0 +1,36 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  defaults:
+    memory:
+      twoimage: 0

--- a/pkg/controller/resolvedofferings/computeclass_test.go
+++ b/pkg/controller/resolvedofferings/computeclass_test.go
@@ -88,3 +88,7 @@ func TestUserOverrideComputeClass(t *testing.T) {
 func TestWithAcornfileMemoryAndSpecOverride(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/with-acornfile-memory-and-spec-override", Calculate)
 }
+
+func TestRemovedContainer(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/removed-container", Calculate)
+}

--- a/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/existing.yaml
@@ -1,0 +1,9 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/expected.golden
@@ -1,0 +1,65 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: resolved-offerings
+  defaults: {}
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings:
+    containers:
+      "":
+        memory: 0
+      left:
+        memory: 0
+      oneimage:
+        memory: 1048576
+    region: local
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/input.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/removed-container/input.yaml
@@ -1,0 +1,37 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  resolvedOfferings:
+    containers:
+      twoimage:
+        memory: 0

--- a/pkg/controller/scheduling/computeclass_test.go
+++ b/pkg/controller/scheduling/computeclass_test.go
@@ -114,3 +114,7 @@ func TestInvalidPriorityClassShouldError(t *testing.T) {
 
 	assert.True(t, resp.NoPrune, "NoPrune should be true when error occurs")
 }
+
+func TestRemovedContainerComputeClass(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/removed-container", Calculate)
+}

--- a/pkg/controller/scheduling/memory_test.go
+++ b/pkg/controller/scheduling/memory_test.go
@@ -42,3 +42,7 @@ func TestAllSetOverwrite(t *testing.T) {
 func TestSameGenerationMemory(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/same-generation", Calculate)
 }
+
+func TestRemovedContainerMemory(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/removed-container", Calculate)
+}

--- a/pkg/controller/scheduling/testdata/computeclass/removed-container/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/removed-container/existing.yaml
@@ -1,0 +1,20 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/pkg/controller/scheduling/testdata/computeclass/removed-container/expected.golden
+++ b/pkg/controller/scheduling/testdata/computeclass/removed-container/expected.golden
@@ -1,0 +1,88 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  computeClass:
+    oneimage: sample-compute-class
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: scheduling
+  defaults:
+    memory:
+      "": 0
+      left: 1048576
+      oneimage: 1048576
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          cpu: 1m
+          memory: 1Mi
+    oneimage:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: foo
+                operator: In
+                values:
+                - bar
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          cpu: 1m
+          memory: 1Mi
+      tolerations:
+      - key: taints.acorn.io/workload
+        operator: Exists
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/scheduling/testdata/computeclass/removed-container/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/removed-container/input.yaml
@@ -1,0 +1,42 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  computeClass:
+    oneimage: sample-compute-class
+status:
+  observedGeneration: 1
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  namespace: app-created-namespace
+  appImage:
+    id: test
+    defaults:
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  scheduling:
+    twoimage:
+      requirements: {}

--- a/pkg/controller/scheduling/testdata/memory/removed-container/expected.golden
+++ b/pkg/controller/scheduling/testdata/memory/removed-container/expected.golden
@@ -1,0 +1,73 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: scheduling
+  defaults:
+    memory:
+      "": 0
+      left: 0
+      oneimage: 0
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  scheduling:
+    left:
+      requirements: {}
+    oneimage:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          memory: 1Mi
+      tolerations:
+      - key: taints.acorn.io/workload
+        operator: Exists
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/scheduling/testdata/memory/removed-container/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/removed-container/input.yaml
@@ -1,0 +1,41 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  defaults:
+    memory:
+      "": 0
+      left: 0
+      oneimage: 0
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  scheduling:
+    twoimage:
+      requirements: {}

--- a/pkg/controller/scheduling/testdata/tolerations/removed-container/expected.golden
+++ b/pkg/controller/scheduling/testdata/tolerations/removed-container/expected.golden
@@ -1,0 +1,63 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: scheduling
+  defaults: {}
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  scheduling:
+    left:
+      requirements: {}
+    oneimage:
+      requirements: {}
+      tolerations:
+      - key: taints.acorn.io/workload
+        operator: Exists
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/scheduling/testdata/tolerations/removed-container/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/removed-container/input.yaml
@@ -1,0 +1,35 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+    defaults:
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  scheduling:
+    twoimage:
+      tolerations: []

--- a/pkg/controller/scheduling/toleration_test.go
+++ b/pkg/controller/scheduling/toleration_test.go
@@ -14,3 +14,7 @@ func TestContainerTolerations(t *testing.T) {
 func TestJobTolerations(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/tolerations/job", Calculate)
 }
+
+func TestRemovedContainerTolerations(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/tolerations/removed-container", Calculate)
+}


### PR DESCRIPTION
We discovered this bug earlier today while working on something else. If you do `acorn update --image <image> <app name>`, and containers that were previously defined in the app no longer are, the resolved offerings, defaults, and scheduling information would still be present in the app's status for the old containers, even though they are not in the app anymore. This PR adds logic to delete containers from these maps when they no longer exist in the app. I also added new unit tests that check for this.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

