### PR TITLE
fix: address issue where quota would not correctly track computeclass usage

### DIFF
--- a/pkg/controller/quota/quota_test.go
+++ b/pkg/controller/quota/quota_test.go
@@ -11,6 +11,12 @@ func TestBasic(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/basic", EnsureQuotaRequest)
 }
 
+// TestAllSet simulates a secenario where the resolvedOfferings field does not have
+// any usage set for containers, just all.
+func TestOnlyAllSet(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/only-all-set", EnsureQuotaRequest)
+}
+
 func TestNotEnforced(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/not-enforced", EnsureQuotaRequest)
 }

--- a/pkg/controller/quota/testdata/only-all-set/existing.yaml
+++ b/pkg/controller/quota/testdata/only-all-set/existing.yaml
@@ -1,0 +1,11 @@
+kind: ProjectInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-namespace
+  annotations:
+    acorn.io/enforced-quota: "true"
+spec: {}
+status:
+  defaultRegion: local
+  supportedRegions:
+    - local

--- a/pkg/controller/quota/testdata/only-all-set/expected.golden
+++ b/pkg/controller/quota/testdata/only-all-set/expected.golden
@@ -1,0 +1,34 @@
+`apiVersion: internal.admin.acorn.io/v1
+kind: QuotaRequestInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+  creationTimestamp: null
+  name: app-name
+  namespace: app-namespace
+spec:
+  resources:
+    apps: 0
+    computeClasses:
+      default-compute-class:
+        cpu: 250m
+        memory: 1Gi
+    containers: 1
+    images: 0
+    jobs: 1
+    secrets: 1
+    volumeClasses:
+      default-volume-class:
+        volumeStorage: 10G
+    volumes: 1
+status:
+  allocatedResources:
+    apps: 0
+    computeClasses: null
+    containers: 0
+    images: 0
+    jobs: 0
+    secrets: 0
+    volumeClasses: null
+    volumes: 0
+`

--- a/pkg/controller/quota/testdata/only-all-set/input.yaml
+++ b/pkg/controller/quota/testdata/only-all-set/input.yaml
@@ -1,0 +1,80 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: image-name
+  computeClass:
+    "": default-compute-class
+status:
+  observedGeneration: 1
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    containers:
+      container-name:
+        sidecars:
+          sidecar-name:
+            image: "image-name"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+    jobs:
+      job-name:
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+    secrets:
+      test:
+        params:
+          characters: bcdfghjklmnpqrstvwxz2456789
+          length: 54
+        type: token
+    volumes:
+      test:
+        accessModes:
+        - readWriteOnce
+  resolvedOfferings:
+    containers:
+      "":
+        class: default-compute-class
+        cpu: 125
+        memory: 536870912
+      # simulating a bug where the container and sidecar do not have
+      # a resolved offering
+    volumes:
+      test:
+        class: default-volume-class
+        size: 536870912
+  scheduling:
+    container-name:
+      requirements:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 75m
+          memory: 128Mi # simulate requestScaler
+    sidecar-name:
+      requirements:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 75m
+          memory: 128Mi # simulate requestScaler


### PR DESCRIPTION
Part of a fix for https://github.com/acorn-io/manager/issues/2025

This PR fixes an issue where quota would not correctly count `""` usage when processing compute classes.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

