### PR TITLE
fix: handle multiple default compute classes

### DIFF
--- a/pkg/computeclasses/computeclasses.go
+++ b/pkg/computeclasses/computeclasses.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 
 	"github.com/acorn-io/baaah/pkg/router"
 	apiv1 "github.com/acorn-io/runtime/pkg/apis/api.acorn.io/v1"
@@ -147,11 +146,11 @@ func GetComputeClassNameForWorkload(workload string, container internalv1.Contai
 
 // GetClassForWorkload determines what ComputeClass should be used for the given appInstance, container and
 // workload.
-func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses internalv1.ComputeClassMap, container internalv1.Container, workload, namespace string) (*internaladminv1.ProjectComputeClassInstance, error) {
+func GetClassForWorkload(ctx context.Context, c client.Client, computeClasses internalv1.ComputeClassMap, container internalv1.Container, workload, namespace, region string) (*internaladminv1.ProjectComputeClassInstance, error) {
 	var err error
 	ccName := GetComputeClassNameForWorkload(workload, container, computeClasses)
 	if ccName == "" {
-		ccName, err = GetDefaultComputeClass(ctx, c, namespace)
+		ccName, err = internaladminv1.GetDefaultComputeClass(ctx, c, namespace, region)
 		if err != nil {
 			return nil, err
 		}
@@ -188,73 +187,4 @@ func GetAsProjectComputeClassInstance(ctx context.Context, c client.Client, name
 		return &cc, nil
 	}
 	return &projectComputeClass, nil
-}
-
-func getCurrentClusterComputeClassDefault(ctx context.Context, c client.Client) (*internaladminv1.ClusterComputeClassInstance, error) {
-	clusterComputeClasses := internaladminv1.ClusterComputeClassInstanceList{}
-	if err := c.List(ctx, &clusterComputeClasses, &client.ListOptions{}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(clusterComputeClasses.Items, func(i, j int) bool {
-		return clusterComputeClasses.Items[i].Name < clusterComputeClasses.Items[j].Name
-	})
-
-	var defaultCCC *internaladminv1.ClusterComputeClassInstance
-	for _, clusterComputeClass := range clusterComputeClasses.Items {
-		if clusterComputeClass.Default {
-			if defaultCCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultCCC.Name, clusterComputeClass.Name)
-			}
-			t := clusterComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultCCC = &t
-		}
-	}
-
-	return defaultCCC, nil
-}
-
-func getCurrentProjectComputeClassDefault(ctx context.Context, c client.Client, namespace string) (*internaladminv1.ProjectComputeClassInstance, error) {
-	projectComputeClasses := internaladminv1.ProjectComputeClassInstanceList{}
-	if err := c.List(ctx, &projectComputeClasses, &client.ListOptions{Namespace: namespace}); err != nil {
-		return nil, err
-	}
-
-	sort.Slice(projectComputeClasses.Items, func(i, j int) bool {
-		return projectComputeClasses.Items[i].Name < projectComputeClasses.Items[j].Name
-	})
-
-	var defaultPCC *internaladminv1.ProjectComputeClassInstance
-	for _, projectComputeClass := range projectComputeClasses.Items {
-		if projectComputeClass.Default {
-			if defaultPCC != nil {
-				return nil, fmt.Errorf(
-					"cannot establish defaults because two default computeclasses exist: %v and %v",
-					defaultPCC.Name, projectComputeClass.Name)
-			}
-			t := projectComputeClass // Create a new variable that isn't being iterated on to get a pointer
-			defaultPCC = &t
-		}
-	}
-
-	return defaultPCC, nil
-}
-
-func GetDefaultComputeClass(ctx context.Context, c client.Client, namespace string) (string, error) {
-	pcc, err := getCurrentProjectComputeClassDefault(ctx, c, namespace)
-	if err != nil {
-		return "", err
-	} else if pcc != nil {
-		return pcc.Name, nil
-	}
-
-	ccc, err := getCurrentClusterComputeClassDefault(ctx, c)
-	if err != nil {
-		return "", err
-	} else if ccc != nil {
-		return ccc.Name, nil
-	}
-	return "", nil
 }

--- a/pkg/controller/defaults/memory.go
+++ b/pkg/controller/defaults/memory.go
@@ -72,7 +72,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 func addWorkloadMemoryDefault(req router.Request, appInstance *v1.AppInstance, configDefault *int64, containers map[string]v1.Container) error {
 	for name, container := range containers {
 		memory := configDefault
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/defaults/memory.go
+++ b/pkg/controller/defaults/memory.go
@@ -24,7 +24,7 @@ func addDefaultMemory(req router.Request, cfg *apiv1.Config, appInstance *v1.App
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/defaults/memory_test.go
+++ b/pkg/controller/defaults/memory_test.go
@@ -45,6 +45,14 @@ func TestMemorySameGeneration(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/same-generation", Calculate)
 }
 
+func TestTwoCCCDefaultsCrossRegion(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/two-ccc-defaults-different-regions", Calculate)
+}
+
+func TestTwoPCCDefaultsCrossRegion(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/memory/two-pcc-defaults-different-regions", Calculate)
+}
+
 func TestTwoCCCDefaultsShouldError(t *testing.T) {
 	harness, input, err := tester.FromDir(scheme.Scheme, "testdata/memory/two-ccc-defaults-should-error")
 	if err != nil {

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/existing.yaml
@@ -1,0 +1,54 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+supportedRegions: [local]
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/expected.golden
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/expected.golden
@@ -1,0 +1,62 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defaults
+  defaults:
+    memory:
+      "": 1048576
+      left: 1048576
+      oneimage: 1048576
+    region: local
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-different-regions/input.yaml
@@ -1,0 +1,33 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/existing.yaml
@@ -1,0 +1,56 @@
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+  namespace: app-namespace
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+supportedRegions: [local]
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+  namespace: app-namespace
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/expected.golden
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/expected.golden
@@ -1,0 +1,62 @@
+`apiVersion: internal.acorn.io/v1
+kind: AppInstance
+metadata:
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576
+status:
+  appImage:
+    buildContext: {}
+    id: test
+    imageData: {}
+    vcs: {}
+  appSpec:
+    containers:
+      oneimage:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: image-name
+        metrics: {}
+        ports:
+        - port: 80
+          protocol: http
+          targetPort: 81
+        probes: null
+        sidecars:
+          left:
+            image: foo
+            metrics: {}
+            ports:
+            - port: 90
+              protocol: tcp
+              targetPort: 91
+            probes: null
+  appStatus: {}
+  columns: {}
+  conditions:
+    reason: Success
+    status: "True"
+    success: true
+    type: defaults
+  defaults:
+    memory:
+      "": 0
+      left: 1048576
+      oneimage: 1048576
+    region: local
+  namespace: app-created-namespace
+  observedGeneration: 1
+  resolvedOfferings: {}
+  staged:
+    appImage:
+      buildContext: {}
+      imageData: {}
+      vcs: {}
+  summary: {}
+`

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-different-regions/input.yaml
@@ -1,0 +1,33 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -26,7 +26,7 @@ func resolveComputeClasses(req router.Request, cfg *apiv1.Config, appInstance *v
 	if value, ok := appInstance.Spec.ComputeClasses[""]; ok {
 		defaultCC = value
 	} else {
-		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace)
+		defaultCC, err = adminv1.GetDefaultComputeClass(req.Ctx, req.Client, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/resolvedofferings/computeclass.go
+++ b/pkg/controller/resolvedofferings/computeclass.go
@@ -116,7 +116,7 @@ func resolveComputeClassForContainer(req router.Request, appInstance *v1.AppInst
 	var ccName string
 
 	// First, get the compute class for the workload
-	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace)
+	cc, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, containerName, appInstance.Namespace, appInstance.GetRegion())
 	if err != nil {
 		return v1.ContainerResolvedOffering{}, err
 	}

--- a/pkg/controller/resolvedofferings/computeclass_test.go
+++ b/pkg/controller/resolvedofferings/computeclass_test.go
@@ -73,6 +73,14 @@ func TestTwoPCCDefaultsShouldError(t *testing.T) {
 	assert.True(t, resp.NoPrune, "NoPrune should be true when error occurs")
 }
 
+func TestTwoCCCDefaultsDifferentRegions(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/two-ccc-defaults-different-regions", Calculate)
+}
+
+func TestTwoPCCDefaultsDifferentRegions(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/two-pcc-defaults-different-regions", Calculate)
+}
+
 func TestComputeClassDefault(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/compute-class-default", Calculate)
 }

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/existing.yaml
@@ -1,0 +1,54 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/expected.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/expected.yaml
@@ -1,0 +1,47 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - reason: Success
+      status: "True"
+      success: true
+      type: resolved-offerings
+  resolvedOfferings:
+    region: local
+    containers:
+      "":
+        memory: 0
+      left:
+        memory: 0
+      oneimage:
+        memory: 1048576

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/input.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-ccc-defaults-different-regions/input.yaml
@@ -1,0 +1,33 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/existing.yaml
@@ -1,0 +1,54 @@
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/expected.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/expected.yaml
@@ -1,0 +1,47 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - reason: Success
+      status: "True"
+      success: true
+      type: resolved-offerings
+  resolvedOfferings:
+    region: local
+    containers:
+      "":
+        memory: 0
+      left:
+        memory: 0
+      oneimage:
+        memory: 1048576

--- a/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/input.yaml
+++ b/pkg/controller/resolvedofferings/testdata/computeclass/two-pcc-defaults-different-regions/input.yaml
@@ -1,0 +1,33 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/scheduling/computeclass_test.go
+++ b/pkg/controller/scheduling/computeclass_test.go
@@ -73,6 +73,14 @@ func TestRequestScalerFloor(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/request-scaler-floor", Calculate)
 }
 
+func TestTwoCCCDefaultsDifferentRegions(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/two-ccc-defaults-different-regions", Calculate)
+}
+
+func TestTwoPCCDefaultsDifferentRegions(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/two-pcc-defaults-different-regions", Calculate)
+}
+
 func TestTwoCCCDefaultsShouldError(t *testing.T) {
 	harness, input, err := tester.FromDir(scheme.Scheme, "testdata/computeclass/two-ccc-defaults-should-error")
 	if err != nil {

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -76,7 +76,7 @@ func addScheduling(req router.Request, appInstance *v1.AppInstance, workloads ma
 			return err
 		}
 
-		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace)
+		computeClass, err := computeclasses.GetClassForWorkload(req.Ctx, req.Client, appInstance.Spec.ComputeClasses, container, name, appInstance.Namespace, appInstance.GetRegion())
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/existing.yaml
@@ -1,0 +1,44 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/expected.yaml
@@ -1,0 +1,61 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  defaults:
+    memory:
+      "": 0
+      left: 1048576
+      oneimage: 1048576
+  observedGeneration: 1
+  resolvedOfferings: {}
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - reason: Success
+      status: "True"
+      success: true
+      type: scheduling
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          memory: 1Mi
+    oneimage:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          memory: 1Mi
+      tolerations:
+      - key: taints.acorn.io/workload
+        operator: Exists
+

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-different-regions/input.yaml
@@ -1,0 +1,38 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/existing.yaml
@@ -1,0 +1,44 @@
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+---
+kind: ProjectComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class-other
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+default: true
+supportedRegions: [non-local]
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 2Mi # 2Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/expected.yaml
@@ -1,0 +1,61 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  defaults:
+    memory:
+      "": 0
+      left: 1048576
+      oneimage: 1048576
+  observedGeneration: 1
+  resolvedOfferings: {}
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - reason: Success
+      status: "True"
+      success: true
+      type: scheduling
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          memory: 1Mi
+    oneimage:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          memory: 1Mi
+      tolerations:
+      - key: taints.acorn.io/workload
+        operator: Exists
+

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-different-regions/input.yaml
@@ -1,0 +1,38 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  memory:
+    oneimage: 1048576 # 1Mi
+status:
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."


### PR DESCRIPTION
acorn-io/manager#1819

Adding support for multiple defaults. Will follow up with additional testing coverage.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

