### PR TITLE
Enable setting a default ComputeClass on projects

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/router"
@@ -18,7 +19,7 @@ import (
 	"github.com/acorn-io/runtime/pkg/client"
 	"github.com/acorn-io/runtime/pkg/config"
 	"github.com/acorn-io/runtime/pkg/imagesource"
-	kclient "github.com/acorn-io/runtime/pkg/k8sclient"
+	rkclient "github.com/acorn-io/runtime/pkg/k8sclient"
 	"github.com/acorn-io/runtime/pkg/labels"
 	"github.com/acorn-io/runtime/pkg/run"
 	"github.com/acorn-io/runtime/pkg/scheme"
@@ -26,6 +27,7 @@ import (
 	"github.com/acorn-io/z"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -33,14 +35,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
-	crClient "sigs.k8s.io/controller-runtime/pkg/client"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestVolume(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	image, err := c.AcornImageBuild(ctx, "./testdata/volume/Acornfile", &client.AcornImageBuildOptions{
@@ -123,7 +125,7 @@ func TestServiceConsumer(t *testing.T) {
 
 	ctx := helper.GetCTX(t)
 	c, _ := helper.ClientAndProject(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 
 	image, err := c.AcornImageBuild(ctx, "./testdata/serviceconsumer/Acornfile", &client.AcornImageBuildOptions{
 		Cwd: "./testdata/serviceconsumer/",
@@ -170,7 +172,7 @@ func TestVolumeBadClassInImageBoundToGoodClass(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -231,7 +233,7 @@ func TestVolumeBoundBadClass(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -278,7 +280,7 @@ func TestVolumeClassInactive(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	volumeClass := adminapiv1.ClusterVolumeClass{
@@ -312,7 +314,7 @@ func TestVolumeClassSizeTooSmall(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	volumeClass := adminapiv1.ClusterVolumeClass{
@@ -356,7 +358,7 @@ func TestVolumeClassSizeTooLarge(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	volumeClass := adminapiv1.ClusterVolumeClass{
@@ -400,7 +402,7 @@ func TestVolumeClassRemoved(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -466,7 +468,7 @@ func TestClusterVolumeClass(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -529,7 +531,7 @@ func TestClusterVolumeClassValuesInAcornfile(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -588,7 +590,7 @@ func TestProjectVolumeClass(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -651,7 +653,7 @@ func TestProjectVolumeClassDefaultSizeValidation(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -718,7 +720,7 @@ func TestProjectVolumeClassDefaultSizeBadValidation(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -765,7 +767,7 @@ func TestProjectVolumeClassValuesInAcornfile(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -824,7 +826,7 @@ func TestImageNameAnnotation(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	k8sclient := helper.MustReturn(kclient.Default)
+	k8sclient := helper.MustReturn(rkclient.Default)
 	c, _ := helper.ClientAndProject(t)
 
 	image, err := c.AcornImageBuild(helper.GetCTX(t), "./testdata/named/Acornfile", &client.AcornImageBuildOptions{
@@ -889,7 +891,7 @@ func TestDeployParam(t *testing.T) {
 
 	ctx := helper.GetCTX(t)
 	c, project := helper.ClientAndProject(t)
-	kclient := helper.MustReturn(kclient.Default)
+	kclient := helper.MustReturn(rkclient.Default)
 
 	image, err := c.AcornImageBuild(ctx, "./testdata/params/Acornfile", &client.AcornImageBuildOptions{
 		Cwd: "./testdata/params",
@@ -936,7 +938,7 @@ func TestRequireComputeClass(t *testing.T) {
 
 	helper.StartController(t)
 	c, _ := helper.ClientAndProject(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 
 	helper.SetRequireComputeClassWithRestore(ctx, t, kc)
 
@@ -1045,7 +1047,7 @@ func TestRequireComputeClass(t *testing.T) {
 	for _, tt := range checks {
 		asClusterComputeClass := adminv1.ClusterComputeClassInstance(tt.computeClass)
 		// Perform the same test cases on both Project and Cluster ComputeClasses
-		for kind, computeClass := range map[string]crClient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
+		for kind, computeClass := range map[string]kclient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
 			testcase := fmt.Sprintf("%v-%v", kind, tt.name)
 			t.Run(testcase, func(t *testing.T) {
 				if !tt.noComputeClass {
@@ -1058,7 +1060,7 @@ func TestRequireComputeClass(t *testing.T) {
 						if err := kc.Delete(context.Background(), computeClass); err != nil && !apierrors.IsNotFound(err) {
 							t.Fatal(err)
 						}
-						err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+						err := helper.EnsureDoesNotExist(ctx, func() (kclient.Object, error) {
 							lookingFor := computeClass
 							err := kc.Get(ctx, router.Key(computeClass.GetNamespace(), computeClass.GetName()), lookingFor)
 							return lookingFor, err
@@ -1093,7 +1095,7 @@ func TestRequireComputeClass(t *testing.T) {
 						if err = kc.Delete(context.Background(), app); err != nil && !apierrors.IsNotFound(err) {
 							t.Fatal(err)
 						}
-						err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+						err := helper.EnsureDoesNotExist(ctx, func() (kclient.Object, error) {
 							lookingFor := app
 							err := kc.Get(ctx, router.Key(app.GetName(), app.GetNamespace()), lookingFor)
 							return lookingFor, err
@@ -1122,7 +1124,7 @@ func TestRequireComputeClass(t *testing.T) {
 func TestUsingComputeClasses(t *testing.T) {
 	helper.StartController(t)
 	c, _ := helper.ClientAndProject(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 
 	ctx := helper.GetCTX(t)
 
@@ -1366,7 +1368,7 @@ func TestUsingComputeClasses(t *testing.T) {
 	for _, tt := range checks {
 		asClusterComputeClass := adminv1.ClusterComputeClassInstance(tt.computeClass)
 		// Perform the same test cases on both Project and Cluster ComputeClasses
-		for kind, computeClass := range map[string]crClient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
+		for kind, computeClass := range map[string]kclient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
 			testcase := fmt.Sprintf("%v-%v", kind, tt.name)
 			t.Run(testcase, func(t *testing.T) {
 				if !tt.noComputeClass {
@@ -1379,7 +1381,7 @@ func TestUsingComputeClasses(t *testing.T) {
 						if err := kc.Delete(context.Background(), computeClass); err != nil && !apierrors.IsNotFound(err) {
 							t.Fatal(err)
 						}
-						err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+						err := helper.EnsureDoesNotExist(ctx, func() (kclient.Object, error) {
 							lookingFor := computeClass
 							err := kc.Get(ctx, router.Key(computeClass.GetNamespace(), computeClass.GetName()), lookingFor)
 							return lookingFor, err
@@ -1413,7 +1415,7 @@ func TestUsingComputeClasses(t *testing.T) {
 						if err = kc.Delete(context.Background(), app); err != nil && !apierrors.IsNotFound(err) {
 							t.Fatal(err)
 						}
-						err := helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+						err := helper.EnsureDoesNotExist(ctx, func() (kclient.Object, error) {
 							lookingFor := app
 							err := kc.Get(ctx, router.Key(app.GetName(), app.GetNamespace()), lookingFor)
 							return lookingFor, err
@@ -1437,6 +1439,91 @@ func TestUsingComputeClasses(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestProjectSpecifiedDefaultComputeClass(t *testing.T) {
+	helper.StartController(t)
+
+	ctx := helper.GetCTX(t)
+	c, project := helper.ClientAndProject(t)
+	kc := helper.MustReturn(rkclient.Default)
+
+	projectComputeClass := adminv1.ProjectComputeClassInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "self-specified-default",
+			Namespace: c.GetNamespace(),
+		},
+		CPUScaler: 0.25,
+		Default:   true,
+		Memory: adminv1.ComputeClassMemory{
+			Min: "1024",
+			Max: "2Gi",
+		},
+		SupportedRegions: []string{apiv1.LocalRegion},
+	}
+	clusterComputeClass := adminv1.ClusterComputeClassInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "project-specified-default",
+		},
+		CPUScaler: 0.25,
+		Memory: adminv1.ComputeClassMemory{
+			Min: "512",
+			Max: "1Gi",
+		},
+		SupportedRegions: []string{apiv1.LocalRegion},
+	}
+
+	for _, cc := range []kclient.Object{&projectComputeClass, &clusterComputeClass} {
+		obj := cc
+		t.Cleanup(func() {
+			assert.NoError(t, kclient.IgnoreNotFound(kc.Delete(ctx, obj)))
+		})
+		assert.NoError(t, kc.Create(ctx, obj))
+	}
+
+	// Set the project's default field and wait until the status field is set
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var p v1.ProjectInstance
+		require.NoError(c, kc.Get(ctx, router.Key("", project.Name), &p))
+		p.Spec.DefaultComputeClass = clusterComputeClass.Name
+
+		require.NoError(c, kc.Update(ctx, &p))
+		project = &p
+	}, time.Minute, time.Second, "failed to update project default")
+
+	project = helper.WaitForObject(t, kc.Watch, new(v1.ProjectInstanceList), project, func(obj *v1.ProjectInstance) bool {
+		return obj.Status.DefaultComputeClass == clusterComputeClass.Name
+	})
+
+	cwd := "./testdata/simple"
+	image, err := c.AcornImageBuild(ctx, cwd+"/Acornfile", &client.AcornImageBuildOptions{
+		Cwd: cwd,
+	})
+	require.NoError(t, err)
+
+	appName := "app"
+	t.Cleanup(func() {
+		err := kc.Delete(ctx, &v1.AppInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appName,
+				Namespace: c.GetNamespace(),
+			},
+		})
+		assert.NoError(t, kclient.IgnoreNotFound(err))
+	})
+
+	app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{Name: appName})
+	require.NoError(t, err)
+
+	// Wait for the app to be scheduled and ensure the computeclass matches the project's default
+	helper.WaitForObject(t, kc.Watch, new(v1.AppInstanceList), apiv1.AppToAppInstance(app), func(obj *v1.AppInstance) bool {
+		containers, ok := obj.Status.ResolvedOfferings.Containers[""]
+		if !ok {
+			return false
+		}
+
+		return containers.Class == clusterComputeClass.Name
+	})
 }
 
 func TestJobDelete(t *testing.T) {
@@ -1466,7 +1553,7 @@ func TestJobDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_ = helper.EnsureDoesNotExist(ctx, func() (crClient.Object, error) {
+	_ = helper.EnsureDoesNotExist(ctx, func() (kclient.Object, error) {
 		return c.AppGet(ctx, app.Name)
 	})
 }
@@ -1494,7 +1581,7 @@ func TestAppWithBadDefaultRegion(t *testing.T) {
 	helper.StartController(t)
 
 	ctx := helper.GetCTX(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	c, project := helper.ClientAndProject(t)
 
 	storageClasses := new(storagev1.StorageClassList)
@@ -1561,7 +1648,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	}
 	ctx := helper.GetCTX(t)
 	c, _ := helper.ClientAndProject(t)
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 
 	cfg, err := config.Get(ctx, kc)
 	if err != nil {
@@ -1706,7 +1793,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	}
 }
 
-func getPodIPFromAppName(ctx context.Context, t *testing.T, kc *crClient.WithWatch, appName, namespace string) string {
+func getPodIPFromAppName(ctx context.Context, t *testing.T, kc *kclient.WithWatch, appName, namespace string) string {
 	t.Helper()
 	selector, err := k8slabels.Parse(fmt.Sprintf("%s=%s", labels.AcornAppName, appName))
 	if err != nil {
@@ -1716,7 +1803,7 @@ func getPodIPFromAppName(ctx context.Context, t *testing.T, kc *crClient.WithWat
 	var podList corev1.PodList
 	podIP := ""
 	for podIP == "" {
-		err = (*kc).List(ctx, &podList, &kclient.ListOptions{
+		err = (*kc).List(ctx, &podList, &rkclient.ListOptions{
 			LabelSelector: selector,
 			Namespace:     namespace,
 		})
@@ -1835,7 +1922,7 @@ func TestEnforcedQuota(t *testing.T) {
 		t.Fatal("error while getting rest config:", err)
 	}
 	// Create a project.
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	project := helper.TempProject(t, kc)
 
 	// Create a client for the project.
@@ -1915,7 +2002,7 @@ func TestAutoUpgradeImageValidation(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while getting rest config:", err)
 	}
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	project := helper.TempProject(t, kc)
 
 	c, err := client.New(restConfig, project.Name, project.Name)
@@ -1951,7 +2038,7 @@ func TestAutoUpgradeLocalImage(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while getting rest config:", err)
 	}
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	project := helper.TempProject(t, kc)
 
 	c, err := client.New(restConfig, project.Name, project.Name)
@@ -2003,7 +2090,7 @@ func TestIgnoreResourceRequirements(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while getting rest config:", err)
 	}
-	kc := helper.MustReturn(kclient.Default)
+	kc := helper.MustReturn(rkclient.Default)
 	project := helper.TempProject(t, kc)
 
 	helper.SetIgnoreResourceRequirementsWithRestore(ctx, t, kc)

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -560,7 +560,7 @@ type InfoList struct {
 
 type Project v1.ProjectInstance
 
-func (p *Project) NamespaceScoped() bool {
+func (*Project) NamespaceScoped() bool {
 	return false
 }
 

--- a/pkg/apis/internal.acorn.io/v1/projectinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/projectinstance.go
@@ -15,13 +15,15 @@ type ProjectInstance struct {
 }
 
 type ProjectInstanceSpec struct {
-	DefaultRegion    string   `json:"defaultRegion,omitempty"`
-	SupportedRegions []string `json:"supportedRegions,omitempty"`
+	DefaultComputeClass string   `json:"defaultComputeClass,omitempty"`
+	DefaultRegion       string   `json:"defaultRegion,omitempty"`
+	SupportedRegions    []string `json:"supportedRegions,omitempty"`
 }
 
 type ProjectInstanceStatus struct {
-	Namespace     string `json:"namespace,omitempty"`
-	DefaultRegion string `json:"defaultRegion,omitempty"`
+	Namespace           string `json:"namespace,omitempty"`
+	DefaultComputeClass string `json:"defaultComputeClass,omitempty"`
+	DefaultRegion       string `json:"defaultRegion,omitempty"`
 	// SupportedRegions on the status field should be an explicit list of supported regions.
 	// That is, if the user specifies "*" for supported regions, then the status value should be the list of all regions.
 	// This is to avoid having to make another call to explicitly list all regions.

--- a/pkg/apis/internal.admin.acorn.io/v1/default.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"sort"
 
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/z"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) (*ClusterComputeClassInstance, error) {
+func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, projectDefaultComputeClass string) (*ClusterComputeClassInstance, error) {
 	clusterComputeClasses := ClusterComputeClassInstanceList{}
 	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
 		return nil, err
@@ -18,7 +20,7 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) 
 		return clusterComputeClasses.Items[i].Name < clusterComputeClasses.Items[j].Name
 	})
 
-	var defaultCCC *ClusterComputeClassInstance
+	var defaultCCC, projectDefaultCCC *ClusterComputeClassInstance
 	for _, clusterComputeClass := range clusterComputeClasses.Items {
 		if clusterComputeClass.Default {
 			if defaultCCC != nil {
@@ -26,15 +28,26 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) 
 					"cannot establish defaults because two default computeclasses exist: %v and %v",
 					defaultCCC.Name, clusterComputeClass.Name)
 			}
-			t := clusterComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultCCC = &t
+
+			// Create a new variable that isn't being iterated on to get a pointer
+			if projectDefaultComputeClass != "" {
+				defaultCCC = z.Pointer(clusterComputeClass)
+			}
 		}
+
+		if clusterComputeClass.Name == projectDefaultComputeClass {
+			projectDefaultCCC = z.Pointer(clusterComputeClass)
+		}
+	}
+
+	if projectDefaultCCC != nil {
+		return projectDefaultCCC, nil
 	}
 
 	return defaultCCC, nil
 }
 
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, namespace string) (*ProjectComputeClassInstance, error) {
+func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, projectDefaultComputeClass, namespace string) (*ProjectComputeClassInstance, error) {
 	projectComputeClasses := ProjectComputeClassInstanceList{}
 	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
 		return nil, err
@@ -44,7 +57,7 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 		return projectComputeClasses.Items[i].Name < projectComputeClasses.Items[j].Name
 	})
 
-	var defaultPCC *ProjectComputeClassInstance
+	var defaultPCC, projectDefaultPCC *ProjectComputeClassInstance
 	for _, projectComputeClass := range projectComputeClasses.Items {
 		if projectComputeClass.Default {
 			if defaultPCC != nil {
@@ -52,23 +65,40 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 					"cannot establish defaults because two default computeclasses exist: %v and %v",
 					defaultPCC.Name, projectComputeClass.Name)
 			}
-			t := projectComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultPCC = &t
+
+			// Create a new variable that isn't being iterated on to get a pointer
+			if projectDefaultComputeClass != "" {
+				defaultPCC = z.Pointer(projectComputeClass)
+			}
 		}
+
+		if projectComputeClass.Name == projectDefaultComputeClass {
+			projectDefaultPCC = z.Pointer(projectComputeClass)
+		}
+	}
+
+	if projectDefaultPCC != nil {
+		return projectDefaultPCC, nil
 	}
 
 	return defaultPCC, nil
 }
 
 func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace string) (string, error) {
-	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace)
+	var project internalv1.ProjectInstance
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, &project); err != nil {
+		return "", fmt.Errorf("failed to get projectinstance to determine default compute class: %w", err)
+	}
+	projectDefault := project.Status.DefaultComputeClass
+
+	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, projectDefault, namespace)
 	if err != nil {
 		return "", err
 	} else if pcc != nil {
 		return pcc.Name, nil
 	}
 
-	ccc, err := getCurrentClusterComputeClassDefault(ctx, c)
+	ccc, err := getCurrentClusterComputeClassDefault(ctx, c, projectDefault)
 	if err != nil {
 		return "", err
 	} else if ccc != nil {

--- a/pkg/apis/internal.admin.acorn.io/v1/default.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, projectDefaultComputeClass string) (*ClusterComputeClassInstance, error) {
-	clusterComputeClasses := ClusterComputeClassInstanceList{}
+func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, projectDefault string) (*ClusterComputeClassInstance, error) {
+	var clusterComputeClasses ClusterComputeClassInstanceList
 	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
 		return nil, err
 	}
@@ -30,12 +30,10 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, 
 			}
 
 			// Create a new variable that isn't being iterated on to get a pointer
-			if projectDefaultComputeClass != "" {
-				defaultCCC = z.Pointer(clusterComputeClass)
-			}
+			defaultCCC = z.Pointer(clusterComputeClass)
 		}
 
-		if clusterComputeClass.Name == projectDefaultComputeClass {
+		if clusterComputeClass.Name == projectDefault {
 			projectDefaultCCC = z.Pointer(clusterComputeClass)
 		}
 	}
@@ -47,8 +45,8 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, 
 	return defaultCCC, nil
 }
 
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, projectDefaultComputeClass, namespace string) (*ProjectComputeClassInstance, error) {
-	projectComputeClasses := ProjectComputeClassInstanceList{}
+func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, projectDefault, namespace string) (*ProjectComputeClassInstance, error) {
+	var projectComputeClasses ProjectComputeClassInstanceList
 	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
 		return nil, err
 	}
@@ -67,12 +65,10 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 			}
 
 			// Create a new variable that isn't being iterated on to get a pointer
-			if projectDefaultComputeClass != "" {
-				defaultPCC = z.Pointer(projectComputeClass)
-			}
+			defaultPCC = z.Pointer(projectComputeClass)
 		}
 
-		if projectComputeClass.Name == projectDefaultComputeClass {
+		if projectDefault projectComputeClass.Name == projectDefault {
 			projectDefaultPCC = z.Pointer(projectComputeClass)
 		}
 	}
@@ -94,15 +90,18 @@ func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace stri
 	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, projectDefault, namespace)
 	if err != nil {
 		return "", err
-	} else if pcc != nil {
+	}
+	if pcc != nil {
 		return pcc.Name, nil
 	}
 
 	ccc, err := getCurrentClusterComputeClassDefault(ctx, c, projectDefault)
 	if err != nil {
 		return "", err
-	} else if ccc != nil {
+	}
+	if ccc != nil {
 		return ccc.Name, nil
 	}
+
 	return "", nil
 }

--- a/pkg/apis/internal.admin.acorn.io/v1/default.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default.go
@@ -33,7 +33,7 @@ func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, 
 			defaultCCC = z.Pointer(clusterComputeClass)
 		}
 
-		if clusterComputeClass.Name == projectDefault {
+		if projectDefault != "" && clusterComputeClass.Name == projectDefault {
 			projectDefaultCCC = z.Pointer(clusterComputeClass)
 		}
 	}
@@ -68,7 +68,7 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 			defaultPCC = z.Pointer(projectComputeClass)
 		}
 
-		if projectDefault projectComputeClass.Name == projectDefault {
+		if projectDefault != "" && projectComputeClass.Name == projectDefault {
 			projectDefaultPCC = z.Pointer(projectComputeClass)
 		}
 	}

--- a/pkg/apis/internal.admin.acorn.io/v1/default.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default.go
@@ -7,79 +7,9 @@ import (
 
 	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/z"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client, projectSpecified string) (*ClusterComputeClassInstance, error) {
-	var clusterComputeClasses ClusterComputeClassInstanceList
-	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(clusterComputeClasses.Items, func(i, j int) bool {
-		return clusterComputeClasses.Items[i].Name < clusterComputeClasses.Items[j].Name
-	})
-
-	var defaultCCC, projectSpecifiedCCC *ClusterComputeClassInstance
-	for _, clusterComputeClass := range clusterComputeClasses.Items {
-		if clusterComputeClass.Default {
-			if defaultCCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultCCC.Name, clusterComputeClass.Name)
-			}
-
-			// Create a new variable that isn't being iterated on to get a pointer
-			defaultCCC = z.Pointer(clusterComputeClass)
-		}
-
-		if projectSpecified != "" && clusterComputeClass.Name == projectSpecified {
-			projectSpecifiedCCC = z.Pointer(clusterComputeClass)
-		}
-	}
-
-	if projectSpecifiedCCC != nil {
-		return projectSpecifiedCCC, nil
-	}
-
-	return defaultCCC, nil
-}
-
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, projectSpecified, namespace string) (*ProjectComputeClassInstance, error) {
-	var projectComputeClasses ProjectComputeClassInstanceList
-	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(projectComputeClasses.Items, func(i, j int) bool {
-		return projectComputeClasses.Items[i].Name < projectComputeClasses.Items[j].Name
-	})
-
-	var defaultPCC, projectSpecifiedPCC *ProjectComputeClassInstance
-	for _, projectComputeClass := range projectComputeClasses.Items {
-		if projectComputeClass.Default {
-			if defaultPCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultPCC.Name, projectComputeClass.Name)
-			}
-
-			// Create a new variable that isn't being iterated on to get a pointer
-			defaultPCC = z.Pointer(projectComputeClass)
-		}
-
-		if projectSpecified != "" && projectComputeClass.Name == projectSpecified {
-			projectSpecifiedPCC = z.Pointer(projectComputeClass)
-		}
-	}
-
-	if projectSpecifiedPCC != nil {
-		return projectSpecifiedPCC, nil
-	}
-
-	return defaultPCC, nil
-}
 
 // GetDefaultComputeClassName gets the name of the effective default ComputeClass for a given project namespace.
 // The precedence for picking the default ComputeClass is as follows:
@@ -89,37 +19,96 @@ func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, 
 //  3. The ClusterComputeClassInstance with a Default field set to true
 //
 // If no default ComputeClass is found, an empty string is returned.
-func GetDefaultComputeClassName(ctx context.Context, c client.Client, namespace string) (string, error) {
+// If the project specifies a default compute class that doesn't exist, an error is returned.
+func GetDefaultComputeClassName(ctx context.Context, c kclient.Client, namespace string) (string, error) {
 	var project internalv1.ProjectInstance
-	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, &project); err != nil {
-		return "", fmt.Errorf("failed to get projectinstance to determine default compute class: %w", err)
-	}
-	projectSpecified := project.Status.DefaultComputeClass
-
-	var defaultComputeClasses []string
-	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, projectSpecified, namespace)
-	if err != nil {
-		return "", err
-	}
-	if pcc != nil {
-		defaultComputeClasses = append(defaultComputeClasses, pcc.Name)
+	if err := c.Get(ctx, kclient.ObjectKey{Name: namespace}, &project); err != nil {
+		return "", fmt.Errorf("failed to get project instance to determine default compute class: %w", err)
 	}
 
-	ccc, err := getCurrentClusterComputeClassDefault(ctx, c, projectSpecified)
-	if err != nil {
-		return "", err
-	}
-	if ccc != nil {
-		defaultComputeClasses = append(defaultComputeClasses, ccc.Name)
-	}
+	if projectSpecified := project.Status.DefaultComputeClass; projectSpecified != "" {
+		if err := lookupComputeClass(ctx, c, namespace, projectSpecified); err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", fmt.Errorf("project specified default compute class [%v] does not exist: %w", projectSpecified, err)
+			}
+			return "", fmt.Errorf("failed to get project specified default compute class [%v]: %w", projectSpecified, err)
+		}
 
-	if sets.New(defaultComputeClasses...).Has(projectSpecified) {
 		return projectSpecified, nil
 	}
 
-	if len(defaultComputeClasses) > 0 {
-		return defaultComputeClasses[0], nil
+	if pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace); err != nil {
+		return "", err
+	} else if pcc != nil && pcc.Name != "" {
+		return pcc.Name, nil
+	}
+
+	if ccc, err := getCurrentClusterComputeClassDefault(ctx, c); err != nil {
+		return "", err
+	} else if ccc != nil && ccc.Name != "" {
+		return ccc.Name, nil
 	}
 
 	return "", nil
+}
+
+func getCurrentClusterComputeClassDefault(ctx context.Context, c kclient.Client) (*ClusterComputeClassInstance, error) {
+	var clusterComputeClasses ClusterComputeClassInstanceList
+	if err := c.List(ctx, &clusterComputeClasses, &kclient.ListOptions{}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(clusterComputeClasses.Items, func(i, j int) bool {
+		return clusterComputeClasses.Items[i].Name < clusterComputeClasses.Items[j].Name
+	})
+
+	var defaultCCC *ClusterComputeClassInstance
+	for _, clusterComputeClass := range clusterComputeClasses.Items {
+		if clusterComputeClass.Default {
+			if defaultCCC != nil {
+				return nil, fmt.Errorf(
+					"cannot establish defaults because two default computeclasses exist: %v and %v",
+					defaultCCC.Name, clusterComputeClass.Name)
+			}
+
+			defaultCCC = z.Pointer(clusterComputeClass)
+		}
+	}
+
+	return defaultCCC, nil
+}
+
+func getCurrentProjectComputeClassDefault(ctx context.Context, c kclient.Client, namespace string) (*ProjectComputeClassInstance, error) {
+	var projectComputeClasses ProjectComputeClassInstanceList
+	if err := c.List(ctx, &projectComputeClasses, &kclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(projectComputeClasses.Items, func(i, j int) bool {
+		return projectComputeClasses.Items[i].Name < projectComputeClasses.Items[j].Name
+	})
+
+	var defaultPCC *ProjectComputeClassInstance
+	for _, projectComputeClass := range projectComputeClasses.Items {
+		if projectComputeClass.Default {
+			if defaultPCC != nil {
+				return nil, fmt.Errorf(
+					"cannot establish defaults because two default computeclasses exist: %v and %v",
+					defaultPCC.Name, projectComputeClass.Name)
+			}
+
+			defaultPCC = z.Pointer(projectComputeClass)
+		}
+	}
+
+	return defaultPCC, nil
+}
+
+func lookupComputeClass(ctx context.Context, c kclient.Client, namespace, name string) error {
+	if err := c.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: name},
+		new(ProjectComputeClassInstance)); kclient.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	return c.Get(ctx, kclient.ObjectKey{Namespace: "", Name: name}, new(ClusterComputeClassInstance))
 }

--- a/pkg/apis/internal.admin.acorn.io/v1/default_test.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default_test.go
@@ -172,7 +172,7 @@ func TestGetDefaultComputeClass(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "pcc-project",
 						},
-						Spec: internalv1.ProjectInstanceSpec{
+						Status: internalv1.ProjectInstanceStatus{
 							DefaultComputeClass: "project-specified-default",
 						},
 					},
@@ -185,7 +185,7 @@ func TestGetDefaultComputeClass(t *testing.T) {
 				).Build(),
 			},
 			expected: expected{
-				computeClassName: "self-specified-default",
+				error: true,
 			},
 		},
 	} {

--- a/pkg/apis/internal.admin.acorn.io/v1/default_test.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/default_test.go
@@ -1,0 +1,208 @@
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	internalv1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	internaladminv1 "github.com/acorn-io/runtime/pkg/apis/internal.admin.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/scheme"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetDefaultComputeClass(t *testing.T) {
+	ctx := context.Background()
+
+	type args struct {
+		namespace string
+		client    kclient.Client
+	}
+	type expected struct {
+		computeClassName string
+		error            bool
+	}
+	for _, tt := range []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "No defaults",
+			args: args{
+				namespace: "pcc-project",
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+					&internalv1.ProjectInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pcc-project",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "project-compute-class",
+							Namespace: "pcc-project",
+						},
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster-compute-class",
+						},
+					},
+				).Build(),
+			},
+		},
+		{
+			name: "Default cluster compute class",
+			args: args{
+				namespace: "pcc-project",
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+					&internalv1.ProjectInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pcc-project",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "other-project-compute-class",
+							Namespace: "pcc-project",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "project-compute-class",
+							Namespace: "pcc-project",
+						},
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "other-cluster-compute-class",
+						},
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster-compute-class",
+						},
+						Default: true,
+					},
+				).Build(),
+			},
+			expected: expected{
+				computeClassName: "cluster-compute-class",
+			},
+		},
+		{
+			name: "Project compute classes take precedence over cluster compute classes",
+			args: args{
+				namespace: "pcc-project",
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+					&internalv1.ProjectInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pcc-project",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "other-project-compute-class",
+							Namespace: "pcc-project",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "project-compute-class",
+							Namespace: "pcc-project",
+						},
+						Default: true,
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "other-cluster-compute-class",
+						},
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster-compute-class",
+						},
+						Default: true,
+					},
+				).Build(),
+			},
+			expected: expected{
+				computeClassName: "project-compute-class",
+			},
+		},
+		{
+			name: "Project specified compute class takes precedence over default project compute class",
+			args: args{
+				namespace: "pcc-project",
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+					&internalv1.ProjectInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pcc-project",
+						},
+						Status: internalv1.ProjectInstanceStatus{
+							DefaultComputeClass: "project-specified-default",
+						},
+					},
+					&internaladminv1.ProjectComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "self-specified-default",
+							Namespace: "pcc-project",
+						},
+						Default: true,
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "project-specified-default",
+						},
+					},
+				).Build(),
+			},
+			expected: expected{
+				computeClassName: "project-specified-default",
+			},
+		},
+		{
+			name: "Project specified compute class not found",
+			args: args{
+				namespace: "pcc-project",
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+					&internalv1.ProjectInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pcc-project",
+						},
+						Spec: internalv1.ProjectInstanceSpec{
+							DefaultComputeClass: "project-specified-default",
+						},
+					},
+					&internaladminv1.ClusterComputeClassInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "self-specified-default",
+						},
+						Default: true,
+					},
+				).Build(),
+			},
+			expected: expected{
+				computeClassName: "self-specified-default",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			kc := tt.args.client
+			if kc == nil {
+				kc = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			}
+
+			actualComputeClassName, err := internaladminv1.GetDefaultComputeClassName(ctx, kc, tt.args.namespace)
+			if tt.expected.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expected.computeClassName, actualComputeClassName)
+		})
+	}
+}

--- a/pkg/computeclasses/computeclasses.go
+++ b/pkg/computeclasses/computeclasses.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 
 	"github.com/acorn-io/baaah/pkg/router"
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
@@ -145,13 +144,12 @@ func GetComputeClassNameForWorkload(workload string, container internalv1.Contai
 	return cc
 }
 
-// GetClassForWorkload determines what ComputeClass should be used for the given appInstance, container and
-// workload.
+// GetClassForWorkload determines what ComputeClass should be used for the given appInstance, container, and workload.
 func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses internalv1.ComputeClassMap, container internalv1.Container, workload, namespace string) (*internaladminv1.ProjectComputeClassInstance, error) {
-	var err error
 	ccName := GetComputeClassNameForWorkload(workload, container, computeClasses)
 	if ccName == "" {
-		ccName, err = GetDefaultComputeClass(ctx, c, namespace)
+		var err error
+		ccName, err = internaladminv1.GetDefaultComputeClass(ctx, c, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -171,90 +169,19 @@ func GetAsProjectComputeClassInstance(ctx context.Context, c client.Client, name
 		return nil, nil
 	}
 
-	projectComputeClass := internaladminv1.ProjectComputeClassInstance{}
-	err := c.Get(ctx, router.Key(namespace, computeClass), &projectComputeClass)
-	if err != nil {
+	var projectComputeClass internaladminv1.ProjectComputeClassInstance
+	if err := c.Get(ctx, router.Key(namespace, computeClass), &projectComputeClass); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
-		clusterComputeClass := internaladminv1.ClusterComputeClassInstance{}
-		err = c.Get(ctx, router.Key("", computeClass), &clusterComputeClass)
-		if err != nil {
+		var clusterComputeClass internaladminv1.ClusterComputeClassInstance
+		if err := c.Get(ctx, router.Key("", computeClass), &clusterComputeClass); err != nil {
 			return nil, err
 		}
 
-		cc := internaladminv1.ProjectComputeClassInstance(clusterComputeClass)
-		return &cc, nil
+		projectComputeClass = internaladminv1.ProjectComputeClassInstance(clusterComputeClass)
 	}
+
 	return &projectComputeClass, nil
-}
-
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) (*internaladminv1.ClusterComputeClassInstance, error) {
-	clusterComputeClasses := internaladminv1.ClusterComputeClassInstanceList{}
-	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(clusterComputeClasses.Items, func(i, j int) bool {
-		return clusterComputeClasses.Items[i].Name < clusterComputeClasses.Items[j].Name
-	})
-
-	var defaultCCC *internaladminv1.ClusterComputeClassInstance
-	for _, clusterComputeClass := range clusterComputeClasses.Items {
-		if clusterComputeClass.Default {
-			if defaultCCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultCCC.Name, clusterComputeClass.Name)
-			}
-			t := clusterComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultCCC = &t
-		}
-	}
-
-	return defaultCCC, nil
-}
-
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, namespace string) (*internaladminv1.ProjectComputeClassInstance, error) {
-	projectComputeClasses := internaladminv1.ProjectComputeClassInstanceList{}
-	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(projectComputeClasses.Items, func(i, j int) bool {
-		return projectComputeClasses.Items[i].Name < projectComputeClasses.Items[j].Name
-	})
-
-	var defaultPCC *internaladminv1.ProjectComputeClassInstance
-	for _, projectComputeClass := range projectComputeClasses.Items {
-		if projectComputeClass.Default {
-			if defaultPCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultPCC.Name, projectComputeClass.Name)
-			}
-			t := projectComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultPCC = &t
-		}
-	}
-
-	return defaultPCC, nil
-}
-
-func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace string) (string, error) {
-	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace)
-	if err != nil {
-		return "", err
-	} else if pcc != nil {
-		return pcc.Name, nil
-	}
-
-	ccc, err := getCurrentClusterComputeClassDefault(ctx, c)
-	if err != nil {
-		return "", err
-	} else if ccc != nil {
-		return ccc.Name, nil
-	}
-	return "", nil
 }

