### PR TITLE
Fix: Remove PDB for single replica deployment

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -980,7 +980,10 @@ func ToFunctions(req router.Request, appInstance *v1.AppInstance, tag name.Refer
 			}
 			result = append(result, perms...)
 		}
-		result = append(result, sa, dep, pdb.ToPodDisruptionBudget(dep))
+		result = append(result, sa, dep)
+		if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 1 {
+			result = append(result, pdb.ToPodDisruptionBudget(dep))
+		}
 	}
 
 	return result, nil
@@ -1036,7 +1039,11 @@ func ToDeployments(req router.Request, appInstance *v1.AppInstance, tag name.Ref
 			}
 			result = append(result, perms...)
 		}
-		result = append(result, sa, dep, pdb.ToPodDisruptionBudget(dep))
+		result = append(result, sa, dep)
+
+		if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 1 {
+			result = append(result, pdb.ToPodDisruptionBudget(dep))
+		}
 	}
 
 	return result, nil

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -353,7 +353,7 @@ func TestFiles(t *testing.T) {
 	assert.Equal(t, "/a/b2/c", dep.Spec.Template.Spec.Containers[1].VolumeMounts[1].MountPath)
 	assert.Equal(t, toHash("ZA=="), dep.Spec.Template.Spec.Containers[1].VolumeMounts[1].SubPath)
 
-	configMap := objs[6].(*corev1.Secret)
+	configMap := objs[4].(*corev1.Secret)
 
 	assert.Len(t, configMap.Data, 2)
 	assert.Equal(t, []byte("d"), configMap.Data[toHash("ZA==")])

--- a/pkg/controller/appdefinition/router.go
+++ b/pkg/controller/appdefinition/router.go
@@ -160,7 +160,7 @@ func toRouter(appInstance *v1.AppInstance, routerName string, router v1.Router, 
 		dep.Spec.Replicas = new(int32)
 	}
 
-	return []kclient.Object{
+	objects := []kclient.Object{
 		dep,
 		&corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{},
@@ -180,8 +180,13 @@ func toRouter(appInstance *v1.AppInstance, routerName string, router v1.Router, 
 				Annotations: deploymentAnnotations,
 			},
 		},
-		pdb.ToPodDisruptionBudget(dep),
-	}, nil
+	}
+
+	if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 1 {
+		objects = append(objects, pdb.ToPodDisruptionBudget(dep))
+	}
+
+	return objects, nil
 }
 
 func toNginxConf(internalClusterDomain, namespace, routerName string, router v1.Router) (string, string) {

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -228,36 +198,6 @@ spec:
       serviceAccountName: twoimage
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: twoimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: twoimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: twoimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/computeclass/generic-resources/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/generic-resources/expected.golden
@@ -115,36 +115,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -214,36 +184,6 @@ spec:
       serviceAccountName: twoimage
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: twoimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: twoimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: twoimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.golden
@@ -113,36 +113,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.golden
@@ -93,36 +93,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -188,36 +158,6 @@ spec:
       serviceAccountName: web
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: web
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: web
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: web
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/depends/expected.golden
+++ b/pkg/controller/appdefinition/testdata/depends/expected.golden
@@ -93,36 +93,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -192,38 +162,6 @@ spec:
       serviceAccountName: web
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-    apply.acorn.io/create: "false"
-    apply.acorn.io/update: "false"
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: web
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: web
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: web
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.golden
@@ -93,36 +93,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: buildimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: buildimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: buildimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -203,36 +173,6 @@ spec:
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -132,46 +132,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-    admit-scoped.io: test-container
-    admit.io: test-admit-app-spec-ann
-    allowed-container.io: test-allowed-container-ann
-    allowed-global.io: test-global
-    allowed.io: test-allowed-app-spec-ann
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-    allowed-global.io: test-global
-    allowed.io: test-allowed-app-spec-label
-    permit-container.io: test-permit-container-label
-    permit-scoped.io: test-container
-    permit.io: test-permit-app-spec-label
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/karpenter/expected.golden
@@ -107,36 +107,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: scalenil
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: scalenil
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: scalenil
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -203,36 +173,6 @@ spec:
       serviceAccountName: scaleone
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: scaleone
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: scaleone
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: scaleone
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: v1

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -132,46 +132,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-    appSpecAnn: test-app-spec-ann
-    container-scoped-ann: test-container
-    containerAnn: test-container-ann
-    global-scoped-ann: test-global
-    named-scoped-ann: test-named
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-    appSpecLabel: test-app-spec-label
-    container-scoped-label: test-container
-    containerLabel: test-container-label
-    global-scoped-label: test-global
-    named-scoped-label: test-named
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/metrics/expected.golden
@@ -88,36 +88,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-with-metrics
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-with-metrics
-    acorn.io/container-name: nginx
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: nginx
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-with-metrics
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: nginx
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -102,36 +102,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/expected.golden
@@ -93,36 +93,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: buildimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: buildimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: buildimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -188,36 +158,6 @@ spec:
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.golden
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.golden
@@ -98,36 +98,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: ServiceInstance
 metadata:

--- a/pkg/controller/appdefinition/testdata/probes/expected.golden
+++ b/pkg/controller/appdefinition/testdata/probes/expected.golden
@@ -96,36 +96,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: nodefault
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: nodefault
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: nodefault
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -215,36 +185,6 @@ spec:
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 10
 status: {}
-
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: oneimage
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: oneimage
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: oneimage
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 
 ---
 apiVersion: internal.acorn.io/v1

--- a/pkg/controller/appdefinition/testdata/template/expected.golden
+++ b/pkg/controller/appdefinition/testdata/template/expected.golden
@@ -79,36 +79,6 @@ spec:
 status: {}
 
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    acorn.io/config-hash: ""
-  creationTimestamp: null
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/app-public-name: app-name
-    acorn.io/container-name: container-name
-    acorn.io/managed: "true"
-    acorn.io/project-name: app-namespace
-  name: container-name
-  namespace: app-created-namespace
-spec:
-  maxUnavailable: 25%
-  selector:
-    matchLabels:
-      acorn.io/app-name: app-name
-      acorn.io/app-namespace: app-namespace
-      acorn.io/container-name: container-name
-      acorn.io/managed: "true"
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
-
----
 apiVersion: internal.acorn.io/v1
 kind: AppInstance
 metadata:


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/runtime/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/runtime/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

We should remove PDB for single-replica container. It has casued us issues that prevent pods being evicted and node being consolidated.
