### PR TITLE
fix: resolved offerings: calculate if a container is missing

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -629,7 +629,7 @@ func containerAnnotation(container v1.Container) string {
 }
 
 func resolvedOfferingsAnnotation(appInstance *v1.AppInstance, container v1.Container) (string, error) {
-	if resolved, exists := appInstance.Status.ResolvedOfferings.Containers[container.Name]; exists {
+	if resolved, exists := appInstance.Status.ResolvedOfferings.Containers[strings.ToLower(container.Name)]; exists {
 		data, err := convert.EncodeToMap(resolved)
 		if err != nil {
 			return "", err

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/acorn-io/schemer/data/convert"
 	"github.com/acorn-io/z"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -630,7 +629,6 @@ func containerAnnotation(container v1.Container) string {
 }
 
 func resolvedOfferingsAnnotation(appInstance *v1.AppInstance, containerName string) (string, error) {
-	logrus.Infof("resolved offerings annotation - container name: %s", containerName)
 	if resolved, exists := appInstance.Status.ResolvedOfferings.Containers[containerName]; exists {
 		data, err := convert.EncodeToMap(resolved)
 		if err != nil {

--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -147,7 +147,7 @@ func toJob(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSec
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      podLabels,
-				Annotations: labels.Merge(podAnnotations(appInstance, container), baseAnnotations),
+				Annotations: labels.Merge(podAnnotations(appInstance, name, container), baseAnnotations),
 			},
 			Spec: corev1.PodSpec{
 				Affinity:                      appInstance.Status.Scheduling[name].Affinity,


### PR DESCRIPTION
We saw cases (involving nested acorns) where resolved offerings would have containers missing from the list entirely. I think this was due to weird behavior where the `.Status.AppStatus.Containers` would not be populated on a nested acorn the first time it ran through the resolved offerings handler. To make sure that everything ultimately gets resolved, I added this new `needsCalculation` function that checks to make sure that every container defined in the app is also present in the resolved offerings.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