--- a/pkg/computeclasses/computeclasses.go
+++ b/pkg/computeclasses/computeclasses.go
@@ -149,7 +149,7 @@ func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses in
 	ccName := GetComputeClassNameForWorkload(workload, container, computeClasses)
 	if ccName == "" {
 		var err error
-		ccName, err = internaladminv1.GetDefaultComputeClass(ctx, c, namespace)
+		ccName, err = internaladminv1.GetDefaultComputeClassName(ctx, c, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/defaults/memory.go
+++ b/pkg/controller/defaults/memory.go
@@ -24,7 +24,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClassName(req.Ctx, req.Client, appInstance.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -26,7 +26,7 @@ func resolveComputeClasses(req router.Request, cfg *apiv1.Config, appInstance *v
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClassName(req.Ctx, req.Client, appInstance.Namespace)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func resolveComputeClassForContainer(req router.Request, appInstance *v1.AppInst
 	// Next, determine the memory request. This is the order of priority:
 	// 1. runtime-level overrides from the user (in app.Spec)
 	// 2. defaults in the acorn image
-	// 3. defaults from compute class
+	// 3. defaults from compute class and project status
 	// 4. global default
 
 	var (

--- a/pkg/controller/resolvedofferings/computeclass_test.go
+++ b/pkg/controller/resolvedofferings/computeclass_test.go
@@ -92,3 +92,7 @@ func TestWithAcornfileMemoryAndSpecOverride(t *testing.T) {
 func TestRemovedContainer(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/removed-container", Calculate)
 }
+
+func TestProjectSpecifiedDefault(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/project-specified-default", Calculate)
+}

--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
@@ -49,6 +49,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/acornfile-override-compute-class/expected.golden
@@ -49,7 +49,6 @@ status:
   resolvedOfferings:
     containers:
       "":
-        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
@@ -48,7 +48,6 @@ status:
   resolvedOfferings:
     containers:
       "":
-        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/compute-class-default/expected.golden
@@ -48,6 +48,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/existing.yaml
@@ -1,0 +1,53 @@
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: self-set-default
+  namespace: app-namespace
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: project-specified-default
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultComputeClass: project-specified-default
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/expected.golden
@@ -1,0 +1,71 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: resolved-offerings
+  defaults: {}
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings:
+    containers:
+      "":
+        class: project-specified-default
+        cpu: 1
+        memory: 1048576
+      left:
+        class: project-specified-default
+        cpu: 1
+        memory: 1048576
+      oneimage:
+        class: project-specified-default
+        cpu: 1
+        memory: 1048576
+    region: local
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/input.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/project-specified-default/input.yaml
@@ -1,0 +1,33 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
@@ -51,7 +51,6 @@ status:
   resolvedOfferings:
     containers:
       "":
-        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/user-override-compute-class/expected.golden
@@ -51,6 +51,7 @@ status:
   resolvedOfferings:
     containers:
       "":
+        class: sample-compute-class
         memory: 0
       left:
         class: sample-compute-class

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -98,7 +98,9 @@ func routes(router *router.Router, cfg *rest.Config, registryTransport http.Roun
 	appRouter.HandlerFunc(appstatus.CLIStatus)
 
 	projectRouter := router.Type(&v1.ProjectInstance{})
-	projectRouter.HandlerFunc(project.SetProjectSupportedRegions)
+	projectRouter.HandlerFunc(project.SetSupportedRegions)
+	projectRouter.HandlerFunc(project.SetDefaultComputeClass)
+
 	// Don't delete the namespace until the project instance is deleted.
 	projectRouter.IncludeFinalizing().HandlerFunc(project.CreateNamespace)
 	projectRouter.FinalizeFunc(labels.Prefix+"project-app-delete", project.EnsureAllAppsRemoved)

--- a/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/invalid-priority-class-should-error/existing.yaml
@@ -7,3 +7,8 @@ description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
 priorityClassName: does-not-exist
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/computeclass/priority-class/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/priority-class/existing.yaml
@@ -13,3 +13,8 @@ description: Simple description for a simple ComputeClass
 cpuScaler: 0.25
 default: true
 priorityClassName: exists
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/existing.yaml
@@ -40,3 +40,8 @@ affinity:
           operator: In
           values:
           - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/existing.yaml
@@ -18,3 +18,8 @@ affinity:
           operator: In
           values:
           - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/all-set/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/container/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/job/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/removed-container/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/removed-container/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/sidecar/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/two-containers/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/existing.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/tolerations/container/existing.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/tolerations/job/existing.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/controller/scheduling/testdata/tolerations/removed-container/existing.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/removed-container/existing.yaml
@@ -1,0 +1,5 @@
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -11460,6 +11460,12 @@ func schema_pkg_apis_internalacornio_v1_ProjectInstanceSpec(ref common.Reference
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"defaultComputeClass": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"defaultRegion": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -11493,6 +11499,12 @@ func schema_pkg_apis_internalacornio_v1_ProjectInstanceStatus(ref common.Referen
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"defaultComputeClass": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/project/handlers.go
+++ b/pkg/project/handlers.go
@@ -14,7 +14,20 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SetProjectSupportedRegions(req router.Request, resp router.Response) error {
+// SetDefaultComputeClass sets the default compute class status field of a [v1.ProjectInstance] to the value of its spec
+// field if set.
+func SetDefaultComputeClass(req router.Request, resp router.Response) error {
+	project := req.Object.(*v1.ProjectInstance)
+	if cc := project.Spec.DefaultComputeClass; cc != "" &&
+		project.Status.DefaultComputeClass != cc {
+		project.Status.DefaultComputeClass = cc
+	}
+
+	resp.Objects(req.Object)
+	return nil
+}
+
+func SetSupportedRegions(req router.Request, resp router.Response) error {
 	project := req.Object.(*v1.ProjectInstance)
 	project.SetDefaultRegion(apiv1.LocalRegion)
 	if slices.Contains(project.Status.SupportedRegions, apiv1.AllRegions) {

--- a/pkg/project/handlers.go
+++ b/pkg/project/handlers.go
@@ -20,15 +20,14 @@ import (
 // field if set.
 func SetDefaultComputeClass(req router.Request, resp router.Response) error {
 	project := req.Object.(*v1.ProjectInstance)
-	if cc := project.Spec.DefaultComputeClass; cc != "" &&
-		project.Status.DefaultComputeClass != cc {
+	if cc := project.Spec.DefaultComputeClass; cc != "" && project.Status.DefaultComputeClass != cc {
 		// The spec has been changed, update the status field to match.
 		project.Status.DefaultComputeClass = cc
 	}
 
 	// Check if the given compute class exists
 	if project.Status.DefaultComputeClass != "" {
-		if _, err := computeclasses.GetAsProjectComputeClassInstance(req.Ctx, req.Client, project.Status.Namespace, project.Status.DefaultComputeClass); err != nil {
+		if _, err := computeclasses.GetAsProjectComputeClassInstance(req.Ctx, req.Client, project.Name, project.Status.DefaultComputeClass); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to check existence of default compute class on project [%s] status: %w", project.Name, err)
 			}

--- a/pkg/project/handlers.go
+++ b/pkg/project/handlers.go
@@ -35,7 +35,6 @@ func SetDefaultComputeClass(req router.Request, resp router.Response) error {
 			// The compute class does not exist, clear the status field.
 			project.Status.DefaultComputeClass = ""
 		}
-		// TODO(njhale): Unset the status field if the project does not support the same regions as the compute class?
 	}
 
 	resp.Objects(req.Object)

--- a/pkg/project/handlers.go
+++ b/pkg/project/handlers.go
@@ -1,11 +1,13 @@
 package project
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/acorn-io/baaah/pkg/router"
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/runtime/pkg/computeclasses"
 	"github.com/acorn-io/runtime/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +22,21 @@ func SetDefaultComputeClass(req router.Request, resp router.Response) error {
 	project := req.Object.(*v1.ProjectInstance)
 	if cc := project.Spec.DefaultComputeClass; cc != "" &&
 		project.Status.DefaultComputeClass != cc {
+		// The spec has been changed, update the status field to match.
 		project.Status.DefaultComputeClass = cc
+	}
+
+	// Check if the given compute class exists
+	if project.Status.DefaultComputeClass != "" {
+		if _, err := computeclasses.GetAsProjectComputeClassInstance(req.Ctx, req.Client, project.Status.Namespace, project.Status.DefaultComputeClass); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to check existence of default compute class on project [%s] status: %w", project.Name, err)
+			}
+
+			// The compute class does not exist, clear the status field.
+			project.Status.DefaultComputeClass = ""
+		}
+		// TODO(njhale): Unset the status field if the project does not support the same regions as the compute class?
 	}
 
 	resp.Objects(req.Object)

--- a/pkg/project/handlers_test.go
+++ b/pkg/project/handlers_test.go
@@ -14,6 +14,13 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func TestDefaultComputeClass(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setdefaultcomputeclass/cc-missing", SetDefaultComputeClass)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setdefaultcomputeclass/spec-only", SetDefaultComputeClass)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setdefaultcomputeclass/status-only", SetDefaultComputeClass)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setdefaultcomputeclass/spec-override", SetDefaultComputeClass)
+}
+
 func TestSetProjectSupportedRegions(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/no-default", SetSupportedRegions)
 	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-supported-regions", SetSupportedRegions)

--- a/pkg/project/handlers_test.go
+++ b/pkg/project/handlers_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestSetProjectSupportedRegions(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/no-default", SetProjectSupportedRegions)
-	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-supported-regions", SetProjectSupportedRegions)
-	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-default-and-supported", SetProjectSupportedRegions)
-	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/all-supported-regions-with-default", SetProjectSupportedRegions)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/no-default", SetSupportedRegions)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-supported-regions", SetSupportedRegions)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/with-default-and-supported", SetSupportedRegions)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/setsupportedregions/all-supported-regions-with-default", SetSupportedRegions)
 }
 
 func TestCreateNamespace(t *testing.T) {

--- a/pkg/project/testdata/setdefaultcomputeclass/cc-missing/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/cc-missing/expected.golden
@@ -1,0 +1,9 @@
+`apiVersion: internal.acorn.io/v1
+kind: ProjectInstance
+metadata:
+  creationTimestamp: null
+  name: acorn
+spec:
+  defaultComputeClass: compute-class-a
+status: {}
+`

--- a/pkg/project/testdata/setdefaultcomputeclass/cc-missing/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/cc-missing/expected.golden
@@ -1,9 +1,1 @@
-`apiVersion: internal.acorn.io/v1
-kind: ProjectInstance
-metadata:
-  creationTimestamp: null
-  name: acorn
-spec:
-  defaultComputeClass: compute-class-a
-status: {}
-`
+""

--- a/pkg/project/testdata/setdefaultcomputeclass/cc-missing/input.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/cc-missing/input.yaml
@@ -1,0 +1,8 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: acorn
+spec:
+  defaultComputeClass: compute-class-a
+status:
+  defaultComputeClass: compute-class-a

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-only/existing.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-only/existing.yaml
@@ -2,11 +2,9 @@
 kind: ProjectComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: compute-class-a
+  namespace: acorn
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -15,20 +13,17 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
-kind: ProjectComputeClassInstance
+kind: ClusterComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class-other
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: cluster-compute-class-b
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -37,13 +32,13 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
 kind: ProjectInstance
 apiVersion: internal.acorn.io/v1
 metadata:
-  name: app-namespace
+  name: acorn

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-only/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-only/expected.golden
@@ -1,10 +1,1 @@
-`apiVersion: internal.acorn.io/v1
-kind: ProjectInstance
-metadata:
-  creationTimestamp: null
-  name: acorn
-spec:
-  defaultComputeClass: cluster-compute-class-b
-status:
-  defaultComputeClass: cluster-compute-class-b
-`
+""

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-only/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-only/expected.golden
@@ -1,0 +1,10 @@
+`apiVersion: internal.acorn.io/v1
+kind: ProjectInstance
+metadata:
+  creationTimestamp: null
+  name: acorn
+spec:
+  defaultComputeClass: cluster-compute-class-b
+status:
+  defaultComputeClass: cluster-compute-class-b
+`

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-only/input.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-only/input.yaml
@@ -1,0 +1,6 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: acorn
+spec:
+  defaultComputeClass: cluster-compute-class-b

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-override/existing.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-override/existing.yaml
@@ -2,11 +2,9 @@
 kind: ProjectComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: compute-class-a
+  namespace: acorn
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -15,20 +13,17 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
-kind: ProjectComputeClassInstance
+kind: ClusterComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class-other
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: cluster-compute-class-b
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -37,13 +32,15 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
 kind: ProjectInstance
 apiVersion: internal.acorn.io/v1
 metadata:
-  name: app-namespace
+  name: acorn
+status:
+  defaultComputeClass: cluster-compute-class-b

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-override/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-override/expected.golden
@@ -1,10 +1,1 @@
-`apiVersion: internal.acorn.io/v1
-kind: ProjectInstance
-metadata:
-  creationTimestamp: null
-  name: acorn
-spec:
-  defaultComputeClass: compute-class-a
-status:
-  defaultComputeClass: compute-class-a
-`
+""

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-override/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-override/expected.golden
@@ -1,0 +1,10 @@
+`apiVersion: internal.acorn.io/v1
+kind: ProjectInstance
+metadata:
+  creationTimestamp: null
+  name: acorn
+spec:
+  defaultComputeClass: compute-class-a
+status:
+  defaultComputeClass: compute-class-a
+`

--- a/pkg/project/testdata/setdefaultcomputeclass/spec-override/input.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/spec-override/input.yaml
@@ -1,0 +1,6 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: acorn
+spec:
+  defaultComputeClass: compute-class-a

--- a/pkg/project/testdata/setdefaultcomputeclass/status-only/existing.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/status-only/existing.yaml
@@ -2,11 +2,9 @@
 kind: ProjectComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: compute-class-a
+  namespace: acorn
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -15,20 +13,17 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
-kind: ProjectComputeClassInstance
+kind: ClusterComputeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: sample-compute-class-other
-  namespace: app-namespace
-description: Simple description for a simple ComputeClass
+  name: cluster-compute-class-b
 cpuScaler: 0.25
-default: true
 memory:
   min: 1Mi # 1Mi
   max: 2Mi # 2Mi
@@ -37,13 +32,15 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+        - matchExpressions:
+            - key: foo
+              operator: In
+              values:
+                - bar
 ---
 kind: ProjectInstance
 apiVersion: internal.acorn.io/v1
 metadata:
-  name: app-namespace
+  name: acorn
+status:
+  defaultComputeClass: cluster-compute-class-b

--- a/pkg/project/testdata/setdefaultcomputeclass/status-only/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/status-only/expected.golden
@@ -1,9 +1,1 @@
-`apiVersion: internal.acorn.io/v1
-kind: ProjectInstance
-metadata:
-  creationTimestamp: null
-  name: acorn
-spec: {}
-status:
-  defaultComputeClass: cluster-compute-class-b
-`
+""

--- a/pkg/project/testdata/setdefaultcomputeclass/status-only/expected.golden
+++ b/pkg/project/testdata/setdefaultcomputeclass/status-only/expected.golden
@@ -1,0 +1,9 @@
+`apiVersion: internal.acorn.io/v1
+kind: ProjectInstance
+metadata:
+  creationTimestamp: null
+  name: acorn
+spec: {}
+status:
+  defaultComputeClass: cluster-compute-class-b
+`

--- a/pkg/project/testdata/setdefaultcomputeclass/status-only/input.yaml
+++ b/pkg/project/testdata/setdefaultcomputeclass/status-only/input.yaml
@@ -1,0 +1,6 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: acorn
+status:
+  defaultComputeClass: cluster-compute-class-b

--- a/pkg/server/registry/apigroups/acorn/projects/validator.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator.go
@@ -42,7 +42,6 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) field.Erro
 			// Some other error occurred while trying to get the compute class, return an internal error.
 			result = append(result, field.InternalError(field.NewPath("spec", "defaultComputeClass"), err))
 		}
-		// TODO(njhale): Validate that the compute class shares the project's supported regions?
 	}
 
 	return result

--- a/pkg/server/registry/apigroups/acorn/projects/validator_test.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator_test.go
@@ -6,7 +6,6 @@ import (
 
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/runtime/pkg/apis/internal.acorn.io/v1"
-	internaladminv1 "github.com/acorn-io/runtime/pkg/apis/internal.admin.acorn.io/v1"
 	"github.com/acorn-io/runtime/pkg/scheme"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,65 +99,6 @@ func TestProjectCreateValidation(t *testing.T) {
 					DefaultComputeClass: "compute-class-dne",
 				},
 			},
-			wantError: true,
-		},
-		{
-			name: "Create project with default computeclass that points to a specific clustercomputeclass",
-			project: apiv1.Project{
-				Spec: v1.ProjectInstanceSpec{
-					DefaultComputeClass: "cluster-compute-class",
-				},
-			},
-			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-				&internaladminv1.ClusterComputeClassInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-compute-class",
-					},
-				},
-				&internaladminv1.ClusterComputeClassInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-compute-class-2",
-					},
-				},
-			).Build(),
-		},
-		{
-			name: "Create project with default computeclass that points to a specific projectcomputeclass",
-			project: apiv1.Project{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pcc-project",
-				},
-				Spec: v1.ProjectInstanceSpec{
-					DefaultComputeClass: "project-compute-class",
-				},
-			},
-			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-				&internaladminv1.ProjectComputeClassInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "project-compute-class",
-						Namespace: "pcc-project",
-					},
-				},
-			).Build(),
-		},
-		{
-			name: "Create project with default computeclass that points to a projectcomputeclass in a different project",
-			project: apiv1.Project{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pcc-project",
-				},
-				Spec: v1.ProjectInstanceSpec{
-					DefaultComputeClass: "project-compute-class",
-				},
-			},
-			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
-				&internaladminv1.ProjectComputeClassInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "project-compute-class",
-						Namespace: "not-pcc-project",
-					},
-				},
-			).Build(),
 			wantError: true,
 		},
 	}

