### PR TITLE
enhance: AppLogEndpoint + AppLogSecret on Region object supporting the new app logs feature

### DIFF
--- a/pkg/apis/api.acorn.io/v1/region.go
+++ b/pkg/apis/api.acorn.io/v1/region.go
@@ -28,7 +28,9 @@ type RegionSpec struct {
 }
 
 type RegionStatus struct {
-	Conditions []v1.Condition `json:"conditions,omitempty"`
+	Conditions     []v1.Condition `json:"conditions,omitempty"`
+	AppLogEndpoint string         `json:"appLogEndpoint,omitempty"`
+	AppLogSecret   string         `json:"appLogSecret,omitempty"`
 }
 
 func (in *Region) NamespaceScoped() bool {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -5354,6 +5354,18 @@ func schema_pkg_apis_apiacornio_v1_RegionStatus(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"appLogEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"appLogSecret": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Tracking Issue https://github.com/acorn-io/manager/issues/1962

This information will be used by the Account API Server to determine where to get the app logs from for this region.
At some point we will have multiple endpoints per geographical region.
Which one to use will be determined dynamically.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

