### PR TITLE
Fix: add logic to update volume reclaim policy to delete

### DIFF
--- a/pkg/server/registry/apigroups/acorn/volumes/policyswitcher.go
+++ b/pkg/server/registry/apigroups/acorn/volumes/policyswitcher.go
@@ -1,0 +1,49 @@
+package volumes
+
+import (
+	"context"
+
+	"github.com/acorn-io/mink/pkg/strategy"
+	"github.com/acorn-io/mink/pkg/strategy/remote"
+	"github.com/acorn-io/mink/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+type PolicySwitcherStrategy struct {
+	strategy   strategy.CompleteStrategy
+	translator *Translator
+	remote     *remote.Remote
+}
+
+// NewPolicySwitcherStrategy returns a new policy switcher strategy that switch persistvolume policy from retain to delete when the volume is being deleted.
+// This makes sure the actual storage resource is deleted when the volume is deleted.
+func NewPolicySwitcherStrategy(s strategy.CompleteStrategy, t *Translator, r *remote.Remote) strategy.Deleter {
+	return &PolicySwitcherStrategy{
+		translator: t,
+		strategy:   s,
+		remote:     r,
+	}
+}
+
+func (p *PolicySwitcherStrategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
+	pvName, err := p.translator.FromVolumeToPVName(ctx, obj.GetNamespace(), obj.GetName())
+	if err != nil {
+		return nil, err
+	}
+	pvObj, err := p.remote.Get(ctx, "", pvName)
+	if err != nil {
+		return nil, err
+	}
+	pv := pvObj.(*v1.PersistentVolume)
+	pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
+	_, err = p.remote.Update(ctx, pv)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.strategy.Delete(ctx, obj)
+}
+
+func (p *PolicySwitcherStrategy) Get(ctx context.Context, namespace, name string) (types.Object, error) {
+	return p.strategy.Get(ctx, namespace, name)
+}


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Previously, we have set PV/PVC's claimpolicy to `retain` to intentionally keep PV around when user has deleted their app. This is to avoid PV gets deleted when PVC is deleted. However this exposes a problem that when the volume/PV is deleted from acorn, the underlying storage resource is not cleaned up because of `retain` policy. So, when acorn initialize a delete call, we tweak the PV's reclaim policy to be `delete` before we actually delete the resource. This makes sure the driver will clean up the PV and underlying storage resource.

The downside of this fix, is that we will switch every PV's claimpolicy to `delete` regardless of what it has been actually configured in the cluster, if you delete PV through acorn api.

https://github.com/acorn-io/manager/issues/1764