--- a/pkg/server/registry/apigroups/admin/computeclass/strategy.go
+++ b/pkg/server/registry/apigroups/admin/computeclass/strategy.go
@@ -65,7 +65,7 @@ func (s *Strategy) List(ctx context.Context, namespace string, _ storage.ListOpt
 
 	for _, ccc := range clusterComputeClasses.Items {
 		if _, ok := projectComputeClassesSeen[ccc.Name]; ok {
-			// A project compute class with the same name exists, skipping the project compute class
+			// A project compute class with the same name exists, skipping the cluster compute class
 			continue
 		}
 		if projectDefaultExists {

--- a/pkg/server/registry/apigroups/admin/computeclass/strategy.go
+++ b/pkg/server/registry/apigroups/admin/computeclass/strategy.go
@@ -65,7 +65,7 @@ func (s *Strategy) List(ctx context.Context, namespace string, _ storage.ListOpt
 
 	for _, ccc := range clusterComputeClasses.Items {
 		if _, ok := projectComputeClassesSeen[ccc.Name]; ok {
-			// A project volume class with the same name exists, skipping the cluster volume class
+			// A project compute class with the same name exists, skipping the project compute class
 			continue
 		}
 		if projectDefaultExists {


### PR DESCRIPTION
Enable selecting the default `ComputeClass` for `Apps` deployed to a project via a new project spec field. 

The `DefaultComputeClass` field contains the name of a `[Project|Cluster]ComputeClassInstance` to select as the default. If no compute classes with that name exist, the existing `ComputeClass` defaulting rules are applied.

This PR also extends API validation for project create and update to ensure that a compute class with a matching name exists when the field is set.

Part of https://github.com/acorn-io/manager/issues/1943